### PR TITLE
Fix revision being 0

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -29,8 +29,8 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("4.1.0.0")]
-[assembly: AssemblyFileVersion("4.1.0.0")]
+[assembly: AssemblyVersion("4.1.0.1")]
+[assembly: AssemblyFileVersion("4.1.0.1")]
 [assembly: AssemblyInformationalVersion("4.1.0")]
 
 // Neutral Language

--- a/SharedAssemblyInfo.template.cs
+++ b/SharedAssemblyInfo.template.cs
@@ -29,7 +29,7 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("4.1.0.0")]
+[assembly: AssemblyVersion("4.1.0.1")]
 [assembly: AssemblyFileVersion("4.1.0.$REVNUM$")]
 [assembly: AssemblyInformationalVersion("4.1.0")]
 


### PR DESCRIPTION
The revision being set to 0 breaks settings files.

See line 350 of .\evemon\src\EVEMon.Common\Helpers\PlanIOHelper.cs for the offender.

Fixes #5