### PR TITLE
Refactor: skill plan duplicate confirmation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ ModelManifest.xml
 /*.bat
 /tools/XmlGenerator/*.sqlite
 tools/XmlGenerator/sqlite-latest.sqlite-journal
+
+# Rider and Jetbrains
+.idea/

--- a/src/EVEMon.Common/Helpers/PlanIOHelper.cs
+++ b/src/EVEMon.Common/Helpers/PlanIOHelper.cs
@@ -459,10 +459,14 @@ namespace EVEMon.Common.Helpers
             // Check if there is already a plan with the same skills
             if (ccpCharacter.Plans.Any(plan => !newPlan.Except(plan, new PlanEntryComparer()).Any()))
             {
-                MessageBox.Show(@"There is already a plan with the same skills in the characters' Plans.",
-                    @"Plan Creation Failure",
-                    MessageBoxButtons.OK, MessageBoxIcon.Exclamation);
-                return false;
+                if (MessageBox.Show(@"There is already a plan with the same skills in the characters' Plans.
+
+Would you like to proceed?",
+                        @"Plan Creation Duplicate",
+                        MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+                {
+                    return false;
+                }
             }
 
             // Add plan and save

--- a/src/EVEMon.Common/Loadouts/LoadoutsProvider.cs
+++ b/src/EVEMon.Common/Loadouts/LoadoutsProvider.cs
@@ -33,12 +33,12 @@ namespace EVEMon.Common.Loadouts
         /// <value>
         /// The providers.
         /// </value>
-        public static IEnumerable<LoadoutsProvider> Providers => Assembly.
-            GetExecutingAssembly().GetTypes().Where(type => typeof(LoadoutsProvider).
-            IsAssignableFrom(type) && type.GetConstructor(Type.EmptyTypes) != null).Select(
-            type => Activator.CreateInstance(type) as LoadoutsProvider).Where(provider =>
-            !string.IsNullOrWhiteSpace(provider.Name) && provider.Enabled).OrderBy(provider =>
-            provider.Name);
+        public static IEnumerable<LoadoutsProvider> Providers => 
+            Assembly.GetExecutingAssembly().GetTypes()
+                .Where(type => typeof(LoadoutsProvider).IsAssignableFrom(type) && type.GetConstructor(Type.EmptyTypes) != null)
+                .Select(type => Activator.CreateInstance(type) as LoadoutsProvider)
+                .Where(provider => !string.IsNullOrWhiteSpace(provider.Name) && provider.Enabled)
+                .OrderBy(provider => provider.Name);
 
         /// <summary>
         /// Gets the loadouts feed asynchronous.

--- a/src/EVEMon.Common/Loadouts/Osmium/OsmiumLoadoutsProvider.cs
+++ b/src/EVEMon.Common/Loadouts/Osmium/OsmiumLoadoutsProvider.cs
@@ -11,6 +11,7 @@ using EVEMon.Common.Interfaces;
 using EVEMon.Common.Net;
 using EVEMon.Common.Serialization.Osmium.Loadout;
 
+
 namespace EVEMon.Common.Loadouts.Osmium
 {
     public sealed class OsmiumLoadoutsProvider : LoadoutsProvider
@@ -39,7 +40,7 @@ namespace EVEMon.Common.Loadouts.Osmium
         /// <value>
         ///   <c>true</c> if enabled; otherwise, <c>false</c>.
         /// </value>
-        protected override bool Enabled => true;
+        protected override bool Enabled => false;
 
         #endregion
 
@@ -182,3 +183,4 @@ namespace EVEMon.Common.Loadouts.Osmium
 
     }
 }
+

--- a/src/EVEMon/SkillPlanner/ShipBrowserControl.cs
+++ b/src/EVEMon/SkillPlanner/ShipBrowserControl.cs
@@ -61,7 +61,7 @@ namespace EVEMon.SkillPlanner
             if (DesignMode || this.IsDesignModeHosted())
                 return;
 
-            if (Character != null)
+            if (Character != null && LoadoutsProvider.Providers.Any())
             {
                 ToolStripItem[] toolStripItems = LoadoutsProvider.Providers
                     .Select(provider => new ToolStripMenuItem(provider.Name))
@@ -77,7 +77,7 @@ namespace EVEMon.SkillPlanner
                 splitButtonLoadouts.Text = Settings.LoadoutsProvider.Provider?.Name;
             }
 
-            lblViewLoadouts.Visible = splitButtonLoadouts.Visible = Character != null;
+            lblViewLoadouts.Visible = splitButtonLoadouts.Visible = Character != null && LoadoutsProvider.Providers.Any();
 
             UpdateControlVisibility();
         }


### PR DESCRIPTION
Not sure if there is a reason Evemon blocks a duplicate plan. 

This changes the messagebox that stops the action, to a confirmation for a duplicate.

Fixes issue: #93 