### PR TITLE
Typo fix in PI warning: singular/plural

### DIFF
--- a/src/EVEMon.Common/Notifications/PlanetaryPinsNotificationEventArgs.cs
+++ b/src/EVEMon.Common/Notifications/PlanetaryPinsNotificationEventArgs.cs
@@ -58,7 +58,7 @@ namespace EVEMon.Common.Notifications
         /// </summary>
         private void UpdateDescription()
         {
-            Description = $"{PlanetaryPins.Count} planetary colon{(PlanetaryPins.Count == 1 ? "y" : "ies")} are idle.";
+            Description = $"{PlanetaryPins.Count} planetary colon{(PlanetaryPins.Count == 1 ? "y is" : "ies are")} idle.";
         }
     }
  }


### PR DESCRIPTION
Originally files as https://github.com/peterhaneve/evemon/pull/292 - but never got merged.

Haven't tried compiling it, but it's just wording inside two strings.