### PR TITLE
Performance improvements for many characters

### DIFF
--- a/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalCharacterCollection.cs
@@ -142,7 +142,7 @@ namespace EVEMon.Common.Collections.Global
                 character.Dispose();
             }
 
-            // Import the characters, their identies, etc
+            // Import the characters, their identities, etc
             Items.Clear();
             foreach (SerializableSettingsCharacter serialCharacter in serial)
             {

--- a/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalMonitoredCharacterCollection.cs
@@ -96,9 +96,11 @@ namespace EVEMon.Common.Collections.Global
                 Items.Add(character);
                 character.Monitored = true;
                 character.UISettings = characterSettings.Settings;
-
-                EveMonClient.OnMonitoredCharactersChanged();
             }
+
+            // Notify once after all characters have been imported, instead of
+            // per-character which caused N redundant LayoutTabPages + Settings.Save calls
+            EveMonClient.OnMonitoredCharactersChanged();
         }
 
         /// <summary>

--- a/src/EVEMon.Common/Collections/Global/GlobalNotificationCollection.cs
+++ b/src/EVEMon.Common/Collections/Global/GlobalNotificationCollection.cs
@@ -62,8 +62,10 @@ namespace EVEMon.Common.Collections.Global
 
             case NotificationBehaviour.Merge:
                 // Merge the notifications with the same key
+                // Snapshot Items to prevent IndexOutOfRangeException if the notification
+                // chain (via ThreadSafeInvoke) re-enters and modifies Items concurrently
                 long key = notification.InvalidationKey;
-                foreach (NotificationEventArgs other in Items.Where(x => x.InvalidationKey == key))
+                foreach (NotificationEventArgs other in Items.ToArray().Where(x => x.InvalidationKey == key))
                 {
                     notification.Append(other);
                 }

--- a/src/EVEMon.Common/Extensions/EventHandlerExtensions.cs
+++ b/src/EVEMon.Common/Extensions/EventHandlerExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Windows.Forms;
 
 namespace EVEMon.Common.Extensions
 {
@@ -32,6 +33,11 @@ namespace EVEMon.Common.Extensions
                 // Check if our target requires an Invoke
                 if (sync != null && sync.InvokeRequired)
                 {
+                    // Skip if the target control is disposed or has no handle;
+                    // invoking on such a control causes unpredictable exceptions.
+                    if (sync is Control ctrl && (ctrl.IsDisposed || !ctrl.IsHandleCreated))
+                        continue;
+
                     // Yes it does, so invoke the handler using the target's BeginInvoke method, but wait for it to finish
                     // This is preferable to using Invoke so that if an exception is thrown its presented
                     // in the context of the handler, not the current thread
@@ -43,7 +49,7 @@ namespace EVEMon.Common.Extensions
                     }
                     catch (ObjectDisposedException)
                     {
-                        // Ignore, already cleaned up -- code was likely changed to use `using`.
+                        // Control was disposed between BeginInvoke and EndInvoke
                     }
 
                     continue;
@@ -81,11 +87,25 @@ namespace EVEMon.Common.Extensions
                 // Check if our target requires an Invoke
                 if (sync != null && sync.InvokeRequired)
                 {
+                    // Skip if the target control is disposed or has no handle;
+                    // invoking on such a control causes unpredictable exceptions.
+                    if (sync is Control ctrl && (ctrl.IsDisposed || !ctrl.IsHandleCreated))
+                        continue;
+
                     // Yes it does, so invoke the handler using the target's BeginInvoke method, but wait for it to finish
                     // This is preferable to using Invoke so that if an exception is thrown its presented
                     // in the context of the handler, not the current thread
-                    IAsyncResult result = sync.BeginInvoke(handler, new[] { sender, e });
-                    sync.EndInvoke(result);
+                    IAsyncResult result = sync.BeginInvoke(handler, new[] { sender, (object)e });
+
+                    try
+                    {
+                        sync.EndInvoke(result);
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        // Control was disposed between BeginInvoke and EndInvoke
+                    }
+
                     continue;
                 }
 

--- a/src/EVEMon.Common/Extensions/EventHandlerExtensions.cs
+++ b/src/EVEMon.Common/Extensions/EventHandlerExtensions.cs
@@ -51,6 +51,12 @@ namespace EVEMon.Common.Extensions
                     {
                         // Control was disposed between BeginInvoke and EndInvoke
                     }
+                    catch (IndexOutOfRangeException) when (sync is Control c && (c.IsDisposed || !c.IsHandleCreated))
+                    {
+                        // Control.EndInvoke throws IndexOutOfRangeException when the
+                        // control's internal async result list is cleared during disposal
+                        // or handle recreation (e.g. resize triggering layout changes).
+                    }
 
                     continue;
                 }
@@ -104,6 +110,12 @@ namespace EVEMon.Common.Extensions
                     catch (ObjectDisposedException)
                     {
                         // Control was disposed between BeginInvoke and EndInvoke
+                    }
+                    catch (IndexOutOfRangeException) when (sync is Control c && (c.IsDisposed || !c.IsHandleCreated))
+                    {
+                        // Control.EndInvoke throws IndexOutOfRangeException when the
+                        // control's internal async result list is cleared during disposal
+                        // or handle recreation (e.g. resize triggering layout changes).
                     }
 
                     continue;

--- a/src/EVEMon.Common/Models/CCPCharacter.cs
+++ b/src/EVEMon.Common/Models/CCPCharacter.cs
@@ -895,11 +895,17 @@ namespace EVEMon.Common.Models
                 if (!CorporationIndustryJobs.Any(job => job.ActiveJobState ==
                         ActiveJobState.Ready && !job.NotificationSend))
                 {
-                    EveMonClient.Notifications.NotifyCharacterIndustryJobCompletion(this,
-                        m_jobsCompletedForCharacter);
+                    // Snapshot the list before notifying — the notification constructor
+                    // iterates the enumerable, and Clear() below (or another timer tick
+                    // calling AddRange) would modify the list mid-iteration, causing
+                    // IndexOutOfRangeException.
+                    var completedSnapshot = m_jobsCompletedForCharacter.ToList();
 
-                    // Now that we have send the notification clear the list
+                    // Now that we have a snapshot, clear the list before notifying
                     m_jobsCompletedForCharacter.Clear();
+
+                    EveMonClient.Notifications.NotifyCharacterIndustryJobCompletion(this,
+                        completedSnapshot);
                 }
             }
         }

--- a/src/EVEMon.Common/Models/Collections/IndustryJobCollection.cs
+++ b/src/EVEMon.Common/Models/Collections/IndustryJobCollection.cs
@@ -128,10 +128,14 @@ namespace EVEMon.Common.Models.Collections
             bool isCorporateMonitor = true;
             if (Items.Count > 0)
             {
+                // Snapshot the items list to avoid IndexOutOfRangeException if the
+                // notification chain causes Items to be modified during iteration
+                var snapshot = Items.ToList();
+
                 // Add the not notified "Ready" jobs to the completed list
                 var jobsCompleted = new LinkedList<IndustryJob>();
                 var characterJobs = new LinkedList<IndustryJob>();
-                foreach (IndustryJob job in Items)
+                foreach (IndustryJob job in snapshot)
                 {
                     if (job.IsActive && job.TTC.Length == 0 && !job.NotificationSend)
                     {

--- a/src/EVEMon.Common/Service/EveIDToName.cs
+++ b/src/EVEMon.Common/Service/EveIDToName.cs
@@ -3,6 +3,7 @@ using EVEMon.Common.Constants;
 using EVEMon.Common.Data;
 using EVEMon.Common.Enumerations.CCPAPI;
 using EVEMon.Common.Extensions;
+using EVEMon.Common.Helpers;
 using EVEMon.Common.Models;
 using EVEMon.Common.Serialization;
 using EVEMon.Common.Serialization.Esi;
@@ -57,7 +58,14 @@ namespace EVEMon.Common.Service
         /// <param name="e">The <see cref="System.EventArgs"/> instance containing the event data.</param>
         private static async void EveMonClient_TimerTick(object sender, EventArgs e)
         {
-            await UpdateOnOneSecondTickAsync();
+            try
+            {
+                await UpdateOnOneSecondTickAsync();
+            }
+            catch (Exception ex)
+            {
+                ExceptionHandler.LogException(ex, true);
+            }
         }
         
         /// <summary>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorFooter.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorFooter.cs
@@ -61,6 +61,10 @@ namespace EVEMon.CharacterMonitoring
             EveMonClient.SchedulerChanged += EveMonClient_SchedulerChanged;
             EveMonClient.CharacterSkillQueueUpdated += EveMonClient_CharacterSkillQueueUpdated;
             Disposed += OnDisposed;
+
+            // Populate controls immediately for lazy monitor creation
+            UpdateFrequentControls();
+            UpdateInfrequentControls();
         }
 
         /// <summary>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.cs
@@ -79,6 +79,12 @@ namespace EVEMon.CharacterMonitoring
             EveMonClient.SettingsChanged += EveMonClient_SettingsChanged;
             EveMonClient.TimerTick += EveMonClient_TimerTick;
             Disposed += OnDisposed;
+
+            // Populate controls immediately — when the monitor is created lazily,
+            // the initial CharacterUpdated/CharacterInfoUpdated events have already
+            // fired and won't repeat until the next API refresh
+            UpdateFrequentControls();
+            UpdateInfrequentControls();
         }
 
         /// <summary>


### PR DESCRIPTION
These are a series of improvements for characters more than 30+ where evemon either crashes or take over 3-4 minutes(bruh!) before it can even become responsive! With the fixes the same 30+ character set finshed loading in 10 second, a 24x improvement.

1. **Fix IndexOutOfRangeException on concurrent collection modification** — Snapshot lists (`.ToList()` / `.ToArray()`) before iterating in industry job notification, `IndustryJobCollection`, and `GlobalNotificationCollection` where timer ticks or re-entrant `ThreadSafeInvoke` could mutate mid-iteration. Also fixed race condition in `EveIDToNames` where it can trigger io excptions.

2. **Lazy-load CharacterMonitor controls** — Only create the heavy `CharacterMonitor` when a tab is first selected, not upfront for every character. Same treatment for `KillLogCollection` cache and `TimerTick` subscription. Header/footer now self-populate on load so they aren't blank.

3. **Coalesce redundant UI updates** — Overview sets a dirty flag and flushes on `TimerTick` instead of rebuilding per character update. `MonitoredCharactersChanged` fires once after import, not per character. `LayoutTabPages` batches tab changes via `SuspendLayout`/`Clear`/`AddRange`/`ResumeLayout` instead of per-tab `Insert`/`Remove`. Think of it this way,  the liberal use of event driven design during initial startup force many updates to UI thread via `ThreadSafeInvoke`. This change instead delay and group the updates via one second ticks from the dispatcher instead of allowing simultaneous UI updates.

4. **Guard `ThreadSafeInvoke` against disposed controls** — Skip `BeginInvoke`/`EndInvoke` when the target control is already disposed or has no handle. Else this could throw `IndexOutOfRangeException`.. During startup if you resize the control, it seems this does not prevent this error. So another commit to conditionally `catch` this if it slipped through the guard.


