### PR TITLE
Fix SSO token refresh and ID lookup errors

### DIFF
--- a/src/EVEMon.Common/Service/EveIDToName.cs
+++ b/src/EVEMon.Common/Service/EveIDToName.cs
@@ -192,23 +192,60 @@ namespace EVEMon.Common.Service
                         info?.OnRequestStart(null);
                     }
                 }
-                string ids = "[ " + string.Join(",", toDo) + " ]";
+                // Filter out invalid IDs: ESI /universe/names/ returns 404 if
+                // any single ID in the batch is invalid (<=0 or deleted)
+                var validIds = new LinkedList<long>();
+                foreach (long id in toDo)
+                {
+                    if (id > 0)
+                        validIds.AddLast(id);
+                    else
+                    {
+                        // Mark invalid IDs as resolved so they won't be retried
+                        m_cache.TryGetValue(id, out StringIDInfo info);
+                        info?.OnRequestComplete(null);
+                    }
+                }
+                if (validIds.Count == 0)
+                {
+                    OnLookupComplete();
+                    return;
+                }
+                string ids = "[ " + string.Join(",", validIds) + " ]";
                 // Given the number of IDs we are requesting, it is very unlikely that the
                 // eTag or expiration will be useful
+                // Pass validIds as state so we can handle errors gracefully
                 EveMonClient.APIProviders.CurrentProvider.QueryEsi<EsiAPICharacterNames>(
                     ESIAPIGenericMethods.CharacterName, OnQueryAPICharacterNameUpdated,
                     new ESIParams()
                     {
                         PostData = ids
-                    });
+                    }, validIds);
             }
 
             private void OnQueryAPICharacterNameUpdated(EsiResult<EsiAPICharacterNames> result,
-                object ignore)
+                object state)
             {
-                // Bail if there is an error
+                var requestedIds = state as LinkedList<long>;
+
+                // Handle errors - ESI returns 404 if ANY ID in the batch is invalid
                 if (result.HasError)
+                {
+                    // Mark all requested IDs as "unknown" so they don't block future lookups
+                    if (requestedIds != null)
+                    {
+                        lock (m_cache)
+                        {
+                            foreach (long id in requestedIds)
+                            {
+                                m_cache.TryGetValue(id, out StringIDInfo info);
+                                // Mark as complete with null/unknown to prevent retry loops
+                                info?.OnRequestComplete(null);
+                            }
+                        }
+                    }
                     EveMonClient.Notifications.NotifyCharacterNameError(result);
+                }
                 else
                 {
                     EveMonClient.Notifications.InvalidateAPIError();
@@ -231,6 +268,10 @@ namespace EVEMon.Common.Service
             protected override string Prefetch(long id)
             {
                 string name = null;
+
+                // Check if we already have a cached value from a previous session
+                if (m_cache.TryGetValue(id, out StringIDInfo cached) && cached.Value != null)
+                    return cached.Value;
 
                 if (id == 0L)
                     // Empty IDs are always "unknown"

--- a/src/EVEMon.Common/Service/SSOAuthenticationService.cs
+++ b/src/EVEMon.Common/Service/SSOAuthenticationService.cs
@@ -41,23 +41,44 @@ namespace EVEMon.Common.Service
         }
 
         /// <summary>
-        /// Starts obtaining information about the character used to authenticate the specified
-        /// token.
+        /// Obtains information about the character from the access token JWT claims.
+        /// Replaces the deprecated /oauth/verify endpoint with local JWT decoding.
         /// </summary>
-        /// <param name="token">The auth token used.</param>
+        /// <param name="token">The access token (JWT) used.</param>
         /// <param name="callback">A callback to receive the token info.</param>
         public static void GetTokenInfo(string token, Action<JsonResult<EsiAPITokenInfo>>
             callback)
         {
-            var url = new Uri(NetworkConstants.SSOBase + NetworkConstants.SSOCharID);
-            Util.DownloadJsonAsync<EsiAPITokenInfo>(url, new RequestParams()
+            JsonResult<EsiAPITokenInfo> result;
+            try
             {
-                Authentication = token
-            }).ContinueWith((result) => Dispatcher.Invoke(() =>
+                var jwt = new JwtSecurityToken(token);
+                // EVE SSO v2 JWT "sub" claim format: "CHARACTER:EVE:<character_id>"
+                string sub = jwt.Subject;
+                string name = jwt.Payload.TryGetValue("name", out var nameVal) ?
+                    nameVal?.ToString() : string.Empty;
+                long characterID = 0;
+                if (!string.IsNullOrEmpty(sub))
+                {
+                    var parts = sub.Split(':');
+                    if (parts.Length >= 3)
+                        long.TryParse(parts[2], out characterID);
+                }
+                if (characterID <= 0)
+                    throw new ArgumentException("Could not extract character ID from JWT");
+                var tokenInfo = new EsiAPITokenInfo()
+                {
+                    CharacterID = characterID,
+                    CharacterName = name ?? string.Empty
+                };
+                result = new JsonResult<EsiAPITokenInfo>(new ResponseParams(200), tokenInfo);
+            }
+            catch (Exception e)
             {
-                // Run the callback on the dispatcher thread
-                callback?.Invoke(result.Result);
-            }));
+                ExceptionHandler.LogException(e, true);
+                result = new JsonResult<EsiAPITokenInfo>(new ResponseParams(0));
+            }
+            Dispatcher.Invoke(() => callback?.Invoke(result));
         }
 
         /// <summary>

--- a/src/EVEMon/EVEMon.csproj
+++ b/src/EVEMon/EVEMon.csproj
@@ -282,10 +282,7 @@
     <PackageReference Include="WinForms.DataVisualization" Version="1.9.2" />
   </ItemGroup>
   <PropertyGroup>
-    <PreBuildEvent>
-        cd "$(SolutionDir)tools\ResFileCreator\bin\$(Configuration)\net8.0-windows\"
-        EVEMonResFileCreator.exe
-    </PreBuildEvent>
+    <PreBuildEvent>pushd "$(SolutionDir)tools\ResFileCreator\bin\$(Configuration)\net8.0-windows" &amp;&amp; .\EVEMonResFileCreator.exe &amp;&amp; popd</PreBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PostBuildEvent>del "$(MSBuildProjectDirectory)"\EVEMon.res


### PR DESCRIPTION
## Summary

- Replace the deprecated `/oauth/verify` endpoint with local JWT decoding for character identification. CCP removed the v1 SSO verify endpoint, causing all token refreshes to fail at the character verification step even when the tokens themselves were valid. The character ID and name are now extracted directly from the JWT access token claims, eliminating the network call entirely.

- Fix `EveIDToName` batch lookups failing with 404. ESI's `/universe/names/` returns 404 if any single ID in the batch is invalid (deleted characters, etc.), which caused the entire lookup to fail. Invalid IDs are now filtered before sending, cached values are reused for previously resolved entities, and all IDs are marked as resolved on error to prevent retry loops.

- Fix `PreBuildEvent` in `EVEMon.csproj` to work with `dotnet build` CLI. The multi-line `cd` + exe invocation only worked in Visual Studio. Uses `pushd` with `&&` chaining and explicit `.\` prefix so `ResFileCreator` runs correctly from both VS and `dotnet build`.

Fixes #89
Fixes #71

## Test

- [x] Verify EVEMon starts without "Error Logging into EVE SSO" notification spam after re-authenticating characters
- [x] Verify no "error looking up character identities" 404 errors on startup
- [x] Verify `dotnet build EVEMon.sln` succeeds from the command line
- [x] Verify characters load and update correctly after SSO re-authentication