### PR TITLE
Fix: Calculation for maximum on implant calculator window

### DIFF
--- a/src/EVEMon/SkillPlanner/ImplantCalculatorWindow.cs
+++ b/src/EVEMon/SkillPlanner/ImplantCalculatorWindow.cs
@@ -79,8 +79,8 @@ namespace EVEMon.SkillPlanner
                     var charAttribute = m_character[attrib];
                     long min = charAttribute.EffectiveValue - charAttribute.ImplantBonus;
                     nud.Minimum = min;
-                    nud.Maximum = min + Math.Min(m_plan.ChosenImplantSet[attrib].Bonus,
-                        EveConstants. MaxImplantPoints);
+                    nud.Maximum = min + Math.Max(m_plan.ChosenImplantSet[attrib].Bonus,
+                        EveConstants.MaxImplantPoints);
                 }
             }
 


### PR DESCRIPTION
Fix for the implant calculation page not allowing to adjust to the maximum of 5 points.

Fixes partial of #95 