### PR TITLE
Fix console cursor position going negative in XmlGenerator

### DIFF
--- a/tools/XmlGenerator/Utils/Util.cs
+++ b/tools/XmlGenerator/Utils/Util.cs
@@ -209,7 +209,12 @@ namespace EVEMon.XmlGenerator.Utils
             s_percentOld = percentRounded;
 
             if (!string.IsNullOrEmpty(s_text))
-                Console.SetCursorPosition(Console.CursorLeft - s_text.Length, Console.CursorTop);
+            {
+                int left = Console.CursorLeft - s_text.Length;
+                if (left < 0)
+                    left = 0;
+                Console.SetCursorPosition(left, Console.CursorTop);
+            }
 
             s_text = $"{percent:P0}";
             Console.Write(s_text);


### PR DESCRIPTION
## Bug Fix Summary
Prevent `ArgumentOutOfRangeException` when `Console.CursorLeft - s_text.Length` results in a negative value by clamping the position to `0`.

## New SDE Export compatible with EVEMon

@mgoeppner With this fix, you can again create XMLs based on the new SDE-SQLite files released here: [https://github.com/noirsoldats/eve-sde-converter/releases/tag/sde-3142455.03](https://github.com/noirsoldats/eve-sde-converter/releases/tag/sde-3142455.03). The Repo-Owner has an [industry tool](https://github.com/noirsoldats/QuantumForge), that consumes those files.

If you're using the export, you can re-create the XMLs for EVEMon and this should help to solve the SDE-based issues https://github.com/mgoeppner/evemon/issues/103 and https://github.com/mgoeppner/evemon/issues/104 without the need to refactor EVEMon for the new SDEs.

I've successfully tested the EVEMon XML generation with the sqlite-files and have another[ branch prepared to bring back certificates and masteries](https://github.com/emyth-juk/evemon/tree/feature/certificates-masteries).

Let me know, if that works for you.