### PR TITLE
[codex] Add Simplified Chinese localization

### DIFF
--- a/src/EVEMon.Common/CloudStorageServices/CloudStorageServiceResources.zh-CN.resx
+++ b/src/EVEMon.Common/CloudStorageServices/CloudStorageServiceResources.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Constants/NetworkConstants.zh-CN.resx
+++ b/src/EVEMon.Common/Constants/NetworkConstants.zh-CN.resx
@@ -1,0 +1,466 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="ESIServerStatus" xml:space="preserve">
+    <value>/v1/状态/</value>
+  </data>
+  <data name="ESISkillQueue" xml:space="preserve">
+    <value>/v2/characters/{0:D}/skillqueue/</value>
+  </data>
+  <data name="EVEMonUpdates" xml:space="preserve">
+    <value>/更新/补丁.xml</value>
+  </data>
+  <data name="CCPPortraits" xml:space="preserve">
+    <value>/characters/{0:D}/portrait?tenant=tranquility&amp;size={1:D}</value>
+  </data>
+  <data name="EVEMonCurrentGithub" xml:space="preserve">
+    <value>https://github.com/mgoeppner/evemon</value>
+  </data>
+  <data name="EVEMonMainPage" xml:space="preserve">
+    <value>https://evemondevteam.github.io/evemon/</value>
+  </data>
+  <data name="EVEMonForums" xml:space="preserve">
+    <value>https://forums.eveonline.com/t/evemon-4-0-beta-under-new-ownership-conversion-for-esi/75953</value>
+  </data>
+  <data name="ESIAccountBalance" xml:space="preserve">
+    <value>/v1/字符/{0:D}/钱包/</value>
+  </data>
+  <data name="MyEVELevelImage" xml:space="preserve">
+    <value>/位图/字符/级别</value>
+  </data>
+  <data name="ESIMarketOrders" xml:space="preserve">
+    <value>/v2/字符/{0:D}/订单/</value>
+  </data>
+  <data name="EVEMonUserVoice" xml:space="preserve">
+    <value>https://github.com/mgoeppner/evemon/issues/</value>
+  </data>
+  <data name="ESIIndustryJobs" xml:space="preserve">
+    <value>/v1/characters/{0:D}/industry/jobs/</value>
+  </data>
+  <data name="ESIResearchPoints" xml:space="preserve">
+    <value>/v1/characters/{0:D}/agents_research/</value>
+  </data>
+  <data name="ESIAccountStatus" xml:space="preserve">
+    <value>/v1/characters/{0:D}/accountStatus/</value>
+  </data>
+  <data name="ESIMailBodies" xml:space="preserve">
+    <value>/v1/字符/{0:D}/邮件/{1:D}/</value>
+  </data>
+  <data name="ESIMailingLists" xml:space="preserve">
+    <value>/v1/characters/{0:D}/mail/lists/</value>
+  </data>
+  <data name="ESIMailMessages" xml:space="preserve">
+    <value>/v1/字符/{0:D}/mail/</value>
+  </data>
+  <data name="ESINotifications" xml:space="preserve">
+    <value>/v5/字符/{0:D}/通知/</value>
+  </data>
+  <data name="ESICharacterSheet" xml:space="preserve">
+    <value>/v5/字符/{0:D}/</value>
+  </data>
+  <data name="ESIStandings" xml:space="preserve">
+    <value>/v1/字符/{0:D}/排名/</value>
+  </data>
+  <data name="CCPCorporationLogo" xml:space="preserve">
+    <value>/corporations/{0:D}/logo?tenant=tranquility&amp;size={1:D}</value>
+  </data>
+  <data name="EVEGateMailOpen" xml:space="preserve">
+    <value>/邮件/已读消息/{0}</value>
+  </data>
+  <data name="EVEGateMailForward" xml:space="preserve">
+    <value>/邮件/ComposeForward/{0}</value>
+  </data>
+  <data name="EVEGateMailReply" xml:space="preserve">
+    <value>/邮件/ComposeReply/{0}</value>
+  </data>
+  <data name="EVEGateMailReplyAll" xml:space="preserve">
+    <value>/Mail/ComposeReplyAll/{0}</value>
+  </data>
+  <data name="EVEGateCharacterProfile" xml:space="preserve">
+    <value>/个人资料/{0}</value>
+  </data>
+  <data name="EVEGateAllianceProfile" xml:space="preserve">
+    <value>/联盟/{0}</value>
+  </data>
+  <data name="EVEGateCorporationProfile" xml:space="preserve">
+    <value>/公司/{0}</value>
+  </data>
+  <data name="CCPAccountManage" xml:space="preserve">
+    <value>https://secure.eveonline.com/AccountManMenu.aspx</value>
+  </data>
+  <data name="ESICorporationIndustryJobs" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/industry/jobs/</value>
+  </data>
+  <data name="ESICorporationMarketOrders" xml:space="preserve">
+    <value>/v3/corporations/{0:D}/orders/</value>
+  </data>
+  <data name="ESIContractBids" xml:space="preserve">
+    <value>/v1/characters/{0:D}/contracts/{1:D}/bids/</value>
+  </data>
+  <data name="ESIContractItems" xml:space="preserve">
+    <value>/v1/characters/{0:D}/contracts/{1:D}/items/</value>
+  </data>
+  <data name="ESIContracts" xml:space="preserve">
+    <value>/v1/characters/{0:D}/contracts/</value>
+  </data>
+  <data name="ESICorporationContractBids" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/contracts/{1:D}/bids/</value>
+  </data>
+  <data name="ESICorporationContractItems" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/contracts/{1:D}/items/</value>
+  </data>
+  <data name="ESICorporationContracts" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/contracts/</value>
+  </data>
+  <data name="ESIAllianceList" xml:space="preserve">
+    <value>/v2/联盟/</value>
+  </data>
+  <data name="ESIAssetList" xml:space="preserve">
+    <value>/v5/字符/{0:D}/资产/</value>
+  </data>
+  <data name="ESICalendarEventAttendees" xml:space="preserve">
+    <value>/v2/字符/{0:D}/日历/{1:D}/与会者/</value>
+  </data>
+  <data name="ESIContactList" xml:space="preserve">
+    <value>/v2/字符/{0:D}/联系人/</value>
+  </data>
+  <data name="ESICorporationAccountBalance" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/钱包/</value>
+  </data>
+  <data name="ESICorporationAssetList" xml:space="preserve">
+    <value>/v5/corporations/{0:D}/资产/</value>
+  </data>
+  <data name="ESICorporationContactList" xml:space="preserve">
+    <value>/v2/corporations/{0:D}/contacts/</value>
+  </data>
+  <data name="ESICorporationContainerLog" xml:space="preserve">
+    <value>/v2/corporations/{0:D}/containers/logs/</value>
+  </data>
+  <data name="ESICorporationFactionalWarfareStats" xml:space="preserve">
+    <value>/v2/corporations/{0:D}/fw/stats/</value>
+  </data>
+  <data name="ESICorporationKillLog" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/killmails/recent/</value>
+  </data>
+  <data name="ESICorporationMedals" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/奖牌/</value>
+  </data>
+  <data name="ESICorporationMemberMedals" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/奖章/颁发/</value>
+  </data>
+  <data name="ESICorporationMemberTracking" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/membertracking/</value>
+  </data>
+  <data name="ESICorporationShareholders" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/股东/</value>
+  </data>
+  <data name="ESICorporationSheet" xml:space="preserve">
+    <value>/v4/corporations/{0:D}/</value>
+  </data>
+  <data name="ESICorporationStandings" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/stands/</value>
+  </data>
+  <data name="ESICorporationTitles" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/titles/</value>
+  </data>
+  <data name="ESICorporationWalletJournal" xml:space="preserve">
+    <value>/v4/corporations/{0:D}/钱包/{1:D}/journal/</value>
+  </data>
+  <data name="ESICorporationWalletTransactions" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/钱包/{1:D}/交易/</value>
+  </data>
+  <data name="ESIEVEFactionalWarfareStats" xml:space="preserve">
+    <value>/v2/fw/统计/</value>
+  </data>
+  <data name="ESIEVEFactionalWarfareTopStats" xml:space="preserve">
+    <value>/v2/fw/排行榜/</value>
+  </data>
+  <data name="ESIFactionalWarfareStats" xml:space="preserve">
+    <value>/v2/字符/{0:D}/fw/stats/</value>
+  </data>
+  <data name="ESIKillLog" xml:space="preserve">
+    <value>/v1/characters/{0:D}/killmails/recent/</value>
+  </data>
+  <data name="ESILocation" xml:space="preserve">
+    <value>/v2/字符/{0:D}/位置/</value>
+  </data>
+  <data name="ESIMedals" xml:space="preserve">
+    <value>/v1/人物/{0:D}/奖牌/</value>
+  </data>
+  <data name="ESIUpcomingCalendarEvents" xml:space="preserve">
+    <value>/v2/字符/{0:D}/日历/</value>
+  </data>
+  <data name="ESIWalletJournal" xml:space="preserve">
+    <value>/v6/字符/{0:D}/钱包/日记/</value>
+  </data>
+  <data name="ESIWalletTransactions" xml:space="preserve">
+    <value>/v1/字符/{0:D}/钱包/交易/</value>
+  </data>
+  <data name="ESIFactionalWarfareSystems" xml:space="preserve">
+    <value>/v3/fw/系统/</value>
+  </data>
+  <data name="ESIJumps" xml:space="preserve">
+    <value>/v1/universe/system_jumps/</value>
+  </data>
+  <data name="ESIKills" xml:space="preserve">
+    <value>/v2/universe/system_kills/</value>
+  </data>
+  <data name="ESISovereignty" xml:space="preserve">
+    <value>/v1/主权/结构/</value>
+  </data>
+  <data name="BitBucketWikiBase" xml:space="preserve">
+    <value>https://bitbucket.org/EVEMonDevTeam/evemon/wiki</value>
+  </data>
+  <data name="EVECommunityBase" xml:space="preserve">
+    <value>https://community.eveonline.com</value>
+  </data>
+  <data name="EVEImageServerBase" xml:space="preserve">
+    <value>https://images.evetech.net</value>
+  </data>
+  <data name="ESICharacterFatigue" xml:space="preserve">
+    <value>/v1/字符/{0:D}/疲劳/</value>
+  </data>
+  <data name="ESIPlanetaryColonies" xml:space="preserve">
+    <value>/v1/字符/{0:D}/行星/</value>
+  </data>
+  <data name="ESIPlanetaryLayout" xml:space="preserve">
+    <value>/v3/字符/{0:D}/行星/{1:D}/</value>
+  </data>
+  <data name="ESIBlueprints" xml:space="preserve">
+    <value>/v2/字符/{0:D}/蓝图/</value>
+  </data>
+  <data name="ESICorporationBlueprints" xml:space="preserve">
+    <value>/v2/corporations/{0:D}/blueprints/</value>
+  </data>
+  <data name="ExternalEveNotificationTextParser" xml:space="preserve">
+    <value>/EVE/ExternalEveNotificationTextParser.cs</value>
+  </data>
+  <data name="NotificationRefTypes" xml:space="preserve">
+    <value>/EVE/NotificationRefTypes.xml</value>
+  </data>
+  <data name="EVEMonTwitter" xml:space="preserve">
+    <value>https://twitter.com/evemon</value>
+  </data>
+  <data name="GoogleAnalyticsUrl" xml:space="preserve">
+    <value>https://ssl.google-analytics.com/collect</value>
+  </data>
+  <data name="NISTTimeServer" xml:space="preserve">
+    <value>tcp://time.nist.gov:13</value>
+  </data>
+  <data name="OsmiumBaseUrl" xml:space="preserve">
+    <value>https://o.smium.org</value>
+  </data>
+  <data name="OsmiumLoadoutFeed" xml:space="preserve">
+    <value>/api/json/loadout/query/{0}?limit=50&amp;sortby=creationdate</value>
+  </data>
+  <data name="OsmiumLoadoutDetails" xml:space="preserve">
+    <value>/api/convert/{0}/eft</value>
+  </data>
+  <data name="OsmiumLoadoutTopic" xml:space="preserve">
+    <value>/装载/{0}</value>
+  </data>
+  <data name="GitHubDownloadsBase" xml:space="preserve">
+    <value>https://github.com/mgoeppner/evemon/releases</value>
+  </data>
+  <data name="BitBucketDatafilesBase" xml:space="preserve">
+    <value>https://mgoeppner.github.io/evemon-datafiles/</value>
+  </data>
+  <data name="BitBucketIssuesBase" xml:space="preserve">
+    <value>https://bitbucket.org/EVEMonDevTeam/evemon/issues</value>
+  </data>
+  <data name="EveFlags" xml:space="preserve">
+    <value>/EVE/Flags.xml</value>
+  </data>
+  <data name="GitHubBase" xml:space="preserve">
+    <value>https://raw.githubusercontent.com/mgoeppner/evemon/main</value>
+  </data>
+  <data name="EVEMonManual" xml:space="preserve">
+    <value>https://evemon.readthedocs.org/</value>
+  </data>
+  <data name="ESIBookmarks" xml:space="preserve">
+    <value>/v2/字符/{0:D}/书签/</value>
+  </data>
+  <data name="ESIClones" xml:space="preserve">
+    <value>/v4/字符/{0:D}/克隆/</value>
+  </data>
+  <data name="ESISkills" xml:space="preserve">
+    <value>/v4/字符/{0:D}/技能/</value>
+  </data>
+  <data name="ESICorporationBookmarks" xml:space="preserve">
+    <value>/v1/corporations/{0:D}/书签/</value>
+  </data>
+  <data name="GlobalNTPPool" xml:space="preserve">
+    <value>pool.ntp.org</value>
+  </data>
+  <data name="ESIBase" xml:space="preserve">
+    <value>https://esi.evetech.net</value>
+  </data>
+  <data name="ESICharacterName" xml:space="preserve">
+    <value>/v3/宇宙/名称/</value>
+  </data>
+  <data name="ESICitadelInfo" xml:space="preserve">
+    <value>/v2/宇宙/结构/{0}/</value>
+  </data>
+  <data name="ESIStationInfo" xml:space="preserve">
+    <value>/v2/universe/stations/{0}/</value>
+  </data>
+  <data name="SSOBase" xml:space="preserve">
+    <value>https://login.eveonline.com/oauth/</value>
+  </data>
+  <data name="SSOCharID" xml:space="preserve">
+    <value>验证</value>
+  </data>
+  <data name="SSOLogin" xml:space="preserve">
+    <value>授权/?response_type=code&amp;redirect_uri={0}&amp;client_id={3}&amp;scope={2}&amp;state={1}</value>
+  </data>
+  <data name="SSORedirect" xml:space="preserve">
+    <value>http://localhost:{0:D}/callback</value>
+  </data>
+  <data name="SSOToken" xml:space="preserve">
+    <value>代币</value>
+  </data>
+  <data name="PostDataAuthToken" xml:space="preserve">
+    <value>grant_type=authorization_code&amp;code={0}</value>
+  </data>
+  <data name="CCPApplicationRegistration" xml:space="preserve">
+    <value>https://peterhaneve.github.io/evemon-esi</value>
+  </data>
+  <data name="SSOScopes" xml:space="preserve">
+    <value>ESI-wallet.read_character_wallet.v1 ESI-calendar.read_calendar_events.v1 ESI-location.read_location.v1 ESI-location.read_ship_type.v1 ESI-mail.read_mail.v1 ESI-skills.read_skills.v1 ESI-skills.read_skillqueue.v1 ESI-clones.read_clones.v1 ESI-characters.read_contacts.v1 ESI-universe.read_structs.v1 ESI-killmails.read_killmails.v1 ESI-assets.read_assets.v1 ESI-planets.manage_planets.v1 ESI-markets.structural_markets.v1 ESI-corporations.read_structs.v1 ESI-characters.read_loyalty.v1 ESI-characters.read_medals.v1 ESI-characters.read_stands.v1 ESI-characters.read_agents_research.v1 ESI-industry.read_character_jobs.v1 ESI-markets.read_character_orders.v1 ESI-characters.read_blueprints.v1 ESI-characters.read_corporation_roles.v1 ESI-contracts.read_character_contracts.v1 ESI-clones.read_implants.v1 ESI-characters.read_fatigue.v1 ESI-killmails.read_corporation_killmails.v1 ESI-wallet.read_corporation_wallets.v1 ESI-characters.read_notifications.v1 ESI-corporations.read_divisions.v1 ESI-corporations.read_contacts.v1 ESI-assets.read_corporation_assets.v1 ESI-corporations.read_blueprints.v1 ESI-contracts.read_corporation_contracts.v1 ESI-corporations.read_stands.v1 ESI-industry.read_corporation_jobs.v1 ESI-markets.read_corporation_orders.v1 ESI-corporations.read_medals.v1 ESI-alliances.read_contacts.v1 ESI-characters.read_fw_stats.v1 ESI-corporations.read_fw_stats.v1</value>
+  </data>
+  <data name="PostDataRefreshToken" xml:space="preserve">
+    <value>grant_type=refresh_token&amp;refresh_token={0}</value>
+  </data>
+  <data name="ESIUpcomingCalendarEventDetails" xml:space="preserve">
+    <value>/v4/字符/{0:D}/日历/{1:D}/</value>
+  </data>
+  <data name="ESIFactionWars" xml:space="preserve">
+    <value>/v2/fw/战争/</value>
+  </data>
+  <data name="ESICharacterAffiliation" xml:space="preserve">
+    <value>/v1/人物/隶属关系/</value>
+  </data>
+  <data name="ESIAttributes" xml:space="preserve">
+    <value>/v1/字符/{0:D}/属性/</value>
+  </data>
+  <data name="ESIImplants" xml:space="preserve">
+    <value>/v2/字符/{0:D}/植入物/</value>
+  </data>
+  <data name="ESIShip" xml:space="preserve">
+    <value>/v2/字符/{0:D}/ship/</value>
+  </data>
+  <data name="ESIEmploymentHistory" xml:space="preserve">
+    <value>/v2/characters/{0:D}/corporationhistory/</value>
+  </data>
+  <data name="BitBucketBase" xml:space="preserve">
+    <value>https://bitbucket.org/EVEMonDevTeam/evemon</value>
+  </data>
+  <data name="ESIPlanetInfo" xml:space="preserve">
+    <value>/v1/宇宙/行星/{0:D}/</value>
+  </data>
+  <data name="ESIKillMail" xml:space="preserve">
+    <value>/v1/killmails/{0}/{1}/</value>
+  </data>
+  <data name="ForumThreadBase" xml:space="preserve">
+    <value>https://forums.eveonline.com/t/evemon-4-0-beta-under-new-ownership-conversion-for-esi/75953</value>
+  </data>
+  <data name="GoogleCalendarSetup" xml:space="preserve">
+    <value>https://www.google.com/search?q=google%20calendar%20get%20calendar%20id</value>
+  </data>
+  <data name="SSOLoginPKCE" xml:space="preserve">
+    <value>授权/?response_type=code&amp;redirect_uri={0}&amp;client_id={3}&amp;scope={2}&amp;state={1}&amp;code_challenge_method=S256&amp;code_challenge={4}</value>
+  </data>
+  <data name="SSODefaultAppID" xml:space="preserve">
+    <value>05153596dde44fd8b0d60c0ad3b90c24</value>
+  </data>
+  <data name="PostDataAuthPKCE" xml:space="preserve">
+    <value>grant_type=authorization_code&amp;code={0}&amp;client_id={1}&amp;code_verifier={2}</value>
+  </data>
+  <data name="SSOBaseV2" xml:space="preserve">
+    <value>https://login.eveonline.com/v2/oauth/</value>
+  </data>
+  <data name="PostDataRefreshPKCE" xml:space="preserve">
+    <value>grant_type=refresh_token&amp;client_id={1}&amp;refresh_token={0}</value>
+  </data>
+  <data name="ESILoyaltyPoints" xml:space="preserve">
+    <value>/v1/字符/{0:D}/忠诚/积分/</value>
+  </data>
+  <data name="ESICorporationMarketOrdersHistory" xml:space="preserve">
+    <value>/v2/corporations/{0:D}/orders/history</value>
+  </data>
+  <data name="ESIMarketOrdersHistory" xml:space="preserve">
+    <value>/v1/characters/{0:D}/orders/history</value>
+  </data>
+  <data name="CCPAllianceLogo" xml:space="preserve">
+    <value>/alliances/{0:D}/logo?tenant=tranquility&amp;size={1:D}</value>
+  </data>
+  <data name="CCPTypeImage" xml:space="preserve">
+    <value>/types/{0:D}/icon?tenant=tranquility&amp;size={1:D}</value>
+  </data>
+  <data name="CCPTypeRender" xml:space="preserve">
+    <value>/types/{0:D}/render?tenant=tranquility&amp;size={1:D}</value>
+  </data>
+  <data name="FuzzworksMarketUrl" xml:space="preserve">
+    <value>https://market.fuzzwork.co.uk/aggregates/?region=10000002&amp;types=</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/ApiErrorTroubleshooter.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/ApiErrorTroubleshooter.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/CharacterPortrait.Designer.cs
+++ b/src/EVEMon.Common/Controls/CharacterPortrait.Designer.cs
@@ -67,21 +67,21 @@
             // 
             this.updatePicture.Name = "updatePicture";
             this.updatePicture.Size = new System.Drawing.Size(243, 22);
-            this.updatePicture.Text = "Update Portrait From The Web";
+            this.updatePicture.Text = resources.GetString("this.updatePicture.Text");
             this.updatePicture.Click += new System.EventHandler(this.miUpdatePicture_Click);
             // 
             // updatePictureFromEVECache
             // 
             this.updatePictureFromEVECache.Name = "updatePictureFromEVECache";
             this.updatePictureFromEVECache.Size = new System.Drawing.Size(243, 22);
-            this.updatePictureFromEVECache.Text = "Update Portrait From EVE Cache";
+            this.updatePictureFromEVECache.Text = resources.GetString("this.updatePictureFromEVECache.Text");
             this.updatePictureFromEVECache.Click += new System.EventHandler(this.miUpdatePictureFromEVECache_Click);
             // 
             // setEVEFolder
             // 
             this.setEVEFolder.Name = "setEVEFolder";
             this.setEVEFolder.Size = new System.Drawing.Size(243, 22);
-            this.setEVEFolder.Text = "Set Portrait Folder";
+            this.setEVEFolder.Text = resources.GetString("this.setEVEFolder.Text");
             this.setEVEFolder.Click += new System.EventHandler(this.miSetEVEFolder_Click);
             // 
             // CharacterPortrait

--- a/src/EVEMon.Common/Controls/CharacterPortrait.resx
+++ b/src/EVEMon.Common/Controls/CharacterPortrait.resx
@@ -237,4 +237,13 @@
         FFFABRRRQAUUUUAFFFFABRRRQB//2Q==
 </value>
   </data>
+  <data name="this.updatePicture.Text" xml:space="preserve">
+    <value>Update Portrait From The Web</value>
+  </data>
+  <data name="this.updatePictureFromEVECache.Text" xml:space="preserve">
+    <value>Update Portrait From EVE Cache</value>
+  </data>
+  <data name="this.setEVEFolder.Text" xml:space="preserve">
+    <value>Set Portrait Folder</value>
+  </data>
 </root>

--- a/src/EVEMon.Common/Controls/CharacterPortrait.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/CharacterPortrait.zh-CN.resx
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.updatePicture.Text" xml:space="preserve">
+    <value>从网络更新肖像</value>
+  </data>
+  <data name="this.updatePictureFromEVECache.Text" xml:space="preserve">
+    <value>从 EVE 缓存更新肖像</value>
+  </data>
+  <data name="this.setEVEFolder.Text" xml:space="preserve">
+    <value>设置肖像文件夹</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/ColumnSelectWindow.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/ColumnSelectWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/CopySaveOptionsWindow.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/CopySaveOptionsWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/EVEMonForm.Designer.cs
+++ b/src/EVEMon.Common/Controls/EVEMonForm.Designer.cs
@@ -38,7 +38,7 @@ namespace EVEMon.Common.Controls
             this.ClientSize = new System.Drawing.Size(292, 266);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "EVEMonForm";
-            this.Text = "EVEMon";
+            this.Text = resources.GetString("this.Text");
             this.ResumeLayout(false);
         }
 

--- a/src/EVEMon.Common/Controls/EVEMonForm.resx
+++ b/src/EVEMon.Common/Controls/EVEMonForm.resx
@@ -1784,4 +1784,7 @@
         rEEAAKxBAACsQQAArEEAAKxB
 </value>
   </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>EVEMon</value>
+  </data>
 </root>

--- a/src/EVEMon.Common/Controls/EVEMonForm.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/EVEMonForm.zh-CN.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>伊芙蒙</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/EveFolderWindow.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/EveFolderWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/EveImage.Designer.cs
+++ b/src/EVEMon.Common/Controls/EveImage.Designer.cs
@@ -48,7 +48,7 @@ namespace EVEMon.Common.Controls
             this.pbImage.TabStop = false;
             this.pbImage.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.pbImage_MouseDoubleClick);
             this.pbImage.MouseClick += new System.Windows.Forms.MouseEventHandler(this.pbImage_MouseClick);
-            this.toolTip.SetToolTip(this.pbImage, "Double-click to view a larger image");
+            this.toolTip.SetToolTip(this.pbImage, resources.GetString("this.pbImage.ToolTip"));
             // 
             // overlayImageList
             // 

--- a/src/EVEMon.Common/Controls/EveImage.resx
+++ b/src/EVEMon.Common/Controls/EveImage.resx
@@ -195,4 +195,7 @@
         AQcBAAEDAQABAwEAAQMBAAEDAQABAQEAAQEBAAEBAQABARAACw==
 </value>
   </data>
+  <data name="this.pbImage.ToolTip" xml:space="preserve">
+    <value>Double-click to view a larger image</value>
+  </data>
 </root>

--- a/src/EVEMon.Common/Controls/EveImage.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/EveImage.zh-CN.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.pbImage.ToolTip" xml:space="preserve">
+    <value>双击查看大图</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/EveImagePopUp.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/EveImagePopUp.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/MessageBoxCustom.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/MessageBoxCustom.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/PrintOptionsDialog.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/PrintOptionsDialog.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/TipWindow.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/TipWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Controls/TrayIcon.zh-CN.resx
+++ b/src/EVEMon.Common/Controls/TrayIcon.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/LocalizationHelper.cs
+++ b/src/EVEMon.Common/LocalizationHelper.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+
+namespace EVEMon.Common
+{
+    /// <summary>
+    /// Provides supported UI language metadata and culture setup.
+    /// </summary>
+    public static class LocalizationHelper
+    {
+        public const string DefaultCultureName = "en-US";
+        public const string ChineseCultureName = "zh-CN";
+
+        private static readonly IReadOnlyList<SupportedLanguage> s_supportedLanguages =
+            new List<SupportedLanguage>
+            {
+                new SupportedLanguage(DefaultCultureName, "English"),
+                new SupportedLanguage(ChineseCultureName, "简体中文")
+            };
+
+        /// <summary>
+        /// Gets the supported UI languages.
+        /// </summary>
+        public static IReadOnlyList<SupportedLanguage> SupportedLanguages => s_supportedLanguages;
+
+        /// <summary>
+        /// Normalizes a culture name to one supported by EVEMon.
+        /// </summary>
+        /// <param name="cultureName">The culture name.</param>
+        /// <returns>A supported culture name.</returns>
+        public static string NormalizeCultureName(string cultureName)
+        {
+            if (string.IsNullOrWhiteSpace(cultureName))
+                return DefaultCultureName;
+
+            return s_supportedLanguages.Any(language =>
+                string.Equals(language.CultureName, cultureName, StringComparison.OrdinalIgnoreCase))
+                ? cultureName
+                : DefaultCultureName;
+        }
+
+        /// <summary>
+        /// Gets the culture information for a supported language.
+        /// </summary>
+        /// <param name="cultureName">The culture name.</param>
+        /// <returns>The culture information.</returns>
+        public static CultureInfo GetCultureInfo(string cultureName)
+            => CultureInfo.GetCultureInfo(NormalizeCultureName(cultureName));
+
+        /// <summary>
+        /// Applies the selected culture to the current and future UI threads.
+        /// </summary>
+        /// <param name="cultureName">The culture name.</param>
+        public static void ApplyCulture(string cultureName)
+        {
+            CultureInfo cultureInfo = GetCultureInfo(cultureName);
+
+            CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+            CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+            Thread.CurrentThread.CurrentCulture = cultureInfo;
+            Thread.CurrentThread.CurrentUICulture = cultureInfo;
+        }
+
+        /// <summary>
+        /// Gets the display string for a supported language.
+        /// </summary>
+        /// <param name="cultureName">The culture name.</param>
+        /// <returns>The display string.</returns>
+        public static string GetDisplayName(string cultureName)
+            => s_supportedLanguages.First(language =>
+                string.Equals(language.CultureName, NormalizeCultureName(cultureName), StringComparison.OrdinalIgnoreCase))
+                .DisplayName;
+    }
+
+    /// <summary>
+    /// Describes a supported EVEMon UI language.
+    /// </summary>
+    public sealed class SupportedLanguage
+    {
+        public SupportedLanguage(string cultureName, string displayName)
+        {
+            CultureName = cultureName;
+            DisplayName = displayName;
+        }
+
+        public string CultureName { get; }
+
+        public string DisplayName { get; }
+
+        public override string ToString() => DisplayName;
+    }
+}

--- a/src/EVEMon.Common/Models/Comparers/SerializableSettingsComparer.cs
+++ b/src/EVEMon.Common/Models/Comparers/SerializableSettingsComparer.cs
@@ -28,6 +28,7 @@ namespace EVEMon.Common.Models.Comparers
                 return false;
             return x.Revision == y.Revision &&
                    x.Compatibility == y.Compatibility &&
+                   x.Language == y.Language &&
                    Equals(x.Updates, y.Updates) &&
                    Equals(x.Notifications, y.Notifications) &&
                    Equals(x.Scheduler, y.Scheduler) &&
@@ -54,6 +55,7 @@ namespace EVEMon.Common.Models.Comparers
             {
                 var hashCode = obj.Revision;
                 hashCode = (hashCode * 397) ^ (int)obj.Compatibility;
+                hashCode = (hashCode * 397) ^ (obj.Language?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (obj.Updates?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (obj.Notifications?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (obj.Scheduler?.GetHashCode() ?? 0);

--- a/src/EVEMon.Common/Net/ExceptionMessages.zh-CN.resx
+++ b/src/EVEMon.Common/Net/ExceptionMessages.zh-CN.resx
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="ConnectFailure" xml:space="preserve">
+    <value>由于 EVEMon 无法连接到服务器，对 {0} 的请求失败。请检查您的网络和/或防火墙设置。</value>
+  </data>
+  <data name="FileException" xml:space="preserve">
+    <value>由于无法写入文件，对 {0} 的文件请求失败。</value>
+  </data>
+  <data name="Forbidden" xml:space="preserve">
+    <value>不允许向 {0} 发出请求。</value>
+  </data>
+  <data name="ImageException" xml:space="preserve">
+    <value>对 {0} 的图像请求失败，因为服务器未返回有效图像。</value>
+  </data>
+  <data name="NameResolutionFailure" xml:space="preserve">
+    <value>对 {0} 的请求失败，因为名称解析程序服务无法解析主机名。请检查您的网络设置。</value>
+  </data>
+  <data name="ProxyAuthenticationFailure" xml:space="preserve">
+    <value>{0} 处的代理服务器拒绝了对 {1} 的请求。请确认您指定了正确的用户名和密码。</value>
+  </data>
+  <data name="ProxyAuthenticationFailureDisabledRequests" xml:space="preserve">
+    <value>{0} 处的代理服务器拒绝了对 {1} 的请求。请确认您指定了正确的用户名和密码。在您的代理设置更新之前，请求已暂时被禁用。</value>
+  </data>
+  <data name="ProxyNameResolutionFailure" xml:space="preserve">
+    <value>名称解析程序服务无法解析代理主机名“{0}”。请验证您是否指定了正确的代理服务器，或检查您的网络设置。</value>
+  </data>
+  <data name="RedirectsExceeded" xml:space="preserve">
+    <value>尝试从 {0} 检索数据时超出了最大重定向数。</value>
+  </data>
+  <data name="RequestProhibitedByProxy" xml:space="preserve">
+    <value>{1} 上的代理不允许向 {0} 发出请求。</value>
+  </data>
+  <data name="RequestsDisabled" xml:space="preserve">
+    <value>对 {0} 的请求失败，因为请求已被暂时禁用。</value>
+  </data>
+  <data name="ServerError" xml:space="preserve">
+    <value>{0} 处的服务器返回错误。服务器返回的完整响应是： </value>
+  </data>
+  <data name="Timeout" xml:space="preserve">
+    <value>对 {0} 的请求失败，因为在超时期间未收到响应。</value>
+  </data>
+  <data name="UnknownException" xml:space="preserve">
+    <value>对 {0} 的请求失败，状态为：{1}。</value>
+  </data>
+  <data name="XmlException" xml:space="preserve">
+    <value>对 {0} 的 Xml 请求失败，因为服务器未返回有效的 Xml 文档</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Properties/Resources.zh-CN.resx
+++ b/src/EVEMon.Common/Properties/Resources.zh-CN.resx
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="ErrorAccountBalance" xml:space="preserve">
+    <value>查询 {0} 的钱包余额时出错。</value>
+  </data>
+  <data name="ErrorAccountStatus" xml:space="preserve">
+    <value>查询 API 密钥 {0} 的帐户状态时出错。</value>
+  </data>
+  <data name="ErrorAssets" xml:space="preserve">
+    <value>查询 {0} 的资产时出错。</value>
+  </data>
+  <data name="ErrorAttributes" xml:space="preserve">
+    <value>查询 {0} 的学习属性时出错。</value>
+  </data>
+  <data name="ErrorCalendarAttendees" xml:space="preserve">
+    <value>获取 {0} 的日历活动参与者时出错。</value>
+  </data>
+  <data name="ErrorCalendarDetails" xml:space="preserve">
+    <value>获取 {0} 的日历活动详细信息时出错。</value>
+  </data>
+  <data name="ErrorCalendarEvents" xml:space="preserve">
+    <value>查询 {0} 的日历事件时出错。</value>
+  </data>
+  <data name="ErrorCharacterList" xml:space="preserve">
+    <value>检索 {0:D} 的字符列表时出错。
+如果您更改了密码，则必须使用“文件”&gt;“添加字符”重新登录。</value>
+  </data>
+  <data name="ErrorCharacterSheet" xml:space="preserve">
+    <value>查询 {0} 的字符表时出错。</value>
+  </data>
+  <data name="ErrorContacts" xml:space="preserve">
+    <value>查询 {0} 的联系人时出错。</value>
+  </data>
+  <data name="ErrorContractBids" xml:space="preserve">
+    <value>获取 {0} 的合同出价时出错。</value>
+  </data>
+  <data name="ErrorContractItems" xml:space="preserve">
+    <value>获取 {0} 的合同项目时出错。</value>
+  </data>
+  <data name="ErrorContracts" xml:space="preserve">
+    <value>查询 {0} 的合同时出错。</value>
+  </data>
+  <data name="ErrorEmploymentHistory" xml:space="preserve">
+    <value>查询 {0} 的工作经历时出错。</value>
+  </data>
+  <data name="ErrorEVEFacWarList" xml:space="preserve">
+    <value>查询EVE派系战争列表时出错。</value>
+  </data>
+  <data name="ErrorEVEFacWarStat" xml:space="preserve">
+    <value>查询EVE派系战争统计信息时出错。</value>
+  </data>
+  <data name="ErrorEVEMail" xml:space="preserve">
+    <value>查询 {0} 的邮件消息时出错。</value>
+  </data>
+  <data name="ErrorEVEMailBody" xml:space="preserve">
+    <value>获取 {0} 的邮件内容时出错。</value>
+  </data>
+  <data name="ErrorEVEMailLists" xml:space="preserve">
+    <value>查询 {0} 的邮件列表时出错。</value>
+  </data>
+  <data name="ErrorFacWarStat" xml:space="preserve">
+    <value>查询{0}派系战争统计信息时出错。</value>
+  </data>
+  <data name="ErrorIDToName" xml:space="preserve">
+    <value>查找角色身份时出错。</value>
+  </data>
+  <data name="ErrorImplants" xml:space="preserve">
+    <value>查询 {0} 的植入时出错。</value>
+  </data>
+  <data name="ErrorIndustryJobs" xml:space="preserve">
+    <value>查询 {0} 的行业职位时出错。</value>
+  </data>
+  <data name="ErrorJumpClones" xml:space="preserve">
+    <value>查询 {0} 的跳转克隆时出错。</value>
+  </data>
+  <data name="ErrorJumpFatigue" xml:space="preserve">
+    <value>查询 {0} 的跳跃疲劳度时出错。</value>
+  </data>
+  <data name="ErrorKillLog" xml:space="preserve">
+    <value>查询 {0} 的终止日志时出错。</value>
+  </data>
+  <data name="ErrorKillMail" xml:space="preserve">
+    <value>从服务器获取终止邮件 {0} 时出错。</value>
+  </data>
+  <data name="ErrorLocation" xml:space="preserve">
+    <value>查询 {0} 的位置时出错。</value>
+  </data>
+  <data name="ErrorMarketOrders" xml:space="preserve">
+    <value>查询{0}的市价单时出错。</value>
+  </data>
+  <data name="ErrorMedals" xml:space="preserve">
+    <value>查询 {0} 的奖牌时出错。</value>
+  </data>
+  <data name="ErrorNotifications" xml:space="preserve">
+    <value>查询 {0} 的 EVE 通知时出错。</value>
+  </data>
+  <data name="ErrorPlanetLayout" xml:space="preserve">
+    <value>获取 {0} 的行星生产布局时出错。</value>
+  </data>
+  <data name="ErrorPlanets" xml:space="preserve">
+    <value>查询行星生产信息时出错。</value>
+  </data>
+  <data name="ErrorResearchPoints" xml:space="preserve">
+    <value>查询 {0} 的研究点时出错。</value>
+  </data>
+  <data name="ErrorShip" xml:space="preserve">
+    <value>查询 {0} 的当前船舶时出错。</value>
+  </data>
+  <data name="ErrorSkillQueue" xml:space="preserve">
+    <value>查询 {0} 的技能队列时出错。</value>
+  </data>
+  <data name="ErrorSkills" xml:space="preserve">
+    <value>查询 {0} 的已知技能时出错。</value>
+  </data>
+  <data name="ErrorSSO" xml:space="preserve">
+    <value>登录 EVE SSO 时出错。
+如果您更改了密码，则必须使用“文件”&gt;“添加字符”重新登录。</value>
+  </data>
+  <data name="ErrorStandings" xml:space="preserve">
+    <value>查询 {0} 的排名时出错。</value>
+  </data>
+  <data name="ErrorStation" xml:space="preserve">
+    <value>查找电台信息时出错。</value>
+  </data>
+  <data name="ErrorStatus" xml:space="preserve">
+    <value>查询 EVE 服务器状态时出错。在 http://EVE-offline.net/ 上检查 EVE 服务器的正常运行时间</value>
+  </data>
+  <data name="ErrorStructure" xml:space="preserve">
+    <value>查找城堡信息时出错。</value>
+  </data>
+  <data name="ErrorWalletJournal" xml:space="preserve">
+    <value>查询 {0} 的钱包日志时出错。</value>
+  </data>
+  <data name="ErrorWalletTransactions" xml:space="preserve">
+    <value>查询 {0} 的钱包交易时出错。</value>
+  </data>
+  <data name="MessageExpiration" xml:space="preserve">
+    <value>此帐户将于 {0} 到期：{1}。</value>
+  </data>
+  <data name="MessageLessThanDay" xml:space="preserve">
+    <value>角色 {0} 的排队技能不足 {1} 天{2}。</value>
+  </data>
+  <data name="MessageMarginTrading" xml:space="preserve">
+    <value>角色{0}没有足够的资金来履行其所有购买订单。</value>
+  </data>
+  <data name="MessageNewContracts" xml:space="preserve">
+    <value>{0}分配的合同{1}。</value>
+  </data>
+  <data name="ErrorLoyalty" xml:space="preserve">
+    <value>查询 {0} 的忠诚度积分余额时出错。</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group0/Default.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group0/Default.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group1/Dice_Spots.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group1/Dice_Spots.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group2/Slashes.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group2/Slashes.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group3/Pie_Slices.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group3/Pie_Slices.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group4/Pentagons.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group4/Pentagons.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group5/Pentagrams.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group5/Pentagrams.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group6/Black_Dice.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group6/Black_Dice.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group7/Red_Dice.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group7/Red_Dice.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Resources/Skill_Select/Group8/Bars.zh-CN.resx
+++ b/src/EVEMon.Common/Resources/Skill_Select/Group8/Bars.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Serialization/Datafiles/DatafileConstants.zh-CN.resx
+++ b/src/EVEMon.Common/Serialization/Datafiles/DatafileConstants.zh-CN.resx
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="BlueprintsDatafile" xml:space="preserve">
+    <value>前夕蓝图-en-US.xml.gzip</value>
+  </data>
+  <data name="CertificatesDatafile" xml:space="preserve">
+    <value>前夕证书-en-US.xml.gzip</value>
+  </data>
+  <data name="GeographyDatafile" xml:space="preserve">
+    <value>前夕地理-en-US.xml.gzip</value>
+  </data>
+  <data name="ItemsDatafile" xml:space="preserve">
+    <value>前夕项目-en-US.xml.gzip</value>
+  </data>
+  <data name="MasteriesDatafile" xml:space="preserve">
+    <value>前夜大师-en-US.xml.gzip</value>
+  </data>
+  <data name="PropertiesDatafile" xml:space="preserve">
+    <value>前夕属性-en-US.xml.gzip</value>
+  </data>
+  <data name="ReprocessingDatafile" xml:space="preserve">
+    <value>EVE-reprocessing-en-US.xml.gzip</value>
+  </data>
+  <data name="SkillsDatafile" xml:space="preserve">
+    <value>EVE-skills-en-US.xml.gzip</value>
+  </data>
+</root>

--- a/src/EVEMon.Common/Serialization/Settings/SerializableSettings.cs
+++ b/src/EVEMon.Common/Serialization/Settings/SerializableSettings.cs
@@ -24,6 +24,7 @@ namespace EVEMon.Common.Serialization.Settings
             m_monitoredCharacters = new Collection<MonitoredCharacterSettings>();
             SSOClientID = string.Empty;
             SSOClientSecret = string.Empty;
+            Language = LocalizationHelper.DefaultCultureName;
             CloudStorageServiceProvider = new CloudStorageServiceProviderSettings();
             PortableEveInstallations = new PortableEveInstallationsSettings();
             Notifications = new NotificationSettings();
@@ -47,6 +48,9 @@ namespace EVEMon.Common.Serialization.Settings
 
         [XmlElement("compatibility")]
         public CompatibilityMode Compatibility { get; set; }
+
+        [XmlElement("language")]
+        public string Language { get; set; }
 
         [XmlArray("esiKeys")]
         [XmlArrayItem("esikey")]

--- a/src/EVEMon.Common/Settings.cs
+++ b/src/EVEMon.Common/Settings.cs
@@ -39,6 +39,7 @@ namespace EVEMon.Common
         {
             SSOClientID = string.Empty;
             SSOClientSecret = string.Empty;
+            Language = LocalizationHelper.DefaultCultureName;
             UI = new UISettings();
             Proxy = new ProxySettings();
             Updates = new UpdateSettings();
@@ -85,6 +86,11 @@ namespace EVEMon.Common
         /// Gets or sets the compatibility mode.
         /// </summary>
         public static CompatibilityMode Compatibility { get; private set; }
+
+        /// <summary>
+        /// Gets the selected UI language.
+        /// </summary>
+        public static string Language { get; private set; }
 
         /// <summary>
         /// Gets the settings for updates.
@@ -187,6 +193,7 @@ namespace EVEMon.Common
                 // API settings
                 SSOClientID = s_settings.SSOClientID ?? string.Empty;
                 SSOClientSecret = s_settings.SSOClientSecret ?? string.Empty;
+                Language = LocalizationHelper.NormalizeCultureName(s_settings.Language);
 
                 // User settings
                 UI = s_settings.UI;
@@ -348,6 +355,7 @@ namespace EVEMon.Common
             {
                 SSOClientID = SSOClientID,
                 SSOClientSecret = SSOClientSecret,
+                Language = Language,
                 Revision = Revision,
                 Compatibility = Compatibility,
                 Scheduler = Scheduler.Export(),

--- a/src/EVEMon.PieChart/SkillsPieChart.zh-CN.resx
+++ b/src/EVEMon.PieChart/SkillsPieChart.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Sales/MineralTile.zh-CN.resx
+++ b/src/EVEMon.Sales/MineralTile.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Sales/MineralWorksheet.Designer.cs
+++ b/src/EVEMon.Sales/MineralWorksheet.Designer.cs
@@ -76,7 +76,7 @@ namespace EVEMon.Sales
             this.btnLockPrices.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.btnLockPrices.Name = "btnLockPrices";
             this.btnLockPrices.Size = new System.Drawing.Size(86, 22);
-            this.btnLockPrices.Text = "Lock Prices";
+            this.btnLockPrices.Text = resources.GetString("this.btnLockPrices.Text");
             this.btnLockPrices.Click += new System.EventHandler(this.btnLockPrices_Click);
             // 
             // toolStripSeparator1
@@ -90,7 +90,7 @@ namespace EVEMon.Sales
             this.tsddFetch.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsddFetch.Name = "tsddFetch";
             this.tsddFetch.Size = new System.Drawing.Size(137, 22);
-            this.tsddFetch.Text = "Fetch Online Prices";
+            this.tsddFetch.Text = resources.GetString("this.tsddFetch.Text");
             // 
             // btnReset
             // 
@@ -98,7 +98,7 @@ namespace EVEMon.Sales
             this.btnReset.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(112, 22);
-            this.btnReset.Text = "Reset Quantities";
+            this.btnReset.Text = resources.GetString("this.btnReset.Text");
             this.btnReset.Click += new System.EventHandler(this.btnReset_Click);
             // 
             // copyTotalDropDownButton
@@ -110,21 +110,21 @@ namespace EVEMon.Sales
             this.copyTotalDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.copyTotalDropDownButton.Name = "copyTotalDropDownButton";
             this.copyTotalDropDownButton.Size = new System.Drawing.Size(93, 22);
-            this.copyTotalDropDownButton.Text = "Copy Total";
+            this.copyTotalDropDownButton.Text = resources.GetString("this.copyTotalDropDownButton.Text");
             this.copyTotalDropDownButton.DropDownOpening += new System.EventHandler(this.copyTotalDropDownButton_DropDownOpening);
             // 
             // copyFormattedTotalToolStripMenuItem
             // 
             this.copyFormattedTotalToolStripMenuItem.Name = "copyFormattedTotalToolStripMenuItem";
             this.copyFormattedTotalToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
-            this.copyFormattedTotalToolStripMenuItem.Text = "Formatted";
+            this.copyFormattedTotalToolStripMenuItem.Text = resources.GetString("this.copyFormattedTotalToolStripMenuItem.Text");
             this.copyFormattedTotalToolStripMenuItem.Click += new System.EventHandler(this.copyFormattedTotalToolStripMenuItem_Click);
             // 
             // copyUnformattedTotalToolStripMenuItem
             // 
             this.copyUnformattedTotalToolStripMenuItem.Name = "copyUnformattedTotalToolStripMenuItem";
             this.copyUnformattedTotalToolStripMenuItem.Size = new System.Drawing.Size(142, 22);
-            this.copyUnformattedTotalToolStripMenuItem.Text = "Unformatted";
+            this.copyUnformattedTotalToolStripMenuItem.Text = resources.GetString("this.copyUnformattedTotalToolStripMenuItem.Text");
             this.copyUnformattedTotalToolStripMenuItem.Click += new System.EventHandler(this.copyUnformattedTotalToolStripMenuItem_Click);
             // 
             // MineralWorksheetStatusStrip
@@ -138,13 +138,13 @@ namespace EVEMon.Sales
             this.MineralWorksheetStatusStrip.Size = new System.Drawing.Size(538, 22);
             this.MineralWorksheetStatusStrip.SizingGrip = false;
             this.MineralWorksheetStatusStrip.TabIndex = 10;
-            this.MineralWorksheetStatusStrip.Text = "statusStrip1";
+            this.MineralWorksheetStatusStrip.Text = resources.GetString("this.MineralWorksheetStatusStrip.Text");
             // 
             // TotalValueToolStripStatusLabel
             // 
             this.TotalValueToolStripStatusLabel.Name = "TotalValueToolStripStatusLabel";
             this.TotalValueToolStripStatusLabel.Size = new System.Drawing.Size(67, 17);
-            this.TotalValueToolStripStatusLabel.Text = "Total Value:";
+            this.TotalValueToolStripStatusLabel.Text = resources.GetString("this.TotalValueToolStripStatusLabel.Text");
             // 
             // tslTotal
             // 
@@ -152,7 +152,7 @@ namespace EVEMon.Sales
             this.tslTotal.Margin = new System.Windows.Forms.Padding(5, 3, 0, 2);
             this.tslTotal.Name = "tslTotal";
             this.tslTotal.Size = new System.Drawing.Size(63, 17);
-            this.tslTotal.Text = "0.00 ISK";
+            this.tslTotal.Text = resources.GetString("this.tslTotal.Text");
             // 
             // tslCourtesy
             // 
@@ -161,7 +161,7 @@ namespace EVEMon.Sales
             this.tslCourtesy.Margin = new System.Windows.Forms.Padding(15, 3, 0, 2);
             this.tslCourtesy.Name = "tslCourtesy";
             this.tslCourtesy.Size = new System.Drawing.Size(179, 17);
-            this.tslCourtesy.Text = "Mineral Prices Courtesy of ---";
+            this.tslCourtesy.Text = resources.GetString("this.tslCourtesy.Text");
             this.tslCourtesy.Visible = false;
             this.tslCourtesy.Click += new System.EventHandler(this.tslCourtesy_Click);
             // 
@@ -362,7 +362,7 @@ namespace EVEMon.Sales
             this.MaximizeBox = false;
             this.Name = "MineralWorksheet";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Mineral Worksheet";
+            this.Text = resources.GetString("this.Text");
             this.Load += new System.EventHandler(this.MineralWorksheet_Load);
             this.MineralWorksheetToolStrip.ResumeLayout(false);
             this.MineralWorksheetToolStrip.PerformLayout();

--- a/src/EVEMon.Sales/MineralWorksheet.resx
+++ b/src/EVEMon.Sales/MineralWorksheet.resx
@@ -237,4 +237,37 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>45</value>
   </metadata>
+  <data name="this.btnLockPrices.Text" xml:space="preserve">
+    <value>Lock Prices</value>
+  </data>
+  <data name="this.tsddFetch.Text" xml:space="preserve">
+    <value>Fetch Online Prices</value>
+  </data>
+  <data name="this.btnReset.Text" xml:space="preserve">
+    <value>Reset Quantities</value>
+  </data>
+  <data name="this.copyTotalDropDownButton.Text" xml:space="preserve">
+    <value>Copy Total</value>
+  </data>
+  <data name="this.copyFormattedTotalToolStripMenuItem.Text" xml:space="preserve">
+    <value>Formatted</value>
+  </data>
+  <data name="this.copyUnformattedTotalToolStripMenuItem.Text" xml:space="preserve">
+    <value>Unformatted</value>
+  </data>
+  <data name="this.MineralWorksheetStatusStrip.Text" xml:space="preserve">
+    <value>statusStrip1</value>
+  </data>
+  <data name="this.TotalValueToolStripStatusLabel.Text" xml:space="preserve">
+    <value>Total Value:</value>
+  </data>
+  <data name="this.tslTotal.Text" xml:space="preserve">
+    <value>0.00 ISK</value>
+  </data>
+  <data name="this.tslCourtesy.Text" xml:space="preserve">
+    <value>Mineral Prices Courtesy of ---</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Mineral Worksheet</value>
+  </data>
 </root>

--- a/src/EVEMon.Sales/MineralWorksheet.zh-CN.resx
+++ b/src/EVEMon.Sales/MineralWorksheet.zh-CN.resx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.btnLockPrices.Text" xml:space="preserve">
+    <value>锁定价格</value>
+  </data>
+  <data name="this.tsddFetch.Text" xml:space="preserve">
+    <value>获取在线价格</value>
+  </data>
+  <data name="this.btnReset.Text" xml:space="preserve">
+    <value>重置数量</value>
+  </data>
+  <data name="this.copyTotalDropDownButton.Text" xml:space="preserve">
+    <value>复制总数</value>
+  </data>
+  <data name="this.copyFormattedTotalToolStripMenuItem.Text" xml:space="preserve">
+    <value>格式化</value>
+  </data>
+  <data name="this.copyUnformattedTotalToolStripMenuItem.Text" xml:space="preserve">
+    <value>未格式化</value>
+  </data>
+  <data name="this.MineralWorksheetStatusStrip.Text" xml:space="preserve">
+    <value>状态条1</value>
+  </data>
+  <data name="this.TotalValueToolStripStatusLabel.Text" xml:space="preserve">
+    <value>总价值：</value>
+  </data>
+  <data name="this.tslTotal.Text" xml:space="preserve">
+    <value>0.00 ISK</value>
+  </data>
+  <data name="this.tslCourtesy.Text" xml:space="preserve">
+    <value>矿物价格由 --- 提供</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>矿物工作表</value>
+  </data>
+</root>

--- a/src/EVEMon.Watchdog/Properties/Resources.zh-CN.resx
+++ b/src/EVEMon.Watchdog/Properties/Resources.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon.Watchdog/WatchdogWindow.zh-CN.resx
+++ b/src/EVEMon.Watchdog/WatchdogWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/APIErrorHandling/APIErrorWindow.Designer.cs
+++ b/src/EVEMon/APIErrorHandling/APIErrorWindow.Designer.cs
@@ -49,7 +49,7 @@
             this.ErrorLabel.Name = "ErrorLabel";
             this.ErrorLabel.Size = new System.Drawing.Size(521, 40);
             this.ErrorLabel.TabIndex = 1;
-            this.ErrorLabel.Text = "Error details.";
+            this.ErrorLabel.Text = resources.GetString("this.ErrorLabel.Text");
             // 
             // IconPictureBox
             // 
@@ -96,7 +96,7 @@
             this.CopyToClipboardLinkLabel.Size = new System.Drawing.Size(90, 23);
             this.CopyToClipboardLinkLabel.TabIndex = 4;
             this.CopyToClipboardLinkLabel.TabStop = true;
-            this.CopyToClipboardLinkLabel.Text = "Copy to Clipboard";
+            this.CopyToClipboardLinkLabel.Text = resources.GetString("this.CopyToClipboardLinkLabel.Text");
             this.CopyToClipboardLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.CopyToClipboardLinkLabel_LinkClicked);
             // 
             // DetailsPanel
@@ -126,7 +126,7 @@
             this.DetailsTextBox.ReadOnly = true;
             this.DetailsTextBox.Size = new System.Drawing.Size(545, 349);
             this.DetailsTextBox.TabIndex = 3;
-            this.DetailsTextBox.Text = "No error details are available.";
+            this.DetailsTextBox.Text = resources.GetString("this.DetailsTextBox.Text");
             // 
             // TroubleshooterPanel
             // 
@@ -156,7 +156,7 @@
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(500, 500);
             this.Name = "ApiErrorWindow";
-            this.Text = "API Error Details";
+            this.Text = resources.GetString("this.Text");
             ((System.ComponentModel.ISupportInitialize)(this.IconPictureBox)).EndInit();
             this.MainTableLayoutPanel.ResumeLayout(false);
             this.MainTableLayoutPanel.PerformLayout();

--- a/src/EVEMon/APIErrorHandling/APIErrorWindow.resx
+++ b/src/EVEMon/APIErrorHandling/APIErrorWindow.resx
@@ -159,4 +159,16 @@
         RK5CYII=
 </value>
   </data>
+  <data name="this.ErrorLabel.Text" xml:space="preserve">
+    <value>Error details.</value>
+  </data>
+  <data name="this.CopyToClipboardLinkLabel.Text" xml:space="preserve">
+    <value>Copy to Clipboard</value>
+  </data>
+  <data name="this.DetailsTextBox.Text" xml:space="preserve">
+    <value>No error details are available.</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>API Error Details</value>
+  </data>
 </root>

--- a/src/EVEMon/APIErrorHandling/APIErrorWindow.zh-CN.resx
+++ b/src/EVEMon/APIErrorHandling/APIErrorWindow.zh-CN.resx
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.ErrorLabel.Text" xml:space="preserve">
+    <value>错误详细信息。</value>
+  </data>
+  <data name="this.CopyToClipboardLinkLabel.Text" xml:space="preserve">
+    <value>复制到剪贴板</value>
+  </data>
+  <data name="this.DetailsTextBox.Text" xml:space="preserve">
+    <value>没有可用的错误详细信息。</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>API错误详细信息</value>
+  </data>
+</root>

--- a/src/EVEMon/APIErrorHandling/HttpTimeoutTroubleshooter.zh-CN.resx
+++ b/src/EVEMon/APIErrorHandling/HttpTimeoutTroubleshooter.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/About/AboutWindow.Designer.cs
+++ b/src/EVEMon/About/AboutWindow.Designer.cs
@@ -144,7 +144,7 @@ namespace EVEMon.About
             this.EVEMonLabel.Name = "EVEMonLabel";
             this.EVEMonLabel.Size = new System.Drawing.Size(49, 13);
             this.EVEMonLabel.TabIndex = 0;
-            this.EVEMonLabel.Text = "EVEMon";
+            this.EVEMonLabel.Text = resources.GetString("this.EVEMonLabel.Text");
             // 
             // VersionLabel
             // 
@@ -153,7 +153,7 @@ namespace EVEMon.About
             this.VersionLabel.Name = "VersionLabel";
             this.VersionLabel.Size = new System.Drawing.Size(59, 13);
             this.VersionLabel.TabIndex = 1;
-            this.VersionLabel.Text = "Version {0}";
+            this.VersionLabel.Text = resources.GetString("this.VersionLabel.Text");
             // 
             // CopyrightLabel
             // 
@@ -162,7 +162,7 @@ namespace EVEMon.About
             this.CopyrightLabel.Name = "CopyrightLabel";
             this.CopyrightLabel.Size = new System.Drawing.Size(107, 13);
             this.CopyrightLabel.TabIndex = 5;
-            this.CopyrightLabel.Text = "Copyright © 2006-{0}";
+            this.CopyrightLabel.Text = resources.GetString("this.CopyrightLabel.Text");
             // 
             // DevelopmentTeamLabel
             // 
@@ -171,7 +171,7 @@ namespace EVEMon.About
             this.DevelopmentTeamLabel.Name = "DevelopmentTeamLabel";
             this.DevelopmentTeamLabel.Size = new System.Drawing.Size(145, 13);
             this.DevelopmentTeamLabel.TabIndex = 6;
-            this.DevelopmentTeamLabel.Text = "EVEMon Development Team";
+            this.DevelopmentTeamLabel.Text = resources.GetString("this.DevelopmentTeamLabel.Text");
             // 
             // HomePageLinkLabel
             // 
@@ -181,7 +181,7 @@ namespace EVEMon.About
             this.HomePageLinkLabel.Size = new System.Drawing.Size(38, 13);
             this.HomePageLinkLabel.TabIndex = 0;
             this.HomePageLinkLabel.TabStop = true;
-            this.HomePageLinkLabel.Text = "http://";
+            this.HomePageLinkLabel.Text = resources.GetString("this.HomePageLinkLabel.Text");
             this.HomePageLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.HomePageLinkLabel_LinkClicked);
             // 
             // BodyLayoutPanel
@@ -240,7 +240,7 @@ namespace EVEMon.About
             this.CreatedByLabel.Name = "CreatedByLabel";
             this.CreatedByLabel.Size = new System.Drawing.Size(279, 13);
             this.CreatedByLabel.TabIndex = 2;
-            this.CreatedByLabel.Text = "Originally created by Timothy \'Six Anari\' Fries of Goonfleet.";
+            this.CreatedByLabel.Text = resources.GetString("this.CreatedByLabel.Text");
             // 
             // ContinuedByLabel
             // 
@@ -250,7 +250,7 @@ namespace EVEMon.About
             this.ContinuedByLabel.Name = "ContinuedByLabel";
             this.ContinuedByLabel.Size = new System.Drawing.Size(257, 13);
             this.ContinuedByLabel.TabIndex = 3;
-            this.ContinuedByLabel.Text = "Continued by the listed \'Developers and contributors\'.";
+            this.ContinuedByLabel.Text = resources.GetString("this.ContinuedByLabel.Text");
             // 
             // DonationsLabel
             // 
@@ -260,7 +260,7 @@ namespace EVEMon.About
             this.DonationsLabel.Name = "DonationsLabel";
             this.DonationsLabel.Size = new System.Drawing.Size(211, 13);
             this.DonationsLabel.TabIndex = 4;
-            this.DonationsLabel.Text = "Donations of ISK are always appreciated. ;)";
+            this.DonationsLabel.Text = resources.GetString("this.DonationsLabel.Text");
             // 
             // DevContribLabel
             // 
@@ -269,7 +269,7 @@ namespace EVEMon.About
             this.DevContribLabel.Name = "DevContribLabel";
             this.DevContribLabel.Size = new System.Drawing.Size(140, 13);
             this.DevContribLabel.TabIndex = 8;
-            this.DevContribLabel.Text = "Developers and contributors";
+            this.DevContribLabel.Text = resources.GetString("this.DevContribLabel.Text");
             // 
             // devsList
             // 
@@ -291,7 +291,7 @@ namespace EVEMon.About
             this.CredentialsLabels.Name = "CredentialsLabels";
             this.CredentialsLabels.Size = new System.Drawing.Size(183, 13);
             this.CredentialsLabels.TabIndex = 10;
-            this.CredentialsLabels.Text = "External contributions and credentials";
+            this.CredentialsLabels.Text = resources.GetString("this.CredentialsLabels.Text");
             // 
             // credentialsFlowLayoutPanel
             // 
@@ -325,7 +325,7 @@ namespace EVEMon.About
             this.ccpGamesLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.ccpGamesLinkLabel.Size = new System.Drawing.Size(235, 32);
             this.ccpGamesLinkLabel.TabIndex = 7;
-            this.ccpGamesLinkLabel.Text = "CCP Games for their efforts towards community developers.";
+            this.ccpGamesLinkLabel.Text = resources.GetString("this.ccpGamesLinkLabel.Text");
             this.ccpGamesLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // ccpDocsLinkLabel
@@ -338,7 +338,7 @@ namespace EVEMon.About
             this.ccpDocsLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.ccpDocsLinkLabel.Size = new System.Drawing.Size(217, 19);
             this.ccpDocsLinkLabel.TabIndex = 8;
-            this.ccpDocsLinkLabel.Text = "CCP 3rd party docs for their documentation.";
+            this.ccpDocsLinkLabel.Text = resources.GetString("this.ccpDocsLinkLabel.Text");
             this.ccpDocsLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // bitbucketLinkLabel
@@ -351,7 +351,7 @@ namespace EVEMon.About
             this.bitbucketLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.bitbucketLinkLabel.Size = new System.Drawing.Size(165, 19);
             this.bitbucketLinkLabel.TabIndex = 21;
-            this.bitbucketLinkLabel.Text = "Bitbucket for hosting the project.";
+            this.bitbucketLinkLabel.Text = resources.GetString("this.bitbucketLinkLabel.Text");
             this.bitbucketLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // gitHubLinkLabel
@@ -364,7 +364,7 @@ namespace EVEMon.About
             this.gitHubLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.gitHubLinkLabel.Size = new System.Drawing.Size(238, 32);
             this.gitHubLinkLabel.TabIndex = 22;
-            this.gitHubLinkLabel.Text = "GitHub for hosting the project and providing our representation site.";
+            this.gitHubLinkLabel.Text = resources.GetString("this.gitHubLinkLabel.Text");
             this.gitHubLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // eveMarketerLinkLabel
@@ -377,7 +377,7 @@ namespace EVEMon.About
             this.eveMarketerLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.eveMarketerLinkLabel.Size = new System.Drawing.Size(216, 19);
             this.eveMarketerLinkLabel.TabIndex = 12;
-            this.eveMarketerLinkLabel.Text = "EVEMarketer for their market data and API.";
+            this.eveMarketerLinkLabel.Text = resources.GetString("this.eveMarketerLinkLabel.Text");
             this.eveMarketerLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // eveMarketDataLinkLabel
@@ -390,7 +390,7 @@ namespace EVEMon.About
             this.eveMarketDataLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.eveMarketDataLinkLabel.Size = new System.Drawing.Size(233, 19);
             this.eveMarketDataLinkLabel.TabIndex = 19;
-            this.eveMarketDataLinkLabel.Text = "EVE-MarketData for their market data and API.";
+            this.eveMarketDataLinkLabel.Text = resources.GetString("this.eveMarketDataLinkLabel.Text");
             this.eveMarketDataLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // googleApisLinkLabel
@@ -403,7 +403,7 @@ namespace EVEMon.About
             this.googleApisLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.googleApisLinkLabel.Size = new System.Drawing.Size(132, 19);
             this.googleApisLinkLabel.TabIndex = 10;
-            this.googleApisLinkLabel.Text = "Google for their API SDK.";
+            this.googleApisLinkLabel.Text = resources.GetString("this.googleApisLinkLabel.Text");
             this.googleApisLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // dropboxSDKLinkLabel
@@ -416,7 +416,7 @@ namespace EVEMon.About
             this.dropboxSDKLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.dropboxSDKLinkLabel.Size = new System.Drawing.Size(138, 19);
             this.dropboxSDKLinkLabel.TabIndex = 17;
-            this.dropboxSDKLinkLabel.Text = "Dropbox for their API SDK.";
+            this.dropboxSDKLinkLabel.Text = resources.GetString("this.dropboxSDKLinkLabel.Text");
             this.dropboxSDKLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // oneDriveSDKLinkLabel
@@ -429,7 +429,7 @@ namespace EVEMon.About
             this.oneDriveSDKLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.oneDriveSDKLinkLabel.Size = new System.Drawing.Size(189, 19);
             this.oneDriveSDKLinkLabel.TabIndex = 18;
-            this.oneDriveSDKLinkLabel.Text = "Microsoft OneDrive for their API SDK.";
+            this.oneDriveSDKLinkLabel.Text = resources.GetString("this.oneDriveSDKLinkLabel.Text");
             this.oneDriveSDKLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // lironLeviLinkLabel
@@ -442,7 +442,7 @@ namespace EVEMon.About
             this.lironLeviLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.lironLeviLinkLabel.Size = new System.Drawing.Size(141, 19);
             this.lironLeviLinkLabel.TabIndex = 15;
-            this.lironLeviLinkLabel.Text = "Liron Levi for his MultiPanel";
+            this.lironLeviLinkLabel.Text = resources.GetString("this.lironLeviLinkLabel.Text");
             this.lironLeviLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // battleClinicLinkLabel
@@ -468,7 +468,7 @@ namespace EVEMon.About
             this.stackOverflowLinkLabel.Padding = new System.Windows.Forms.Padding(5, 3, 0, 3);
             this.stackOverflowLinkLabel.Size = new System.Drawing.Size(264, 32);
             this.stackOverflowLinkLabel.TabIndex = 16;
-            this.stackOverflowLinkLabel.Text = "The users of Stack Overflow who contributed advice and code snippits.";
+            this.stackOverflowLinkLabel.Text = resources.GetString("this.stackOverflowLinkLabel.Text");
             this.stackOverflowLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.LinkLabel_LinkClicked);
             // 
             // forgotLabel
@@ -499,7 +499,7 @@ namespace EVEMon.About
             this.Name = "AboutWindow";
             this.Padding = new System.Windows.Forms.Padding(9);
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "About EVEMon";
+            this.Text = resources.GetString("this.Text");
             this.LegalLayoutPanel.ResumeLayout(false);
             this.LegalLayoutPanel.PerformLayout();
             this.HeaderLayoutPanel.ResumeLayout(false);

--- a/src/EVEMon/About/AboutWindow.resx
+++ b/src/EVEMon/About/AboutWindow.resx
@@ -364,4 +364,70 @@ You should have received a copy of the GNU General Public License along with thi
         07/Tv9O/0/93k8/3/wAELnmClucj0gAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="this.EVEMonLabel.Text" xml:space="preserve">
+    <value>EVEMon</value>
+  </data>
+  <data name="this.VersionLabel.Text" xml:space="preserve">
+    <value>Version {0}</value>
+  </data>
+  <data name="this.CopyrightLabel.Text" xml:space="preserve">
+    <value>Copyright � 2006-{0}</value>
+  </data>
+  <data name="this.DevelopmentTeamLabel.Text" xml:space="preserve">
+    <value>EVEMon Development Team</value>
+  </data>
+  <data name="this.HomePageLinkLabel.Text" xml:space="preserve">
+    <value>http://</value>
+  </data>
+  <data name="this.CreatedByLabel.Text" xml:space="preserve">
+    <value>Originally created by Timothy \'Six Anari\' Fries of Goonfleet.</value>
+  </data>
+  <data name="this.ContinuedByLabel.Text" xml:space="preserve">
+    <value>Continued by the listed \'Developers and contributors\'.</value>
+  </data>
+  <data name="this.DonationsLabel.Text" xml:space="preserve">
+    <value>Donations of ISK are always appreciated. ;)</value>
+  </data>
+  <data name="this.DevContribLabel.Text" xml:space="preserve">
+    <value>Developers and contributors</value>
+  </data>
+  <data name="this.CredentialsLabels.Text" xml:space="preserve">
+    <value>External contributions and credentials</value>
+  </data>
+  <data name="this.ccpGamesLinkLabel.Text" xml:space="preserve">
+    <value>CCP Games for their efforts towards community developers.</value>
+  </data>
+  <data name="this.ccpDocsLinkLabel.Text" xml:space="preserve">
+    <value>CCP 3rd party docs for their documentation.</value>
+  </data>
+  <data name="this.bitbucketLinkLabel.Text" xml:space="preserve">
+    <value>Bitbucket for hosting the project.</value>
+  </data>
+  <data name="this.gitHubLinkLabel.Text" xml:space="preserve">
+    <value>GitHub for hosting the project and providing our representation site.</value>
+  </data>
+  <data name="this.eveMarketerLinkLabel.Text" xml:space="preserve">
+    <value>EVEMarketer for their market data and API.</value>
+  </data>
+  <data name="this.eveMarketDataLinkLabel.Text" xml:space="preserve">
+    <value>EVE-MarketData for their market data and API.</value>
+  </data>
+  <data name="this.googleApisLinkLabel.Text" xml:space="preserve">
+    <value>Google for their API SDK.</value>
+  </data>
+  <data name="this.dropboxSDKLinkLabel.Text" xml:space="preserve">
+    <value>Dropbox for their API SDK.</value>
+  </data>
+  <data name="this.oneDriveSDKLinkLabel.Text" xml:space="preserve">
+    <value>Microsoft OneDrive for their API SDK.</value>
+  </data>
+  <data name="this.lironLeviLinkLabel.Text" xml:space="preserve">
+    <value>Liron Levi for his MultiPanel</value>
+  </data>
+  <data name="this.stackOverflowLinkLabel.Text" xml:space="preserve">
+    <value>The users of Stack Overflow who contributed advice and code snippits.</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>About EVEMon</value>
+  </data>
 </root>

--- a/src/EVEMon/About/AboutWindow.zh-CN.resx
+++ b/src/EVEMon/About/AboutWindow.zh-CN.resx
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="GplLabel.Text" xml:space="preserve">
+    <value>该程序是免费软件；您可以根据自由软件基金会发布的 GNU 通用公共许可证第 2 版的条款重新分发和/或修改它。
+
+分发此程序的目的是希望它有用，但不提供任何保证；甚至没有适销性或特定用途适用性的默示保证。有关更多详细信息，请参阅 GNU 通用公共许可证。
+
+您应该随该程序一起收到 GNU 通用公共许可证的副本；如果没有，请写信给 Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA</value>
+  </data>
+  <data name="this.EVEMonLabel.Text" xml:space="preserve">
+    <value>伊芙蒙</value>
+  </data>
+  <data name="this.VersionLabel.Text" xml:space="preserve">
+    <value>版本{0}</value>
+  </data>
+  <data name="this.CopyrightLabel.Text" xml:space="preserve">
+    <value>版权所有 � 2006-{0}</value>
+  </data>
+  <data name="this.DevelopmentTeamLabel.Text" xml:space="preserve">
+    <value>EVEMon开发团队</value>
+  </data>
+  <data name="this.HomePageLinkLabel.Text" xml:space="preserve">
+    <value>http://</value>
+  </data>
+  <data name="this.CreatedByLabel.Text" xml:space="preserve">
+    <value>最初由 Timothy“Six Anari”Fries of Goonfleet 创建。</value>
+  </data>
+  <data name="this.ContinuedByLabel.Text" xml:space="preserve">
+    <value>继续列出“开发人员和贡献者”。</value>
+  </data>
+  <data name="this.DonationsLabel.Text" xml:space="preserve">
+    <value>ISK 的捐赠始终受到赞赏。 ;)</value>
+  </data>
+  <data name="this.DevContribLabel.Text" xml:space="preserve">
+    <value>开发者和贡献者</value>
+  </data>
+  <data name="this.CredentialsLabels.Text" xml:space="preserve">
+    <value>外部贡献和证书</value>
+  </data>
+  <data name="this.ccpGamesLinkLabel.Text" xml:space="preserve">
+    <value>CCP Games 对社区开发者所做的努力。</value>
+  </data>
+  <data name="this.ccpDocsLinkLabel.Text" xml:space="preserve">
+    <value>CCP 3rd party docs 的文档。</value>
+  </data>
+  <data name="this.bitbucketLinkLabel.Text" xml:space="preserve">
+    <value>用于托管项目的 Bitbucket。</value>
+  </data>
+  <data name="this.gitHubLinkLabel.Text" xml:space="preserve">
+    <value>GitHub 用于托管项目并提供我们的代表网站。</value>
+  </data>
+  <data name="this.eveMarketerLinkLabel.Text" xml:space="preserve">
+    <value>EVEMarketer 提供他们的市场数据和 API。</value>
+  </data>
+  <data name="this.eveMarketDataLinkLabel.Text" xml:space="preserve">
+    <value>EVE-MarketData 提供其市场数据和 API。</value>
+  </data>
+  <data name="this.googleApisLinkLabel.Text" xml:space="preserve">
+    <value>Google 的 API SDK。</value>
+  </data>
+  <data name="this.dropboxSDKLinkLabel.Text" xml:space="preserve">
+    <value>Dropbox 的 API SDK。</value>
+  </data>
+  <data name="this.oneDriveSDKLinkLabel.Text" xml:space="preserve">
+    <value>Microsoft OneDrive 的 API SDK。</value>
+  </data>
+  <data name="this.lironLeviLinkLabel.Text" xml:space="preserve">
+    <value>Liron Levi 的 MultiPanel</value>
+  </data>
+  <data name="this.stackOverflowLinkLabel.Text" xml:space="preserve">
+    <value>提供建议和代码片段的 Stack Overflow 用户。</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>关于EVEMon</value>
+  </data>
+</root>

--- a/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.Designer.cs
+++ b/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.Designer.cs
@@ -68,7 +68,7 @@
             this.characterToRemoveLabel.Name = "characterToRemoveLabel";
             this.characterToRemoveLabel.Size = new System.Drawing.Size(214, 13);
             this.characterToRemoveLabel.TabIndex = 1;
-            this.characterToRemoveLabel.Text = "You are about to delete the character \"{0}\".";
+            this.characterToRemoveLabel.Text = resources.GetString("this.characterToRemoveLabel.Text");
             this.characterToRemoveLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // label2
@@ -79,7 +79,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(168, 13);
             this.label2.TabIndex = 2;
-            this.label2.Text = "All your data and plans will be lost!";
+            this.label2.Text = resources.GetString("this.label2.Text");
             // 
             // cancelButton
             // 
@@ -89,7 +89,7 @@
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 3;
-            this.cancelButton.Text = "&Cancel";
+            this.cancelButton.Text = resources.GetString("this.cancelButton.Text");
             this.cancelButton.UseVisualStyleBackColor = true;
             this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
             // 
@@ -101,7 +101,7 @@
             this.deleteButton.Name = "deleteButton";
             this.deleteButton.Size = new System.Drawing.Size(75, 23);
             this.deleteButton.TabIndex = 4;
-            this.deleteButton.Text = "&Delete";
+            this.deleteButton.Text = resources.GetString("this.deleteButton.Text");
             this.deleteButton.UseVisualStyleBackColor = true;
             this.deleteButton.Click += new System.EventHandler(this.deleteButton_Click);
             // 
@@ -112,7 +112,7 @@
             this.noCharactersLabel.Name = "noCharactersLabel";
             this.noCharactersLabel.Size = new System.Drawing.Size(181, 13);
             this.noCharactersLabel.TabIndex = 6;
-            this.noCharactersLabel.Text = "The ESI key{0} will also be removed:";
+            this.noCharactersLabel.Text = resources.GetString("this.noCharactersLabel.Text");
             // 
             // esiKeysListView
             // 
@@ -153,7 +153,7 @@
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "CharacterDeletionWindow";
-            this.Text = "Delete Character";
+            this.Text = resources.GetString("this.Text");
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();

--- a/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.resx
+++ b/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.resx
@@ -158,4 +158,22 @@
         JP41yQEi7v98+w927K1tbAtjLPB/l3OEO2LTS/UAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.characterToRemoveLabel.Text" xml:space="preserve">
+    <value>You are about to delete the character "{0}".</value>
+  </data>
+  <data name="this.label2.Text" xml:space="preserve">
+    <value>All your data and plans will be lost!</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="this.deleteButton.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="this.noCharactersLabel.Text" xml:space="preserve">
+    <value>The ESI key{0} will also be removed:</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Delete Character</value>
+  </data>
 </root>

--- a/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.zh-CN.resx
+++ b/src/EVEMon/ApiCredentialsManagement/CharacterDeletionWindow.zh-CN.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.characterToRemoveLabel.Text" xml:space="preserve">
+    <value>您即将删除字符“{0}”。</value>
+  </data>
+  <data name="this.label2.Text" xml:space="preserve">
+    <value>您的所有数据和计划都将丢失！</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>取消(&amp;C)</value>
+  </data>
+  <data name="this.deleteButton.Text" xml:space="preserve">
+    <value>删除(&amp;D)</value>
+  </data>
+  <data name="this.noCharactersLabel.Text" xml:space="preserve">
+    <value>ESI 密钥{0}也将被删除：</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>删除角色</value>
+  </data>
+</root>

--- a/src/EVEMon/ApiCredentialsManagement/CharacterImportationWindow.zh-CN.resx
+++ b/src/EVEMon/ApiCredentialsManagement/CharacterImportationWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.Designer.cs
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.Designer.cs
@@ -49,7 +49,7 @@
             this.deletionLabel.Name = "deletionLabel";
             this.deletionLabel.Size = new System.Drawing.Size(238, 13);
             this.deletionLabel.TabIndex = 4;
-            this.deletionLabel.Text = "You are about to delete the ESI key with ID : {0}.";
+            this.deletionLabel.Text = resources.GetString("this.deletionLabel.Text");
             this.deletionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // cancelButton
@@ -60,7 +60,7 @@
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 0;
-            this.cancelButton.Text = "&Cancel";
+            this.cancelButton.Text = resources.GetString("this.cancelButton.Text");
             this.cancelButton.UseVisualStyleBackColor = true;
             // 
             // deleteButton
@@ -71,7 +71,7 @@
             this.deleteButton.Name = "deleteButton";
             this.deleteButton.Size = new System.Drawing.Size(75, 23);
             this.deleteButton.TabIndex = 1;
-            this.deleteButton.Text = "&Delete";
+            this.deleteButton.Text = resources.GetString("this.deleteButton.Text");
             this.deleteButton.UseVisualStyleBackColor = true;
             this.deleteButton.Click += new System.EventHandler(this.deleteButton_Click);
             // 
@@ -115,7 +115,7 @@
             this.deleteWarningLabel.Name = "deleteWarningLabel";
             this.deleteWarningLabel.Size = new System.Drawing.Size(304, 15);
             this.deleteWarningLabel.TabIndex = 7;
-            this.deleteWarningLabel.Text = "Removing characters means losing all their data and plans!";
+            this.deleteWarningLabel.Text = resources.GetString("this.deleteWarningLabel.Text");
             // 
             // charactersListGroupBox
             // 
@@ -127,7 +127,7 @@
             this.charactersListGroupBox.Size = new System.Drawing.Size(495, 114);
             this.charactersListGroupBox.TabIndex = 8;
             this.charactersListGroupBox.TabStop = false;
-            this.charactersListGroupBox.Text = "Select the characters you want to remove";
+            this.charactersListGroupBox.Text = resources.GetString("this.charactersListGroupBox.Text");
             // 
             // EsiKeyDeletionWindow
             // 
@@ -144,7 +144,7 @@
             this.Controls.Add(this.cancelButton);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.Fixed3D;
             this.Name = "EsiKeyDeletionWindow";
-            this.Text = "Delete an ESI key";
+            this.Text = resources.GetString("this.Text");
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
             this.charactersListGroupBox.ResumeLayout(false);
             this.ResumeLayout(false);

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.resx
@@ -158,4 +158,22 @@
         JP41yQEi7v98+w927K1tbAtjLPB/l3OEO2LTS/UAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.deletionLabel.Text" xml:space="preserve">
+    <value>You are about to delete the ESI key with ID : {0}.</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="this.deleteButton.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="this.deleteWarningLabel.Text" xml:space="preserve">
+    <value>Removing characters means losing all their data and plans!</value>
+  </data>
+  <data name="this.charactersListGroupBox.Text" xml:space="preserve">
+    <value>Select the characters you want to remove</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Delete an ESI key</value>
+  </data>
 </root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.zh-CN.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyDeletionWindow.zh-CN.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.deletionLabel.Text" xml:space="preserve">
+    <value>您即将删除 ID 为：{0} 的 ESI 密钥。</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>取消(&amp;C)</value>
+  </data>
+  <data name="this.deleteButton.Text" xml:space="preserve">
+    <value>删除(&amp;D)</value>
+  </data>
+  <data name="this.deleteWarningLabel.Text" xml:space="preserve">
+    <value>删除角色意味着失去所有数据和计划！</value>
+  </data>
+  <data name="this.charactersListGroupBox.Text" xml:space="preserve">
+    <value>选择您要删除的字符</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>删除 ESI 密钥</value>
+  </data>
+</root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.Designer.cs
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.Designer.cs
@@ -111,7 +111,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.ButtonNext.Name = "ButtonNext";
 			this.ButtonNext.Size = new System.Drawing.Size(75, 23);
 			this.ButtonNext.TabIndex = 1;
-			this.ButtonNext.Text = "&Next >";
+			this.ButtonNext.Text = resources.GetString("this.ButtonNext.Text");
 			this.ButtonNext.UseVisualStyleBackColor = true;
 			this.ButtonNext.Click += new System.EventHandler(this.ButtonNext_Click);
 			// 
@@ -123,7 +123,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.ButtonPrevious.Name = "ButtonPrevious";
 			this.ButtonPrevious.Size = new System.Drawing.Size(75, 23);
 			this.ButtonPrevious.TabIndex = 0;
-			this.ButtonPrevious.Text = "< &Previous";
+			this.ButtonPrevious.Text = resources.GetString("this.ButtonPrevious.Text");
 			this.ButtonPrevious.UseVisualStyleBackColor = true;
 			this.ButtonPrevious.Click += new System.EventHandler(this.ButtonPrevious_Click);
 			// 
@@ -136,7 +136,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.ButtonCancel.Name = "ButtonCancel";
 			this.ButtonCancel.Size = new System.Drawing.Size(75, 23);
 			this.ButtonCancel.TabIndex = 2;
-			this.ButtonCancel.Text = "&Cancel";
+			this.ButtonCancel.Text = resources.GetString("this.ButtonCancel.Text");
 			this.ButtonCancel.UseVisualStyleBackColor = true;
 			this.ButtonCancel.Click += new System.EventHandler(this.ButtonCancel_Click);
 			// 
@@ -164,7 +164,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.CredentialsPage.Name = "CredentialsPage";
 			this.CredentialsPage.Size = new System.Drawing.Size(522, 171);
 			this.CredentialsPage.TabIndex = 0;
-			this.CredentialsPage.Text = "credentialsPage";
+			this.CredentialsPage.Text = resources.GetString("this.CredentialsPage.Text");
 			// 
 			// Throbber
 			// 
@@ -199,7 +199,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.ResultPage.Name = "ResultPage";
 			this.ResultPage.Size = new System.Drawing.Size(522, 171);
 			this.ResultPage.TabIndex = 2;
-			this.ResultPage.Text = "resultPage";
+			this.ResultPage.Text = resources.GetString("this.ResultPage.Text");
 			// 
 			// KeyTableLayoutPanel
 			// 
@@ -226,7 +226,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.KeyLabel.Name = "KeyLabel";
 			this.KeyLabel.Size = new System.Drawing.Size(452, 38);
 			this.KeyLabel.TabIndex = 1;
-			this.KeyLabel.Text = "Short description on info retrieval procedure.";
+			this.KeyLabel.Text = resources.GetString("this.KeyLabel.Text");
 			this.KeyLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
 			// 
 			// KeyPicture
@@ -247,7 +247,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.CharactersGroupBox.Size = new System.Drawing.Size(479, 118);
 			this.CharactersGroupBox.TabIndex = 3;
 			this.CharactersGroupBox.TabStop = false;
-			this.CharactersGroupBox.Text = "Characters exposed by API key";
+			this.CharactersGroupBox.Text = resources.GetString("this.CharactersGroupBox.Text");
 			// 
 			// ResultsMultiPanel
 			// 
@@ -274,7 +274,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.CharactersListPage.Name = "CharactersListPage";
 			this.CharactersListPage.Size = new System.Drawing.Size(473, 99);
 			this.CharactersListPage.TabIndex = 0;
-			this.CharactersListPage.Text = "charactersListPage";
+			this.CharactersListPage.Text = resources.GetString("this.CharactersListPage.Text");
 			// 
 			// CharactersListView
 			// 
@@ -315,7 +315,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.AuthenticationErrorPage.Name = "AuthenticationErrorPage";
 			this.AuthenticationErrorPage.Size = new System.Drawing.Size(473, 99);
 			this.AuthenticationErrorPage.TabIndex = 1;
-			this.AuthenticationErrorPage.Text = "authenticationErrorPage";
+			this.AuthenticationErrorPage.Text = resources.GetString("this.AuthenticationErrorPage.Text");
 			// 
 			// AuthenticationErrorGuideLabel
 			// 
@@ -336,7 +336,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.LoginDeniedErrorPage.Name = "LoginDeniedErrorPage";
 			this.LoginDeniedErrorPage.Size = new System.Drawing.Size(473, 99);
 			this.LoginDeniedErrorPage.TabIndex = 2;
-			this.LoginDeniedErrorPage.Text = "loginDeniedErrorPage";
+			this.LoginDeniedErrorPage.Text = resources.GetString("this.LoginDeniedErrorPage.Text");
 			// 
 			// LoginDeniedLinkLabel
 			// 
@@ -361,7 +361,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.GeneralErrorPage.Name = "GeneralErrorPage";
 			this.GeneralErrorPage.Size = new System.Drawing.Size(473, 99);
 			this.GeneralErrorPage.TabIndex = 3;
-			this.GeneralErrorPage.Text = "generalErrorPage";
+			this.GeneralErrorPage.Text = resources.GetString("this.GeneralErrorPage.Text");
 			// 
 			// GeneralErrorLabel
 			// 
@@ -405,7 +405,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.CachedWarningPage.Name = "CachedWarningPage";
 			this.CachedWarningPage.Size = new System.Drawing.Size(473, 98);
 			this.CachedWarningPage.TabIndex = 6;
-			this.CachedWarningPage.Text = "cachedWarningPage";
+			this.CachedWarningPage.Text = resources.GetString("this.CachedWarningPage.Text");
 			// 
 			// CachedWarningLabel
 			// 
@@ -430,7 +430,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.LabelShiftClick.Name = "LabelShiftClick";
 			this.LabelShiftClick.Size = new System.Drawing.Size(301, 13);
 			this.LabelShiftClick.TabIndex = 2;
-			this.LabelShiftClick.Text = "SHIFT+Click will copy ESI authentication URL to the clipboard";
+			this.LabelShiftClick.Text = resources.GetString("this.LabelShiftClick.Text");
 			this.LabelShiftClick.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
 			// EsiKeyUpdateOrAdditionWindow
@@ -449,7 +449,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.Name = "EsiKeyUpdateOrAdditionWindow";
-			this.Text = "ESI Key Import";
+			this.Text = resources.GetString("this.Text");
 			this.MultiPanel.ResumeLayout(false);
 			this.CredentialsPage.ResumeLayout(false);
 			this.CredentialsPage.PerformLayout();

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.resx
@@ -217,4 +217,46 @@ https://secure.eveonline.com/AccountManMenu.aspx
   <metadata name="errorProvider.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="this.ButtonNext.Text" xml:space="preserve">
+    <value>&amp;Next &gt;</value>
+  </data>
+  <data name="this.ButtonPrevious.Text" xml:space="preserve">
+    <value>&lt; &amp;Previous</value>
+  </data>
+  <data name="this.ButtonCancel.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="this.CredentialsPage.Text" xml:space="preserve">
+    <value>credentialsPage</value>
+  </data>
+  <data name="this.ResultPage.Text" xml:space="preserve">
+    <value>resultPage</value>
+  </data>
+  <data name="this.KeyLabel.Text" xml:space="preserve">
+    <value>Short description on info retrieval procedure.</value>
+  </data>
+  <data name="this.CharactersGroupBox.Text" xml:space="preserve">
+    <value>Characters exposed by API key</value>
+  </data>
+  <data name="this.CharactersListPage.Text" xml:space="preserve">
+    <value>charactersListPage</value>
+  </data>
+  <data name="this.AuthenticationErrorPage.Text" xml:space="preserve">
+    <value>authenticationErrorPage</value>
+  </data>
+  <data name="this.LoginDeniedErrorPage.Text" xml:space="preserve">
+    <value>loginDeniedErrorPage</value>
+  </data>
+  <data name="this.GeneralErrorPage.Text" xml:space="preserve">
+    <value>generalErrorPage</value>
+  </data>
+  <data name="this.CachedWarningPage.Text" xml:space="preserve">
+    <value>cachedWarningPage</value>
+  </data>
+  <data name="this.LabelShiftClick.Text" xml:space="preserve">
+    <value>SHIFT+Click will copy ESI authentication URL to the clipboard</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>ESI Key Import</value>
+  </data>
 </root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.zh-CN.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeyUpdateOrAdditionWindow.zh-CN.resx
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="AuthenticationErrorGuideLabel.Text" xml:space="preserve">
+    <value>您提供的 ID 或验证码（或两者）均错误。
+
+选择“上一步”按钮并重试，输入正确的凭据。
+
+如果这个账户是新创建的，你必须等待，至少一个小时，
+CCP 将其包含在 API 中。</value>
+  </data>
+  <data name="LoginDeniedLinkLabel.Text" xml:space="preserve">
+    <value>该 API 密钥所属账户的订阅已过期。
+
+如果 API 密钥属于您的帐户之一，请考虑在以下位置重新订阅：
+https://secure.eveonline.com/AccountManMenu.aspx
+</value>
+  </data>
+  <data name="this.ButtonNext.Text" xml:space="preserve">
+    <value>下一步&gt;</value>
+  </data>
+  <data name="this.ButtonPrevious.Text" xml:space="preserve">
+    <value>&lt;&amp;上一页</value>
+  </data>
+  <data name="this.ButtonCancel.Text" xml:space="preserve">
+    <value>取消(&amp;C)</value>
+  </data>
+  <data name="this.CredentialsPage.Text" xml:space="preserve">
+    <value>凭证页面</value>
+  </data>
+  <data name="this.ResultPage.Text" xml:space="preserve">
+    <value>结果页</value>
+  </data>
+  <data name="this.KeyLabel.Text" xml:space="preserve">
+    <value>关于信息检索过程的简短描述。</value>
+  </data>
+  <data name="this.CharactersGroupBox.Text" xml:space="preserve">
+    <value>API 密钥公开的字符</value>
+  </data>
+  <data name="this.CharactersListPage.Text" xml:space="preserve">
+    <value>字符列表页</value>
+  </data>
+  <data name="this.AuthenticationErrorPage.Text" xml:space="preserve">
+    <value>认证错误页面</value>
+  </data>
+  <data name="this.LoginDeniedErrorPage.Text" xml:space="preserve">
+    <value>登录被拒绝错误页面</value>
+  </data>
+  <data name="this.GeneralErrorPage.Text" xml:space="preserve">
+    <value>一般错误页面</value>
+  </data>
+  <data name="this.CachedWarningPage.Text" xml:space="preserve">
+    <value>缓存警告页面</value>
+  </data>
+  <data name="this.LabelShiftClick.Text" xml:space="preserve">
+    <value>SHIFT+单击会将 ESI 身份验证 URL 复制到剪贴板</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>ESI 密钥导入</value>
+  </data>
+</root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.Designer.cs
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.Designer.cs
@@ -97,7 +97,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.esiKeysLabel.Name = "esiKeysLabel";
 			this.esiKeysLabel.Size = new System.Drawing.Size(50, 13);
 			this.esiKeysLabel.TabIndex = 1;
-			this.esiKeysLabel.Text = "ESI Keys";
+			this.esiKeysLabel.Text = resources.GetString("this.esiKeysLabel.Text");
 			// 
 			// charactersLabel
 			// 
@@ -108,7 +108,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.charactersLabel.Name = "charactersLabel";
 			this.charactersLabel.Size = new System.Drawing.Size(58, 13);
 			this.charactersLabel.TabIndex = 5;
-			this.charactersLabel.Text = "Characters";
+			this.charactersLabel.Text = resources.GetString("this.charactersLabel.Text");
 			// 
 			// esiKeyListLabel
 			// 
@@ -118,7 +118,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.esiKeyListLabel.Name = "esiKeyListLabel";
 			this.esiKeyListLabel.Size = new System.Drawing.Size(796, 318);
 			this.esiKeyListLabel.TabIndex = 0;
-			this.esiKeyListLabel.Text = "First add your ESI key using the above buttons.";
+			this.esiKeyListLabel.Text = resources.GetString("this.esiKeyListLabel.Text");
 			this.esiKeyListLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
 			// charactersListLabel
@@ -141,7 +141,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.closeButton.Name = "closeButton";
 			this.closeButton.Size = new System.Drawing.Size(90, 23);
 			this.closeButton.TabIndex = 9;
-			this.closeButton.Text = "&Close";
+			this.closeButton.Text = resources.GetString("this.closeButton.Text");
 			this.closeButton.UseVisualStyleBackColor = true;
 			this.closeButton.Click += new System.EventHandler(this.closeButton_Click);
 			// 
@@ -167,7 +167,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.charactersTabPage.Padding = new System.Windows.Forms.Padding(3);
 			this.charactersTabPage.Size = new System.Drawing.Size(802, 362);
 			this.charactersTabPage.TabIndex = 1;
-			this.charactersTabPage.Text = "Characters";
+			this.charactersTabPage.Text = resources.GetString("this.charactersTabPage.Text");
 			this.charactersTabPage.UseVisualStyleBackColor = true;
 			// 
 			// charactersPagePanel
@@ -200,7 +200,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.charactersListPage.Name = "charactersListPage";
 			this.charactersListPage.Size = new System.Drawing.Size(796, 318);
 			this.charactersListPage.TabIndex = 0;
-			this.charactersListPage.Text = "charactersListPage";
+			this.charactersListPage.Text = resources.GetString("this.charactersListPage.Text");
 			// 
 			// charactersListView
 			// 
@@ -239,31 +239,31 @@ namespace EVEMon.ApiCredentialsManagement
 			// 
 			// columnType
 			// 
-			this.columnType.Text = "Type";
+			this.columnType.Text = resources.GetString("this.columnType.Text");
 			this.columnType.Width = 49;
 			// 
 			// columnID
 			// 
-			this.columnID.Text = "ID";
+			this.columnID.Text = resources.GetString("this.columnID.Text");
 			this.columnID.Width = 84;
 			// 
 			// columnName
 			// 
-			this.columnName.Text = "Name";
+			this.columnName.Text = resources.GetString("this.columnName.Text");
 			this.columnName.Width = 117;
 			// 
 			// columnESIKeyID
 			// 
-			this.columnESIKeyID.Text = "Key ID";
+			this.columnESIKeyID.Text = resources.GetString("this.columnESIKeyID.Text");
 			this.columnESIKeyID.Width = 75;
 			// 
 			// columnStatus
 			// 
-			this.columnStatus.Text = "Status";
+			this.columnStatus.Text = resources.GetString("this.columnStatus.Text");
 			// 
 			// columnUri
 			// 
-			this.columnUri.Text = "Uri";
+			this.columnUri.Text = resources.GetString("this.columnUri.Text");
 			this.columnUri.Width = 358;
 			// 
 			// noCharactersPage
@@ -274,7 +274,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.noCharactersPage.Name = "noCharactersPage";
 			this.noCharactersPage.Size = new System.Drawing.Size(796, 318);
 			this.noCharactersPage.TabIndex = 1;
-			this.noCharactersPage.Text = "noCharactersPage";
+			this.noCharactersPage.Text = resources.GetString("this.noCharactersPage.Text");
 			// 
 			// charactersToolStrip
 			// 
@@ -295,7 +295,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.importCharacterMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.importCharacterMenu.Name = "importCharacterMenu";
 			this.importCharacterMenu.Size = new System.Drawing.Size(72, 22);
-			this.importCharacterMenu.Text = "&Import...";
+			this.importCharacterMenu.Text = resources.GetString("this.importCharacterMenu.Text");
 			this.importCharacterMenu.Click += new System.EventHandler(this.importCharacterMenu_Click);
 			// 
 			// deleteCharacterMenu
@@ -305,7 +305,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.deleteCharacterMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.deleteCharacterMenu.Name = "deleteCharacterMenu";
 			this.deleteCharacterMenu.Size = new System.Drawing.Size(69, 22);
-			this.deleteCharacterMenu.Text = "&Delete...";
+			this.deleteCharacterMenu.Text = resources.GetString("this.deleteCharacterMenu.Text");
 			this.deleteCharacterMenu.Click += new System.EventHandler(this.deleteCharacterMenu_Click);
 			// 
 			// editUriMenu
@@ -315,7 +315,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.editUriMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.editUriMenu.Name = "editUriMenu";
 			this.editUriMenu.Size = new System.Drawing.Size(74, 22);
-			this.editUriMenu.Text = "&Edit Uri...";
+			this.editUriMenu.Text = resources.GetString("this.editUriMenu.Text");
 			this.editUriMenu.Click += new System.EventHandler(this.editUriButton_Click);
 			// 
 			// groupingMenu
@@ -328,7 +328,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.groupingMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.groupingMenu.Name = "groupingMenu";
 			this.groupingMenu.Size = new System.Drawing.Size(101, 22);
-			this.groupingMenu.Text = "&Group characters";
+			this.groupingMenu.Text = resources.GetString("this.groupingMenu.Text");
 			this.groupingMenu.Click += new System.EventHandler(this.groupingMenu_Click);
 			// 
 			// esiKeysTabPage
@@ -340,7 +340,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.esiKeysTabPage.Padding = new System.Windows.Forms.Padding(3);
 			this.esiKeysTabPage.Size = new System.Drawing.Size(802, 362);
 			this.esiKeysTabPage.TabIndex = 0;
-			this.esiKeysTabPage.Text = "ESI Keys";
+			this.esiKeysTabPage.Text = resources.GetString("this.esiKeysTabPage.Text");
 			this.esiKeysTabPage.UseVisualStyleBackColor = true;
 			// 
 			// esiKeysPagePanel
@@ -419,7 +419,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.addESIKeyMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.addESIKeyMenu.Name = "addESIKeyMenu";
 			this.addESIKeyMenu.Size = new System.Drawing.Size(58, 22);
-			this.addESIKeyMenu.Text = "&Add...";
+			this.addESIKeyMenu.Text = resources.GetString("this.addESIKeyMenu.Text");
 			this.addESIKeyMenu.Click += new System.EventHandler(this.addESIKeyMenu_Click);
 			// 
 			// deleteESIKeyMenu
@@ -429,7 +429,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.deleteESIKeyMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.deleteESIKeyMenu.Name = "deleteESIKeyMenu";
 			this.deleteESIKeyMenu.Size = new System.Drawing.Size(69, 22);
-			this.deleteESIKeyMenu.Text = "&Delete...";
+			this.deleteESIKeyMenu.Text = resources.GetString("this.deleteESIKeyMenu.Text");
 			this.deleteESIKeyMenu.Click += new System.EventHandler(this.deleteESIKeyMenu_Click);
 			// 
 			// editESIKeyMenu
@@ -439,7 +439,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.editESIKeyMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.editESIKeyMenu.Name = "editESIKeyMenu";
 			this.editESIKeyMenu.Size = new System.Drawing.Size(56, 22);
-			this.editESIKeyMenu.Text = "&Edit...";
+			this.editESIKeyMenu.Text = resources.GetString("this.editESIKeyMenu.Text");
 			this.editESIKeyMenu.Click += new System.EventHandler(this.editAPIKeyMenu_Click);
 			// 
 			// EsiKeysManagementWindow
@@ -455,7 +455,7 @@ namespace EVEMon.ApiCredentialsManagement
 			this.MaximizeBox = false;
 			this.MinimumSize = new System.Drawing.Size(600, 400);
 			this.Name = "EsiKeysManagementWindow";
-			this.Text = "ESI Keys Management";
+			this.Text = resources.GetString("this.Text");
 			this.tabControl.ResumeLayout(false);
 			this.charactersTabPage.ResumeLayout(false);
 			this.charactersTabPage.PerformLayout();

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.resx
@@ -223,4 +223,70 @@
         AUbTxDqT/06uZmVAIZy24gIw1/AAMchWTD8zMDAAABupFmmInoHqAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.esiKeysLabel.Text" xml:space="preserve">
+    <value>ESI Keys</value>
+  </data>
+  <data name="this.charactersLabel.Text" xml:space="preserve">
+    <value>Characters</value>
+  </data>
+  <data name="this.esiKeyListLabel.Text" xml:space="preserve">
+    <value>First add your ESI key using the above buttons.</value>
+  </data>
+  <data name="this.closeButton.Text" xml:space="preserve">
+    <value>&amp;Close</value>
+  </data>
+  <data name="this.charactersTabPage.Text" xml:space="preserve">
+    <value>Characters</value>
+  </data>
+  <data name="this.charactersListPage.Text" xml:space="preserve">
+    <value>charactersListPage</value>
+  </data>
+  <data name="this.columnType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="this.columnID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="this.columnName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="this.columnESIKeyID.Text" xml:space="preserve">
+    <value>Key ID</value>
+  </data>
+  <data name="this.columnStatus.Text" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="this.columnUri.Text" xml:space="preserve">
+    <value>Uri</value>
+  </data>
+  <data name="this.noCharactersPage.Text" xml:space="preserve">
+    <value>noCharactersPage</value>
+  </data>
+  <data name="this.importCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Import...</value>
+  </data>
+  <data name="this.deleteCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Delete...</value>
+  </data>
+  <data name="this.editUriMenu.Text" xml:space="preserve">
+    <value>&amp;Edit Uri...</value>
+  </data>
+  <data name="this.groupingMenu.Text" xml:space="preserve">
+    <value>&amp;Group characters</value>
+  </data>
+  <data name="this.esiKeysTabPage.Text" xml:space="preserve">
+    <value>ESI Keys</value>
+  </data>
+  <data name="this.addESIKeyMenu.Text" xml:space="preserve">
+    <value>&amp;Add...</value>
+  </data>
+  <data name="this.deleteESIKeyMenu.Text" xml:space="preserve">
+    <value>&amp;Delete...</value>
+  </data>
+  <data name="this.editESIKeyMenu.Text" xml:space="preserve">
+    <value>&amp;Edit...</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>ESI Keys Management</value>
+  </data>
 </root>

--- a/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.zh-CN.resx
+++ b/src/EVEMon/ApiCredentialsManagement/EsiKeysManagementWindow.zh-CN.resx
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.esiKeysLabel.Text" xml:space="preserve">
+    <value>ESI键</value>
+  </data>
+  <data name="this.charactersLabel.Text" xml:space="preserve">
+    <value>人物</value>
+  </data>
+  <data name="this.esiKeyListLabel.Text" xml:space="preserve">
+    <value>首先使用上述按钮添加您的 ESI 密钥。</value>
+  </data>
+  <data name="this.closeButton.Text" xml:space="preserve">
+    <value>关闭(&amp;C)</value>
+  </data>
+  <data name="this.charactersTabPage.Text" xml:space="preserve">
+    <value>人物</value>
+  </data>
+  <data name="this.charactersListPage.Text" xml:space="preserve">
+    <value>字符列表页</value>
+  </data>
+  <data name="this.columnType.Text" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="this.columnID.Text" xml:space="preserve">
+    <value>ID</value>
+  </data>
+  <data name="this.columnName.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="this.columnESIKeyID.Text" xml:space="preserve">
+    <value>钥匙编号</value>
+  </data>
+  <data name="this.columnStatus.Text" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="this.columnUri.Text" xml:space="preserve">
+    <value>乌里</value>
+  </data>
+  <data name="this.noCharactersPage.Text" xml:space="preserve">
+    <value>无字符页</value>
+  </data>
+  <data name="this.importCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Import...</value>
+  </data>
+  <data name="this.deleteCharacterMenu.Text" xml:space="preserve">
+    <value>删除(&amp;D)...</value>
+  </data>
+  <data name="this.editUriMenu.Text" xml:space="preserve">
+    <value>编辑 Uri(&amp;E)...</value>
+  </data>
+  <data name="this.groupingMenu.Text" xml:space="preserve">
+    <value>字符组(&amp;G)</value>
+  </data>
+  <data name="this.esiKeysTabPage.Text" xml:space="preserve">
+    <value>ESI键</value>
+  </data>
+  <data name="this.addESIKeyMenu.Text" xml:space="preserve">
+    <value>添加(&amp;A)...</value>
+  </data>
+  <data name="this.deleteESIKeyMenu.Text" xml:space="preserve">
+    <value>删除(&amp;D)...</value>
+  </data>
+  <data name="this.editESIKeyMenu.Text" xml:space="preserve">
+    <value>编辑(&amp;E)...</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>ESI 密钥管理</value>
+  </data>
+</root>

--- a/src/EVEMon/BlankCharacter/BlankCharacterControl.Designer.cs
+++ b/src/EVEMon/BlankCharacter/BlankCharacterControl.Designer.cs
@@ -139,7 +139,7 @@
             this.gbRace.Size = new System.Drawing.Size(470, 135);
             this.gbRace.TabIndex = 5;
             this.gbRace.TabStop = false;
-            this.gbRace.Text = "Race";
+            this.gbRace.Text = resources.GetString("this.gbRace.Text");
             // 
             // tlpRaces
             // 
@@ -264,7 +264,7 @@
             this.gbBloodline.Size = new System.Drawing.Size(148, 212);
             this.gbBloodline.TabIndex = 6;
             this.gbBloodline.TabStop = false;
-            this.gbBloodline.Text = "Bloodline";
+            this.gbBloodline.Text = resources.GetString("this.gbBloodline.Text");
             // 
             // tlpBloodline
             // 
@@ -372,7 +372,7 @@
             this.gbAncestry.Size = new System.Drawing.Size(166, 212);
             this.gbAncestry.TabIndex = 7;
             this.gbAncestry.TabStop = false;
-            this.gbAncestry.Text = "Ancestry";
+            this.gbAncestry.Text = resources.GetString("this.gbAncestry.Text");
             // 
             // tlpAncestry
             // 
@@ -412,7 +412,7 @@
             this.lblAncestry1.Name = "lblAncestry1";
             this.lblAncestry1.Size = new System.Drawing.Size(104, 18);
             this.lblAncestry1.TabIndex = 8;
-            this.lblAncestry1.Text = "Liberal Holders";
+            this.lblAncestry1.Text = resources.GetString("this.lblAncestry1.Text");
             this.lblAncestry1.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // rbAncestry2
@@ -477,7 +477,7 @@
             this.lblAncestry3.Name = "lblAncestry3";
             this.lblAncestry3.Size = new System.Drawing.Size(104, 19);
             this.lblAncestry3.TabIndex = 9;
-            this.lblAncestry3.Text = "Religious Reclaimers";
+            this.lblAncestry3.Text = resources.GetString("this.lblAncestry3.Text");
             this.lblAncestry3.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lblAncestry2
@@ -490,7 +490,7 @@
             this.lblAncestry2.Name = "lblAncestry2";
             this.lblAncestry2.Size = new System.Drawing.Size(104, 18);
             this.lblAncestry2.TabIndex = 7;
-            this.lblAncestry2.Text = "Weathy Commoners";
+            this.lblAncestry2.Text = resources.GetString("this.lblAncestry2.Text");
             this.lblAncestry2.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // pbAncestry2
@@ -562,7 +562,7 @@
             this.gbGender.Size = new System.Drawing.Size(146, 212);
             this.gbGender.TabIndex = 8;
             this.gbGender.TabStop = false;
-            this.gbGender.Text = "Gender";
+            this.gbGender.Text = resources.GetString("this.gbGender.Text");
             // 
             // gbCharacterName
             // 
@@ -573,7 +573,7 @@
             this.gbCharacterName.Size = new System.Drawing.Size(226, 46);
             this.gbCharacterName.TabIndex = 9;
             this.gbCharacterName.TabStop = false;
-            this.gbCharacterName.Text = "Blank Character Name";
+            this.gbCharacterName.Text = resources.GetString("this.gbCharacterName.Text");
             // 
             // ilBloodline
             // 
@@ -644,7 +644,7 @@
             this.lblFemale.Name = "lblFemale";
             this.lblFemale.Size = new System.Drawing.Size(85, 20);
             this.lblFemale.TabIndex = 4;
-            this.lblFemale.Text = "Female";
+            this.lblFemale.Text = resources.GetString("this.lblFemale.Text");
             this.lblFemale.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lblMale
@@ -655,7 +655,7 @@
             this.lblMale.Name = "lblMale";
             this.lblMale.Size = new System.Drawing.Size(85, 21);
             this.lblMale.TabIndex = 5;
-            this.lblMale.Text = "Male";
+            this.lblMale.Text = resources.GetString("this.lblMale.Text");
             this.lblMale.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // BlankCharacterControl

--- a/src/EVEMon/BlankCharacter/BlankCharacterControl.resx
+++ b/src/EVEMon/BlankCharacter/BlankCharacterControl.resx
@@ -2527,4 +2527,34 @@
         AeMF/wH8AQABHwT/Af4BAAE/Bv8Bzwz/AQBs/ws=
 </value>
   </data>
+  <data name="this.gbRace.Text" xml:space="preserve">
+    <value>Race</value>
+  </data>
+  <data name="this.gbBloodline.Text" xml:space="preserve">
+    <value>Bloodline</value>
+  </data>
+  <data name="this.gbAncestry.Text" xml:space="preserve">
+    <value>Ancestry</value>
+  </data>
+  <data name="this.lblAncestry1.Text" xml:space="preserve">
+    <value>Liberal Holders</value>
+  </data>
+  <data name="this.lblAncestry3.Text" xml:space="preserve">
+    <value>Religious Reclaimers</value>
+  </data>
+  <data name="this.lblAncestry2.Text" xml:space="preserve">
+    <value>Weathy Commoners</value>
+  </data>
+  <data name="this.gbGender.Text" xml:space="preserve">
+    <value>Gender</value>
+  </data>
+  <data name="this.gbCharacterName.Text" xml:space="preserve">
+    <value>Blank Character Name</value>
+  </data>
+  <data name="this.lblFemale.Text" xml:space="preserve">
+    <value>Female</value>
+  </data>
+  <data name="this.lblMale.Text" xml:space="preserve">
+    <value>Male</value>
+  </data>
 </root>

--- a/src/EVEMon/BlankCharacter/BlankCharacterControl.zh-CN.resx
+++ b/src/EVEMon/BlankCharacter/BlankCharacterControl.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.gbRace.Text" xml:space="preserve">
+    <value>竞赛</value>
+  </data>
+  <data name="this.gbBloodline.Text" xml:space="preserve">
+    <value>血统</value>
+  </data>
+  <data name="this.gbAncestry.Text" xml:space="preserve">
+    <value>祖先</value>
+  </data>
+  <data name="this.lblAncestry1.Text" xml:space="preserve">
+    <value>自由派持有者</value>
+  </data>
+  <data name="this.lblAncestry3.Text" xml:space="preserve">
+    <value>宗教回收者</value>
+  </data>
+  <data name="this.lblAncestry2.Text" xml:space="preserve">
+    <value>富裕的平民</value>
+  </data>
+  <data name="this.gbGender.Text" xml:space="preserve">
+    <value>性别</value>
+  </data>
+  <data name="this.gbCharacterName.Text" xml:space="preserve">
+    <value>空白角色名称</value>
+  </data>
+  <data name="this.lblFemale.Text" xml:space="preserve">
+    <value>女</value>
+  </data>
+  <data name="this.lblMale.Text" xml:space="preserve">
+    <value>男</value>
+  </data>
+</root>

--- a/src/EVEMon/BlankCharacter/BlankCharacterWindow.zh-CN.resx
+++ b/src/EVEMon/BlankCharacter/BlankCharacterWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterAssetsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterAssetsList.Designer.cs
@@ -61,7 +61,7 @@
             this.noAssetsLabel.Name = "noAssetsLabel";
             this.noAssetsLabel.Size = new System.Drawing.Size(472, 401);
             this.noAssetsLabel.TabIndex = 3;
-            this.noAssetsLabel.Text = "No assets are available.";
+            this.noAssetsLabel.Text = resources.GetString("this.noAssetsLabel.Text");
             this.noAssetsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lvAssets
@@ -87,27 +87,27 @@
             // 
             // chItem
             // 
-            this.chItem.Text = "Item";
+            this.chItem.Text = resources.GetString("this.chItem.Text");
             this.chItem.Width = 166;
             // 
             // chQuantity
             // 
-            this.chQuantity.Text = "Quantity";
+            this.chQuantity.Text = resources.GetString("this.chQuantity.Text");
             this.chQuantity.Width = 72;
             // 
             // chVolume
             // 
-            this.chVolume.Text = "Volume";
+            this.chVolume.Text = resources.GetString("this.chVolume.Text");
             this.chVolume.Width = 74;
             // 
             // chGroup
             // 
-            this.chGroup.Text = "Group";
+            this.chGroup.Text = resources.GetString("this.chGroup.Text");
             this.chGroup.Width = 80;
             // 
             // chCategory
             // 
-            this.chCategory.Text = "Category";
+            this.chCategory.Text = resources.GetString("this.chCategory.Text");
             // 
             // contextMenu
             // 
@@ -123,7 +123,7 @@
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export to CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons
@@ -144,7 +144,7 @@
             this.noPricesFoundLabel.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.noPricesFoundLabel.Size = new System.Drawing.Size(208, 13);
             this.noPricesFoundLabel.TabIndex = 1;
-            this.noPricesFoundLabel.Text = "* Prices for some items could not be found.";
+            this.noPricesFoundLabel.Text = resources.GetString("this.noPricesFoundLabel.Text");
             this.noPricesFoundLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // lblTotalCost
@@ -154,7 +154,7 @@
             this.lblTotalCost.Name = "lblTotalCost";
             this.lblTotalCost.Size = new System.Drawing.Size(207, 13);
             this.lblTotalCost.TabIndex = 0;
-            this.lblTotalCost.Text = "Estimated Cost of shown items: {0:N2} ISK";
+            this.lblTotalCost.Text = resources.GetString("this.lblTotalCost.Text");
             this.lblTotalCost.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // totalCostThrobber
@@ -204,7 +204,7 @@
             // 
             this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
             this.showInBrowserMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showInBrowserMenuItem.Text = "Show In Browser...";
+            this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
             this.showInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // CharacterAssetsList

--- a/src/EVEMon/CharacterMonitoring/CharacterAssetsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterAssetsList.resx
@@ -134,4 +134,34 @@
         AgAB/AE/AfgBHwL/AgAB/gF/AfABDwL/AgAG/wIABv8CAAb/AgAG/wIABv8CAAb/AgAL
 </value>
   </data>
+  <data name="this.noAssetsLabel.Text" xml:space="preserve">
+    <value>No assets are available.</value>
+  </data>
+  <data name="this.chItem.Text" xml:space="preserve">
+    <value>Item</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>Quantity</value>
+  </data>
+  <data name="this.chVolume.Text" xml:space="preserve">
+    <value>Volume</value>
+  </data>
+  <data name="this.chGroup.Text" xml:space="preserve">
+    <value>Group</value>
+  </data>
+  <data name="this.chCategory.Text" xml:space="preserve">
+    <value>Category</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export to CSV...</value>
+  </data>
+  <data name="this.noPricesFoundLabel.Text" xml:space="preserve">
+    <value>* Prices for some items could not be found.</value>
+  </data>
+  <data name="this.lblTotalCost.Text" xml:space="preserve">
+    <value>Estimated Cost of shown items: {0:N2} ISK</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterAssetsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterAssetsList.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noAssetsLabel.Text" xml:space="preserve">
+    <value>没有可用的资产。</value>
+  </data>
+  <data name="this.chItem.Text" xml:space="preserve">
+    <value>项目</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>数量</value>
+  </data>
+  <data name="this.chVolume.Text" xml:space="preserve">
+    <value>体积</value>
+  </data>
+  <data name="this.chGroup.Text" xml:space="preserve">
+    <value>集团</value>
+  </data>
+  <data name="this.chCategory.Text" xml:space="preserve">
+    <value>类别</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出为 CSV...</value>
+  </data>
+  <data name="this.noPricesFoundLabel.Text" xml:space="preserve">
+    <value>* 无法找到某些商品的价格。</value>
+  </data>
+  <data name="this.lblTotalCost.Text" xml:space="preserve">
+    <value>显示商品的预计费用：{0:N2} ISK</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterContactList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterContactList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterContractsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterContractsList.Designer.cs
@@ -57,7 +57,7 @@
             this.noContractsLabel.Name = "noContractsLabel";
             this.noContractsLabel.Size = new System.Drawing.Size(454, 434);
             this.noContractsLabel.TabIndex = 2;
-            this.noContractsLabel.Text = "No contracts are available.";
+            this.noContractsLabel.Text = resources.GetString("this.noContractsLabel.Text");
             this.noContractsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lvContracts
@@ -87,31 +87,31 @@
             // 
             // chContract
             // 
-            this.chContract.Text = "Contract";
+            this.chContract.Text = resources.GetString("this.chContract.Text");
             // 
             // chType
             // 
-            this.chType.Text = "Type";
+            this.chType.Text = resources.GetString("this.chType.Text");
             // 
             // chStatus
             // 
-            this.chStatus.Text = "Status";
+            this.chStatus.Text = resources.GetString("this.chStatus.Text");
             // 
             // chIssuer
             // 
-            this.chIssuer.Text = "From";
+            this.chIssuer.Text = resources.GetString("this.chIssuer.Text");
             // 
             // chAssignee
             // 
-            this.chAssignee.Text = "To";
+            this.chAssignee.Text = resources.GetString("this.chAssignee.Text");
             // 
             // chIssued
             // 
-            this.chIssued.Text = "Date Issued";
+            this.chIssued.Text = resources.GetString("this.chIssued.Text");
             // 
             // chRemainingTime
             // 
-            this.chRemainingTime.Text = "Time Left";
+            this.chRemainingTime.Text = resources.GetString("this.chRemainingTime.Text");
             // 
             // contextMenu
             // 
@@ -129,7 +129,7 @@
             // 
             this.showDetailsToolStripMenuItem.Name = "showDetailsToolStripMenuItem";
             this.showDetailsToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showDetailsToolStripMenuItem.Text = "Show Details...";
+            this.showDetailsToolStripMenuItem.Text = resources.GetString("this.showDetailsToolStripMenuItem.Text");
             this.showDetailsToolStripMenuItem.Click += new System.EventHandler(this.showDetailsToolStripMenuItem_Click);
             // 
             // showDetailsMenuSeparator
@@ -141,7 +141,7 @@
             // 
             this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
             this.showInBrowserMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showInBrowserMenuItem.Text = "Show In Browser...";
+            this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
             this.showInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showInBrowserMenuSeparator
@@ -153,7 +153,7 @@
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons

--- a/src/EVEMon/CharacterMonitoring/CharacterContractsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterContractsList.resx
@@ -134,4 +134,37 @@
         AgAB/AE/AfgBHwL/AgAB/gF/AfABDwL/AgAG/wIABv8CAAb/AgAG/wIABv8CAAb/AgAL
 </value>
   </data>
+  <data name="this.noContractsLabel.Text" xml:space="preserve">
+    <value>No contracts are available.</value>
+  </data>
+  <data name="this.chContract.Text" xml:space="preserve">
+    <value>Contract</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="this.chStatus.Text" xml:space="preserve">
+    <value>Status</value>
+  </data>
+  <data name="this.chIssuer.Text" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="this.chAssignee.Text" xml:space="preserve">
+    <value>To</value>
+  </data>
+  <data name="this.chIssued.Text" xml:space="preserve">
+    <value>Date Issued</value>
+  </data>
+  <data name="this.chRemainingTime.Text" xml:space="preserve">
+    <value>Time Left</value>
+  </data>
+  <data name="this.showDetailsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Show Details...</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterContractsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterContractsList.zh-CN.resx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noContractsLabel.Text" xml:space="preserve">
+    <value>没有可用的合同。</value>
+  </data>
+  <data name="this.chContract.Text" xml:space="preserve">
+    <value>合同</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="this.chStatus.Text" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="this.chIssuer.Text" xml:space="preserve">
+    <value>来自</value>
+  </data>
+  <data name="this.chAssignee.Text" xml:space="preserve">
+    <value>至</value>
+  </data>
+  <data name="this.chIssued.Text" xml:space="preserve">
+    <value>发行日期</value>
+  </data>
+  <data name="this.chRemainingTime.Text" xml:space="preserve">
+    <value>剩余时间</value>
+  </data>
+  <data name="this.showDetailsToolStripMenuItem.Text" xml:space="preserve">
+    <value>显示详细信息...</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterEmploymentHistoryList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterEmploymentHistoryList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.Designer.cs
@@ -71,7 +71,7 @@ namespace EVEMon.CharacterMonitoring
 			this.noEVEMailMessagesLabel.Name = "noEVEMailMessagesLabel";
 			this.noEVEMailMessagesLabel.Size = new System.Drawing.Size(454, 434);
 			this.noEVEMailMessagesLabel.TabIndex = 1;
-			this.noEVEMailMessagesLabel.Text = "No EVE mail messages are available.";
+			this.noEVEMailMessagesLabel.Text = resources.GetString("this.noEVEMailMessagesLabel.Text");
 			this.noEVEMailMessagesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
 			// contextMenu
@@ -88,7 +88,7 @@ namespace EVEMon.CharacterMonitoring
 			// 
 			this.mailReadLocal.Name = "mailReadLocal";
 			this.mailReadLocal.Size = new System.Drawing.Size(156, 22);
-			this.mailReadLocal.Text = "Read";
+			this.mailReadLocal.Text = resources.GetString("this.mailReadLocal.Text");
 			this.mailReadLocal.Click += new System.EventHandler(this.mailReadLocal_Click);
 			// 
 			// toolStripSeparator
@@ -100,7 +100,7 @@ namespace EVEMon.CharacterMonitoring
 			// 
 			this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
 			this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-			this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+			this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
 			this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
 			// 
 			// splitContainerMailMessages
@@ -153,29 +153,29 @@ namespace EVEMon.CharacterMonitoring
 			// 
 			// chSenderName
 			// 
-			this.chSenderName.Text = "From";
+			this.chSenderName.Text = resources.GetString("this.chSenderName.Text");
 			// 
 			// chTitle
 			// 
-			this.chTitle.Text = "Subject";
+			this.chTitle.Text = resources.GetString("this.chTitle.Text");
 			this.chTitle.Width = 121;
 			// 
 			// chSentDate
 			// 
-			this.chSentDate.Text = "Received";
+			this.chSentDate.Text = resources.GetString("this.chSentDate.Text");
 			this.chSentDate.Width = 90;
 			// 
 			// chToCharacterIDs
 			// 
-			this.chToCharacterIDs.Text = "To";
+			this.chToCharacterIDs.Text = resources.GetString("this.chToCharacterIDs.Text");
 			// 
 			// chToCorpOrAlliance
 			// 
-			this.chToCorpOrAlliance.Text = "To Corp Or Alliance";
+			this.chToCorpOrAlliance.Text = resources.GetString("this.chToCorpOrAlliance.Text");
 			// 
 			// chToListID
 			// 
-			this.chToListID.Text = "To Mailing List";
+			this.chToListID.Text = resources.GetString("this.chToListID.Text");
 			// 
 			// eveMailReadingPane
 			// 

--- a/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.resx
@@ -137,4 +137,31 @@
   <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>103, 17</value>
   </metadata>
+  <data name="this.noEVEMailMessagesLabel.Text" xml:space="preserve">
+    <value>No EVE mail messages are available.</value>
+  </data>
+  <data name="this.mailReadLocal.Text" xml:space="preserve">
+    <value>Read</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.chSenderName.Text" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="this.chTitle.Text" xml:space="preserve">
+    <value>Subject</value>
+  </data>
+  <data name="this.chSentDate.Text" xml:space="preserve">
+    <value>Received</value>
+  </data>
+  <data name="this.chToCharacterIDs.Text" xml:space="preserve">
+    <value>To</value>
+  </data>
+  <data name="this.chToCorpOrAlliance.Text" xml:space="preserve">
+    <value>To Corp Or Alliance</value>
+  </data>
+  <data name="this.chToListID.Text" xml:space="preserve">
+    <value>To Mailing List</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveMailMessagesList.zh-CN.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noEVEMailMessagesLabel.Text" xml:space="preserve">
+    <value>没有可用的 EVE 邮件消息。</value>
+  </data>
+  <data name="this.mailReadLocal.Text" xml:space="preserve">
+    <value>阅读</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.chSenderName.Text" xml:space="preserve">
+    <value>来自</value>
+  </data>
+  <data name="this.chTitle.Text" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="this.chSentDate.Text" xml:space="preserve">
+    <value>已收到</value>
+  </data>
+  <data name="this.chToCharacterIDs.Text" xml:space="preserve">
+    <value>至</value>
+  </data>
+  <data name="this.chToCorpOrAlliance.Text" xml:space="preserve">
+    <value>致公司或联盟</value>
+  </data>
+  <data name="this.chToListID.Text" xml:space="preserve">
+    <value>到邮件列表</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.Designer.cs
@@ -97,16 +97,16 @@ namespace EVEMon.CharacterMonitoring
             // 
             // chSenderName
             // 
-            this.chSenderName.Text = "From";
+            this.chSenderName.Text = resources.GetString("this.chSenderName.Text");
             // 
             // chType
             // 
-            this.chType.Text = "Subject";
+            this.chType.Text = resources.GetString("this.chType.Text");
             this.chType.Width = 121;
             // 
             // chSentDate
             // 
-            this.chSentDate.Text = "Received";
+            this.chSentDate.Text = resources.GetString("this.chSentDate.Text");
             this.chSentDate.Width = 90;
             // 
             // contextMenu
@@ -120,7 +120,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons
@@ -147,7 +147,7 @@ namespace EVEMon.CharacterMonitoring
             this.noEVENotificationsLabel.Name = "noEVENotificationsLabel";
             this.noEVENotificationsLabel.Size = new System.Drawing.Size(454, 434);
             this.noEVENotificationsLabel.TabIndex = 4;
-            this.noEVENotificationsLabel.Text = "No EVE notifications are available.";
+            this.noEVENotificationsLabel.Text = resources.GetString("this.noEVENotificationsLabel.Text");
             this.noEVENotificationsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // timer

--- a/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.resx
@@ -137,4 +137,19 @@
   <metadata name="timer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>98, 17</value>
   </metadata>
+  <data name="this.chSenderName.Text" xml:space="preserve">
+    <value>From</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>Subject</value>
+  </data>
+  <data name="this.chSentDate.Text" xml:space="preserve">
+    <value>Received</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.noEVENotificationsLabel.Text" xml:space="preserve">
+    <value>No EVE notifications are available.</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterEveNotificationsList.zh-CN.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.chSenderName.Text" xml:space="preserve">
+    <value>来自</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>主题</value>
+  </data>
+  <data name="this.chSentDate.Text" xml:space="preserve">
+    <value>已收到</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.noEVENotificationsLabel.Text" xml:space="preserve">
+    <value>没有可用的 EVE 通知。</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.Designer.cs
@@ -100,7 +100,7 @@
             this.noFactionalWarfareLabel.Name = "noFactionalWarfareLabel";
             this.noFactionalWarfareLabel.Size = new System.Drawing.Size(409, 607);
             this.noFactionalWarfareLabel.TabIndex = 3;
-            this.noFactionalWarfareLabel.Text = "Factional Warfare information not available.";
+            this.noFactionalWarfareLabel.Text = resources.GetString("this.noFactionalWarfareLabel.Text");
             this.noFactionalWarfareLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // notEnlistedLabel
@@ -112,7 +112,7 @@
             this.notEnlistedLabel.Name = "notEnlistedLabel";
             this.notEnlistedLabel.Size = new System.Drawing.Size(409, 607);
             this.notEnlistedLabel.TabIndex = 4;
-            this.notEnlistedLabel.Text = "Character not enlisted in Factional Warfare.";
+            this.notEnlistedLabel.Text = resources.GetString("this.notEnlistedLabel.Text");
             this.notEnlistedLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // ListPanel
@@ -188,17 +188,17 @@
             // 
             // chDescription
             // 
-            this.chDescription.Text = "Personal";
+            this.chDescription.Text = resources.GetString("this.chDescription.Text");
             this.chDescription.Width = 101;
             // 
             // chYou
             // 
-            this.chYou.Text = "You";
+            this.chYou.Text = resources.GetString("this.chYou.Text");
             this.chYou.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // chAll
             // 
-            this.chAll.Text = "All";
+            this.chAll.Text = resources.GetString("this.chAll.Text");
             this.chAll.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // lvMilitia
@@ -252,27 +252,27 @@
             // 
             // chMilitia
             // 
-            this.chMilitia.Text = "Militia";
+            this.chMilitia.Text = resources.GetString("this.chMilitia.Text");
             this.chMilitia.Width = 101;
             // 
             // chAmarr
             // 
-            this.chAmarr.Text = "Amarr";
+            this.chAmarr.Text = resources.GetString("this.chAmarr.Text");
             this.chAmarr.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // chCaldari
             // 
-            this.chCaldari.Text = "Caldari";
+            this.chCaldari.Text = resources.GetString("this.chCaldari.Text");
             this.chCaldari.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // chGallente
             // 
-            this.chGallente.Text = "Gallente";
+            this.chGallente.Text = resources.GetString("this.chGallente.Text");
             this.chGallente.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // chMinmatar
             // 
-            this.chMinmatar.Text = "Minmatar";
+            this.chMinmatar.Text = resources.GetString("this.chMinmatar.Text");
             this.chMinmatar.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // HeaderTableLayoutPanel
@@ -407,7 +407,7 @@
             this.RankLabel.Name = "RankLabel";
             this.RankLabel.Size = new System.Drawing.Size(36, 13);
             this.RankLabel.TabIndex = 3;
-            this.RankLabel.Text = "Rank:";
+            this.RankLabel.Text = resources.GetString("this.RankLabel.Text");
             this.RankLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // TimeServedLabel
@@ -417,7 +417,7 @@
             this.TimeServedLabel.Name = "TimeServedLabel";
             this.TimeServedLabel.Size = new System.Drawing.Size(68, 13);
             this.TimeServedLabel.TabIndex = 4;
-            this.TimeServedLabel.Text = "Time served:";
+            this.TimeServedLabel.Text = resources.GetString("this.TimeServedLabel.Text");
             this.TimeServedLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // FactionLabel
@@ -429,7 +429,7 @@
             this.FactionLabel.Name = "FactionLabel";
             this.FactionLabel.Size = new System.Drawing.Size(45, 13);
             this.FactionLabel.TabIndex = 10;
-            this.FactionLabel.Text = "Faction:";
+            this.FactionLabel.Text = resources.GetString("this.FactionLabel.Text");
             this.FactionLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // CorporationLabel
@@ -440,7 +440,7 @@
             this.CorporationLabel.Name = "CorporationLabel";
             this.CorporationLabel.Size = new System.Drawing.Size(64, 13);
             this.CorporationLabel.TabIndex = 11;
-            this.CorporationLabel.Text = "Corporation:";
+            this.CorporationLabel.Text = resources.GetString("this.CorporationLabel.Text");
             // 
             // CharacterFactionalWarfareStatsList
             // 

--- a/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.resx
@@ -523,4 +523,46 @@
         VmgAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.noFactionalWarfareLabel.Text" xml:space="preserve">
+    <value>Factional Warfare information not available.</value>
+  </data>
+  <data name="this.notEnlistedLabel.Text" xml:space="preserve">
+    <value>Character not enlisted in Factional Warfare.</value>
+  </data>
+  <data name="this.chDescription.Text" xml:space="preserve">
+    <value>Personal</value>
+  </data>
+  <data name="this.chYou.Text" xml:space="preserve">
+    <value>You</value>
+  </data>
+  <data name="this.chAll.Text" xml:space="preserve">
+    <value>All</value>
+  </data>
+  <data name="this.chMilitia.Text" xml:space="preserve">
+    <value>Militia</value>
+  </data>
+  <data name="this.chAmarr.Text" xml:space="preserve">
+    <value>Amarr</value>
+  </data>
+  <data name="this.chCaldari.Text" xml:space="preserve">
+    <value>Caldari</value>
+  </data>
+  <data name="this.chGallente.Text" xml:space="preserve">
+    <value>Gallente</value>
+  </data>
+  <data name="this.chMinmatar.Text" xml:space="preserve">
+    <value>Minmatar</value>
+  </data>
+  <data name="this.RankLabel.Text" xml:space="preserve">
+    <value>Rank:</value>
+  </data>
+  <data name="this.TimeServedLabel.Text" xml:space="preserve">
+    <value>Time served:</value>
+  </data>
+  <data name="this.FactionLabel.Text" xml:space="preserve">
+    <value>Faction:</value>
+  </data>
+  <data name="this.CorporationLabel.Text" xml:space="preserve">
+    <value>Corporation:</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterFactionalWarfareStatsList.zh-CN.resx
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noFactionalWarfareLabel.Text" xml:space="preserve">
+    <value>派系战争信息不可用。</value>
+  </data>
+  <data name="this.notEnlistedLabel.Text" xml:space="preserve">
+    <value>角色未加入派系战争。</value>
+  </data>
+  <data name="this.chDescription.Text" xml:space="preserve">
+    <value>个人</value>
+  </data>
+  <data name="this.chYou.Text" xml:space="preserve">
+    <value>你</value>
+  </data>
+  <data name="this.chAll.Text" xml:space="preserve">
+    <value>全部</value>
+  </data>
+  <data name="this.chMilitia.Text" xml:space="preserve">
+    <value>民兵</value>
+  </data>
+  <data name="this.chAmarr.Text" xml:space="preserve">
+    <value>艾玛</value>
+  </data>
+  <data name="this.chCaldari.Text" xml:space="preserve">
+    <value>加达里</value>
+  </data>
+  <data name="this.chGallente.Text" xml:space="preserve">
+    <value>盖伦特</value>
+  </data>
+  <data name="this.chMinmatar.Text" xml:space="preserve">
+    <value>米玛塔尔</value>
+  </data>
+  <data name="this.RankLabel.Text" xml:space="preserve">
+    <value>排名：</value>
+  </data>
+  <data name="this.TimeServedLabel.Text" xml:space="preserve">
+    <value>任职时间：</value>
+  </data>
+  <data name="this.FactionLabel.Text" xml:space="preserve">
+    <value>派系：</value>
+  </data>
+  <data name="this.CorporationLabel.Text" xml:space="preserve">
+    <value>公司：</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.Designer.cs
@@ -71,19 +71,19 @@ namespace EVEMon.CharacterMonitoring
             // 
             // chState
             // 
-            this.chState.Text = "State";
+            this.chState.Text = resources.GetString("this.chState.Text");
             // 
             // chTTC
             // 
-            this.chTTC.Text = "TTC";
+            this.chTTC.Text = resources.GetString("this.chTTC.Text");
             // 
             // chInstalledItem
             // 
-            this.chInstalledItem.Text = "Installed Item";
+            this.chInstalledItem.Text = resources.GetString("this.chInstalledItem.Text");
             // 
             // chOutputItem
             // 
-            this.chOutputItem.Text = "Output Item";
+            this.chOutputItem.Text = resources.GetString("this.chOutputItem.Text");
             // 
             // contextMenu
             // 
@@ -100,14 +100,14 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.showInstalledInBrowserMenuItem.Name = "showInstalledInBrowserMenuItem";
             this.showInstalledInBrowserMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.showInstalledInBrowserMenuItem.Text = "Show Input In Blueprint Browser...";
+            this.showInstalledInBrowserMenuItem.Text = resources.GetString("this.showInstalledInBrowserMenuItem.Text");
             this.showInstalledInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showProducedInBrowserMenuItem
             // 
             this.showProducedInBrowserMenuItem.Name = "showProducedInBrowserMenuItem";
             this.showProducedInBrowserMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.showProducedInBrowserMenuItem.Text = "Show Output In Browser...";
+            this.showProducedInBrowserMenuItem.Text = resources.GetString("this.showProducedInBrowserMenuItem.Text");
             this.showProducedInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showInBrowserMenuSeparator
@@ -119,7 +119,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(217, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons
@@ -138,7 +138,7 @@ namespace EVEMon.CharacterMonitoring
             this.noJobsLabel.Name = "noJobsLabel";
             this.noJobsLabel.Size = new System.Drawing.Size(454, 434);
             this.noJobsLabel.TabIndex = 2;
-            this.noJobsLabel.Text = "No industry jobs are available.";
+            this.noJobsLabel.Text = resources.GetString("this.noJobsLabel.Text");
             this.noJobsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // industryExpPanelControl
@@ -150,7 +150,7 @@ namespace EVEMon.CharacterMonitoring
             this.industryExpPanelControl.ExpandedHeight = 100;
             this.industryExpPanelControl.ExpandedOnStartup = false;
             this.industryExpPanelControl.HeaderHeight = 30;
-            this.industryExpPanelControl.HeaderText = "Header Text";
+            this.industryExpPanelControl.HeaderText = resources.GetString("this.industryExpPanelControl.HeaderText");
             this.industryExpPanelControl.ImageCollapse = ((System.Drawing.Bitmap)(resources.GetObject("industryExpPanelControl.ImageCollapse")));
             this.industryExpPanelControl.ImageExpand = ((System.Drawing.Bitmap)(resources.GetObject("industryExpPanelControl.ImageExpand")));
             this.industryExpPanelControl.Location = new System.Drawing.Point(0, 334);

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.resx
@@ -151,4 +151,31 @@
         AAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.chState.Text" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="this.chTTC.Text" xml:space="preserve">
+    <value>TTC</value>
+  </data>
+  <data name="this.chInstalledItem.Text" xml:space="preserve">
+    <value>Installed Item</value>
+  </data>
+  <data name="this.chOutputItem.Text" xml:space="preserve">
+    <value>Output Item</value>
+  </data>
+  <data name="this.showInstalledInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show Input In Blueprint Browser...</value>
+  </data>
+  <data name="this.showProducedInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show Output In Browser...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.noJobsLabel.Text" xml:space="preserve">
+    <value>No industry jobs are available.</value>
+  </data>
+  <data name="this.industryExpPanelControl.HeaderText" xml:space="preserve">
+    <value>Header Text</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterIndustryJobsList.zh-CN.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.chState.Text" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="this.chTTC.Text" xml:space="preserve">
+    <value>TTC</value>
+  </data>
+  <data name="this.chInstalledItem.Text" xml:space="preserve">
+    <value>已安装项目</value>
+  </data>
+  <data name="this.chOutputItem.Text" xml:space="preserve">
+    <value>输出项目</value>
+  </data>
+  <data name="this.showInstalledInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在蓝图浏览器中显示输入...</value>
+  </data>
+  <data name="this.showProducedInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示输出...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.noJobsLabel.Text" xml:space="preserve">
+    <value>没有可用的行业职位。</value>
+  </data>
+  <data name="this.industryExpPanelControl.HeaderText" xml:space="preserve">
+    <value>标题文本</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterKillLogList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterKillLogList.Designer.cs
@@ -60,7 +60,7 @@
             this.noKillLogLabel.Name = "noKillLogLabel";
             this.noKillLogLabel.Size = new System.Drawing.Size(324, 382);
             this.noKillLogLabel.TabIndex = 5;
-            this.noKillLogLabel.Text = "Combat log information not available.";
+            this.noKillLogLabel.Text = resources.GetString("this.noKillLogLabel.Text");
             this.noKillLogLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lvKillLog
@@ -91,30 +91,30 @@
             // 
             // chDate
             // 
-            this.chDate.Text = "Date";
+            this.chDate.Text = resources.GetString("this.chDate.Text");
             this.chDate.Width = 106;
             // 
             // chType
             // 
-            this.chType.Text = "Type";
+            this.chType.Text = resources.GetString("this.chType.Text");
             this.chType.Width = 100;
             // 
             // chName
             // 
-            this.chName.Text = "Name";
+            this.chName.Text = resources.GetString("this.chName.Text");
             this.chName.Width = 99;
             // 
             // chCorporation
             // 
-            this.chCorporation.Text = "Corporation";
+            this.chCorporation.Text = resources.GetString("this.chCorporation.Text");
             // 
             // chAlliance
             // 
-            this.chAlliance.Text = "Alliance";
+            this.chAlliance.Text = resources.GetString("this.chAlliance.Text");
             // 
             // chFaction
             // 
-            this.chFaction.Text = "Faction";
+            this.chFaction.Text = resources.GetString("this.chFaction.Text");
             // 
             // contextMenuStrip
             // 
@@ -133,7 +133,7 @@
             this.showDetailsMenuItem.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
             this.showDetailsMenuItem.Name = "showDetailsMenuItem";
             this.showDetailsMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.showDetailsMenuItem.Text = "Show Details...";
+            this.showDetailsMenuItem.Text = resources.GetString("this.showDetailsMenuItem.Text");
             this.showDetailsMenuItem.Click += new System.EventHandler(this.showDetailsMenuItem_Click);
             // 
             // showDetailsMenuSeparator
@@ -145,7 +145,7 @@
             // 
             this.showInShipBrowserMenuItem.Name = "showInShipBrowserMenuItem";
             this.showInShipBrowserMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.showInShipBrowserMenuItem.Text = "Show In Ship Browser...";
+            this.showInShipBrowserMenuItem.Text = resources.GetString("this.showInShipBrowserMenuItem.Text");
             this.showInShipBrowserMenuItem.Click += new System.EventHandler(this.showInShipBrowserMenuItem_Click);
             // 
             // showInBrowserMenuSeparator
@@ -157,7 +157,7 @@
             // 
             this.copyKillInfoMenuItem.Name = "copyKillInfoMenuItem";
             this.copyKillInfoMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.copyKillInfoMenuItem.Text = "Copy Kill Info to Clipboard";
+            this.copyKillInfoMenuItem.Text = resources.GetString("this.copyKillInfoMenuItem.Text");
             this.copyKillInfoMenuItem.Click += new System.EventHandler(this.copyKillInfoMenuItem_Click);
             // 
             // ilIcons

--- a/src/EVEMon/CharacterMonitoring/CharacterKillLogList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterKillLogList.resx
@@ -137,4 +137,34 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>252, 17</value>
   </metadata>
+  <data name="this.noKillLogLabel.Text" xml:space="preserve">
+    <value>Combat log information not available.</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="this.chCorporation.Text" xml:space="preserve">
+    <value>Corporation</value>
+  </data>
+  <data name="this.chAlliance.Text" xml:space="preserve">
+    <value>Alliance</value>
+  </data>
+  <data name="this.chFaction.Text" xml:space="preserve">
+    <value>Faction</value>
+  </data>
+  <data name="this.showDetailsMenuItem.Text" xml:space="preserve">
+    <value>Show Details...</value>
+  </data>
+  <data name="this.showInShipBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Ship Browser...</value>
+  </data>
+  <data name="this.copyKillInfoMenuItem.Text" xml:space="preserve">
+    <value>Copy Kill Info to Clipboard</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterKillLogList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterKillLogList.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noKillLogLabel.Text" xml:space="preserve">
+    <value>战斗日志信息不可用。</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="this.chCorporation.Text" xml:space="preserve">
+    <value>法人</value>
+  </data>
+  <data name="this.chAlliance.Text" xml:space="preserve">
+    <value>联盟</value>
+  </data>
+  <data name="this.chFaction.Text" xml:space="preserve">
+    <value>派系</value>
+  </data>
+  <data name="this.showDetailsMenuItem.Text" xml:space="preserve">
+    <value>显示详细信息...</value>
+  </data>
+  <data name="this.showInShipBrowserMenuItem.Text" xml:space="preserve">
+    <value>在船舶浏览器中显示...</value>
+  </data>
+  <data name="this.copyKillInfoMenuItem.Text" xml:space="preserve">
+    <value>将杀死信息复制到剪贴板</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterLoyaltyList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.Designer.cs
@@ -79,22 +79,22 @@ namespace EVEMon.CharacterMonitoring
             // 
             // itemColumn
             // 
-            this.itemColumn.Text = "Item";
+            this.itemColumn.Text = resources.GetString("this.itemColumn.Text");
             this.itemColumn.Width = 192;
             // 
             // locationColumn
             // 
-            this.locationColumn.Text = "System";
+            this.locationColumn.Text = resources.GetString("this.locationColumn.Text");
             this.locationColumn.Width = 80;
             // 
             // unitaryPriceColumn
             // 
-            this.unitaryPriceColumn.Text = "Unit Price";
+            this.unitaryPriceColumn.Text = resources.GetString("this.unitaryPriceColumn.Text");
             this.unitaryPriceColumn.Width = 92;
             // 
             // quantityColumn
             // 
-            this.quantityColumn.Text = "Quantity";
+            this.quantityColumn.Text = resources.GetString("this.quantityColumn.Text");
             this.quantityColumn.Width = 88;
             // 
             // contextMenu
@@ -111,7 +111,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
             this.showInBrowserMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showInBrowserMenuItem.Text = "Show In Browser...";
+            this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
             this.showInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showInBrowserMenuSeparator
@@ -123,7 +123,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV ...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons
@@ -142,7 +142,7 @@ namespace EVEMon.CharacterMonitoring
             this.noOrdersLabel.Name = "noOrdersLabel";
             this.noOrdersLabel.Size = new System.Drawing.Size(454, 434);
             this.noOrdersLabel.TabIndex = 1;
-            this.noOrdersLabel.Text = "No market orders are available.";
+            this.noOrdersLabel.Text = resources.GetString("this.noOrdersLabel.Text");
             this.noOrdersLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // marketExpPanelControl
@@ -154,7 +154,7 @@ namespace EVEMon.CharacterMonitoring
             this.marketExpPanelControl.ExpandedHeight = 100;
             this.marketExpPanelControl.ExpandedOnStartup = false;
             this.marketExpPanelControl.HeaderHeight = 30;
-            this.marketExpPanelControl.HeaderText = "Header Text";
+            this.marketExpPanelControl.HeaderText = resources.GetString("this.marketExpPanelControl.HeaderText");
             this.marketExpPanelControl.ImageCollapse = ((System.Drawing.Bitmap)(resources.GetObject("marketExpPanelControl.ImageCollapse")));
             this.marketExpPanelControl.ImageExpand = ((System.Drawing.Bitmap)(resources.GetObject("marketExpPanelControl.ImageExpand")));
             this.marketExpPanelControl.Location = new System.Drawing.Point(0, 334);

--- a/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.resx
@@ -151,4 +151,28 @@
         AAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.itemColumn.Text" xml:space="preserve">
+    <value>Item</value>
+  </data>
+  <data name="this.locationColumn.Text" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="this.unitaryPriceColumn.Text" xml:space="preserve">
+    <value>Unit Price</value>
+  </data>
+  <data name="this.quantityColumn.Text" xml:space="preserve">
+    <value>Quantity</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV ...</value>
+  </data>
+  <data name="this.noOrdersLabel.Text" xml:space="preserve">
+    <value>No market orders are available.</value>
+  </data>
+  <data name="this.marketExpPanelControl.HeaderText" xml:space="preserve">
+    <value>Header Text</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMarketOrdersList.zh-CN.resx
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.itemColumn.Text" xml:space="preserve">
+    <value>项目</value>
+  </data>
+  <data name="this.locationColumn.Text" xml:space="preserve">
+    <value>系统</value>
+  </data>
+  <data name="this.unitaryPriceColumn.Text" xml:space="preserve">
+    <value>单价</value>
+  </data>
+  <data name="this.quantityColumn.Text" xml:space="preserve">
+    <value>数量</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出到 CSV...</value>
+  </data>
+  <data name="this.noOrdersLabel.Text" xml:space="preserve">
+    <value>没有可用的市价订单。</value>
+  </data>
+  <data name="this.marketExpPanelControl.HeaderText" xml:space="preserve">
+    <value>标题文本</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMedalsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMedalsList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitor.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitor.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.Designer.cs
@@ -221,22 +221,22 @@ namespace EVEMon.CharacterMonitoring
             this.preferencesMenu.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.preferencesMenu.RightToLeft = System.Windows.Forms.RightToLeft.No;
             this.preferencesMenu.Size = new System.Drawing.Size(29, 22);
-            this.preferencesMenu.Text = "Preferences";
-            this.preferencesMenu.ToolTipText = "Preferences";
+            this.preferencesMenu.Text = resources.GetString("this.preferencesMenu.Text");
+            this.preferencesMenu.ToolTipText = resources.GetString("this.preferencesMenu.ToolTipText");
             this.preferencesMenu.DropDownOpening += new System.EventHandler(this.preferencesMenu_DropDownOpening);
             // 
             // columnSettingsMenuItem
             // 
             this.columnSettingsMenuItem.Name = "columnSettingsMenuItem";
             this.columnSettingsMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.columnSettingsMenuItem.Text = "Column Settings";
+            this.columnSettingsMenuItem.Text = resources.GetString("this.columnSettingsMenuItem.Text");
             this.columnSettingsMenuItem.Click += new System.EventHandler(this.columnSettingsMenuItem_Click);
             // 
             // autoSizeColumnMenuItem
             // 
             this.autoSizeColumnMenuItem.Name = "autoSizeColumnMenuItem";
             this.autoSizeColumnMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.autoSizeColumnMenuItem.Text = "Auto-Size Columns";
+            this.autoSizeColumnMenuItem.Text = resources.GetString("this.autoSizeColumnMenuItem.Text");
             this.autoSizeColumnMenuItem.Click += new System.EventHandler(this.autoSizeColumnMenuItem_Click);
             // 
             // tsColumnSettingsSeparator
@@ -248,14 +248,14 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.hideInactiveMenuItem.Name = "hideInactiveMenuItem";
             this.hideInactiveMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.hideInactiveMenuItem.Text = "Hide Inactive Orders";
+            this.hideInactiveMenuItem.Text = resources.GetString("this.hideInactiveMenuItem.Text");
             this.hideInactiveMenuItem.Click += new System.EventHandler(this.hideInactiveMenuItem_Click);
             // 
             // numberAbsFormatMenuItem
             // 
             this.numberAbsFormatMenuItem.Name = "numberAbsFormatMenuItem";
             this.numberAbsFormatMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.numberAbsFormatMenuItem.Text = "Number Abbreviating Format";
+            this.numberAbsFormatMenuItem.Text = resources.GetString("this.numberAbsFormatMenuItem.Text");
             this.numberAbsFormatMenuItem.Click += new System.EventHandler(this.numberAbsFormatMenuItem_Click);
             // 
             // tsOptionsSeparator
@@ -268,7 +268,7 @@ namespace EVEMon.CharacterMonitoring
             this.showOnlyCharMenuItem.CheckOnClick = true;
             this.showOnlyCharMenuItem.Name = "showOnlyCharMenuItem";
             this.showOnlyCharMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.showOnlyCharMenuItem.Text = "Show Only Issued for Character";
+            this.showOnlyCharMenuItem.Text = resources.GetString("this.showOnlyCharMenuItem.Text");
             this.showOnlyCharMenuItem.Click += new System.EventHandler(this.showOnlyCharMenuItem_Click);
             // 
             // showOnlyCorpMenuItem
@@ -276,7 +276,7 @@ namespace EVEMon.CharacterMonitoring
             this.showOnlyCorpMenuItem.CheckOnClick = true;
             this.showOnlyCorpMenuItem.Name = "showOnlyCorpMenuItem";
             this.showOnlyCorpMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.showOnlyCorpMenuItem.Text = "Show Only Issued for Corporation";
+            this.showOnlyCorpMenuItem.Text = resources.GetString("this.showOnlyCorpMenuItem.Text");
             this.showOnlyCorpMenuItem.Click += new System.EventHandler(this.showOnlyCorpMenuItem_Click);
             // 
             // tsReadingPaneSeparator
@@ -292,7 +292,7 @@ namespace EVEMon.CharacterMonitoring
             this.paneOffMenuItem});
             this.readingPaneMenuItem.Name = "readingPaneMenuItem";
             this.readingPaneMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.readingPaneMenuItem.Text = "Reading Pane";
+            this.readingPaneMenuItem.Text = resources.GetString("this.readingPaneMenuItem.Text");
             this.readingPaneMenuItem.DropDownOpening += new System.EventHandler(this.readingPaneMenuItem_DropDownOpening);
             // 
             // paneRightMenuItem
@@ -301,7 +301,7 @@ namespace EVEMon.CharacterMonitoring
             this.paneRightMenuItem.Name = "paneRightMenuItem";
             this.paneRightMenuItem.Size = new System.Drawing.Size(114, 22);
             this.paneRightMenuItem.Tag = "Right";
-            this.paneRightMenuItem.Text = "Right";
+            this.paneRightMenuItem.Text = resources.GetString("this.paneRightMenuItem.Text");
             this.paneRightMenuItem.Click += new System.EventHandler(this.paneRightMenuItem_Click);
             // 
             // paneBottomMenuItem
@@ -310,7 +310,7 @@ namespace EVEMon.CharacterMonitoring
             this.paneBottomMenuItem.Name = "paneBottomMenuItem";
             this.paneBottomMenuItem.Size = new System.Drawing.Size(114, 22);
             this.paneBottomMenuItem.Tag = "Bottom";
-            this.paneBottomMenuItem.Text = "Bottom";
+            this.paneBottomMenuItem.Text = resources.GetString("this.paneBottomMenuItem.Text");
             this.paneBottomMenuItem.Click += new System.EventHandler(this.paneBottomMenuItem_Click);
             // 
             // paneOffMenuItem
@@ -319,7 +319,7 @@ namespace EVEMon.CharacterMonitoring
             this.paneOffMenuItem.Name = "paneOffMenuItem";
             this.paneOffMenuItem.Size = new System.Drawing.Size(114, 22);
             this.paneOffMenuItem.Tag = "Off";
-            this.paneOffMenuItem.Text = "Off";
+            this.paneOffMenuItem.Text = resources.GetString("this.paneOffMenuItem.Text");
             this.paneOffMenuItem.Click += new System.EventHandler(this.paneOffMenuItem_Click);
             // 
             // combatLogSeparator
@@ -332,7 +332,7 @@ namespace EVEMon.CharacterMonitoring
             this.combatLogMenuItem.CheckOnClick = true;
             this.combatLogMenuItem.Name = "combatLogMenuItem";
             this.combatLogMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.combatLogMenuItem.Text = "Show Condensed Combat Logs";
+            this.combatLogMenuItem.Text = resources.GetString("this.combatLogMenuItem.Text");
             this.combatLogMenuItem.Click += new System.EventHandler(this.combatLogMenuItem_Click);
             // 
             // tsPlanetarySeparator
@@ -345,7 +345,7 @@ namespace EVEMon.CharacterMonitoring
             this.showOnlyExtractorMenuItem.CheckOnClick = true;
             this.showOnlyExtractorMenuItem.Name = "showOnlyExtractorMenuItem";
             this.showOnlyExtractorMenuItem.Size = new System.Drawing.Size(252, 22);
-            this.showOnlyExtractorMenuItem.Text = "Show Only Extractor Control Unit";
+            this.showOnlyExtractorMenuItem.Text = resources.GetString("this.showOnlyExtractorMenuItem.Text");
             this.showOnlyExtractorMenuItem.Click += new System.EventHandler(this.showOnlyExtractorMenuItem_Click);
             // 
             // searchTextDel
@@ -357,8 +357,8 @@ namespace EVEMon.CharacterMonitoring
             this.searchTextDel.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.searchTextDel.Name = "searchTextDel";
             this.searchTextDel.Size = new System.Drawing.Size(23, 22);
-            this.searchTextDel.Text = "searchTextDel";
-            this.searchTextDel.ToolTipText = "Delete search text";
+            this.searchTextDel.Text = resources.GetString("this.searchTextDel.Text");
+            this.searchTextDel.ToolTipText = resources.GetString("this.searchTextDel.ToolTipText");
             this.searchTextDel.MouseUp += new System.Windows.Forms.MouseEventHandler(this.searchTextDel_MouseUp);
             // 
             // searchTextBox
@@ -371,7 +371,7 @@ namespace EVEMon.CharacterMonitoring
             this.searchTextBox.Name = "searchTextBox";
             this.searchTextBox.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.searchTextBox.Size = new System.Drawing.Size(120, 21);
-            this.searchTextBox.ToolTipText = "Search";
+            this.searchTextBox.ToolTipText = resources.GetString("this.searchTextBox.ToolTipText");
             this.searchTextBox.TextChanged += new System.EventHandler(this.searchTextBox_TextChanged);
             // 
             // groupMenu
@@ -382,7 +382,7 @@ namespace EVEMon.CharacterMonitoring
             this.groupMenu.Name = "groupMenu";
             this.groupMenu.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.groupMenu.Size = new System.Drawing.Size(94, 22);
-            this.groupMenu.Text = "Group By...";
+            this.groupMenu.Text = resources.GetString("this.groupMenu.Text");
             this.groupMenu.DropDownOpening += new System.EventHandler(this.groupMenu_DropDownOpening);
             this.groupMenu.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.groupMenu_DropDownItemClicked);
             // 
@@ -393,8 +393,8 @@ namespace EVEMon.CharacterMonitoring
             this.walletJournalCharts.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.walletJournalCharts.Name = "walletJournalCharts";
             this.walletJournalCharts.Size = new System.Drawing.Size(23, 22);
-            this.walletJournalCharts.Text = "Wallet Journal Charts";
-            this.walletJournalCharts.ToolTipText = "Charts";
+            this.walletJournalCharts.Text = resources.GetString("this.walletJournalCharts.Text");
+            this.walletJournalCharts.ToolTipText = resources.GetString("this.walletJournalCharts.ToolTipText");
             this.walletJournalCharts.Click += new System.EventHandler(this.walletJournalCharts_Click);
             // 
             // allContacts
@@ -406,7 +406,7 @@ namespace EVEMon.CharacterMonitoring
             this.allContacts.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.allContacts.Name = "allContacts";
             this.allContacts.Size = new System.Drawing.Size(23, 22);
-            this.allContacts.Text = "All contacts";
+            this.allContacts.Text = resources.GetString("this.allContacts.Text");
             this.allContacts.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // contactsExcellent
@@ -416,7 +416,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsExcellent.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.contactsExcellent.Name = "contactsExcellent";
             this.contactsExcellent.Size = new System.Drawing.Size(23, 22);
-            this.contactsExcellent.Text = "Excellent standing";
+            this.contactsExcellent.Text = resources.GetString("this.contactsExcellent.Text");
             this.contactsExcellent.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // contactsGood
@@ -427,7 +427,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsGood.Name = "contactsGood";
             this.contactsGood.Size = new System.Drawing.Size(23, 22);
             this.contactsGood.Tag = "Good";
-            this.contactsGood.Text = "Good standing";
+            this.contactsGood.Text = resources.GetString("this.contactsGood.Text");
             this.contactsGood.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // contactsNeutral
@@ -437,7 +437,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsNeutral.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.contactsNeutral.Name = "contactsNeutral";
             this.contactsNeutral.Size = new System.Drawing.Size(23, 22);
-            this.contactsNeutral.Text = "Neutral standing";
+            this.contactsNeutral.Text = resources.GetString("this.contactsNeutral.Text");
             this.contactsNeutral.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // contactsBad
@@ -447,7 +447,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsBad.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.contactsBad.Name = "contactsBad";
             this.contactsBad.Size = new System.Drawing.Size(23, 22);
-            this.contactsBad.Text = "Bad standing";
+            this.contactsBad.Text = resources.GetString("this.contactsBad.Text");
             this.contactsBad.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // contactsTerrible
@@ -457,7 +457,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsTerrible.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.contactsTerrible.Name = "contactsTerrible";
             this.contactsTerrible.Size = new System.Drawing.Size(23, 22);
-            this.contactsTerrible.Text = "Terrible standing";
+            this.contactsTerrible.Text = resources.GetString("this.contactsTerrible.Text");
             this.contactsTerrible.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // inWatchList
@@ -467,7 +467,7 @@ namespace EVEMon.CharacterMonitoring
             this.inWatchList.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.inWatchList.Name = "inWatchList";
             this.inWatchList.Size = new System.Drawing.Size(23, 22);
-            this.inWatchList.Text = "Watch List";
+            this.inWatchList.Text = resources.GetString("this.inWatchList.Text");
             this.inWatchList.Click += new System.EventHandler(this.contactsToolbarIcon_Click);
             // 
             // toolStripFeatures
@@ -515,8 +515,8 @@ namespace EVEMon.CharacterMonitoring
             this.skillsIcon.Name = "skillsIcon";
             this.skillsIcon.Size = new System.Drawing.Size(28, 28);
             this.skillsIcon.Tag = "skillsPage";
-            this.skillsIcon.Text = "Skills";
-            this.skillsIcon.ToolTipText = "Display skills list";
+            this.skillsIcon.Text = resources.GetString("this.skillsIcon.Text");
+            this.skillsIcon.ToolTipText = resources.GetString("this.skillsIcon.ToolTipText");
             this.skillsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // skillQueueIcon
@@ -527,8 +527,8 @@ namespace EVEMon.CharacterMonitoring
             this.skillQueueIcon.Name = "skillQueueIcon";
             this.skillQueueIcon.Size = new System.Drawing.Size(28, 28);
             this.skillQueueIcon.Tag = "skillQueuePage";
-            this.skillQueueIcon.Text = "Queue";
-            this.skillQueueIcon.ToolTipText = "Display skills in queue";
+            this.skillQueueIcon.Text = resources.GetString("this.skillQueueIcon.Text");
+            this.skillQueueIcon.ToolTipText = resources.GetString("this.skillQueueIcon.ToolTipText");
             this.skillQueueIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // employmentIcon
@@ -539,8 +539,8 @@ namespace EVEMon.CharacterMonitoring
             this.employmentIcon.Name = "employmentIcon";
             this.employmentIcon.Size = new System.Drawing.Size(28, 28);
             this.employmentIcon.Tag = "employmentPage";
-            this.employmentIcon.Text = "Employment History";
-            this.employmentIcon.ToolTipText = "Display employment history";
+            this.employmentIcon.Text = resources.GetString("this.employmentIcon.Text");
+            this.employmentIcon.ToolTipText = resources.GetString("this.employmentIcon.ToolTipText");
             this.employmentIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // standingsIcon
@@ -551,8 +551,8 @@ namespace EVEMon.CharacterMonitoring
             this.standingsIcon.Name = "standingsIcon";
             this.standingsIcon.Size = new System.Drawing.Size(28, 28);
             this.standingsIcon.Tag = "standingsPage";
-            this.standingsIcon.Text = "Standings";
-            this.standingsIcon.ToolTipText = "Display standings";
+            this.standingsIcon.Text = resources.GetString("this.standingsIcon.Text");
+            this.standingsIcon.ToolTipText = resources.GetString("this.standingsIcon.ToolTipText");
             this.standingsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // contactsIcon
@@ -563,8 +563,8 @@ namespace EVEMon.CharacterMonitoring
             this.contactsIcon.Name = "contactsIcon";
             this.contactsIcon.Size = new System.Drawing.Size(28, 28);
             this.contactsIcon.Tag = "contactsPage";
-            this.contactsIcon.Text = "Contacts";
-            this.contactsIcon.ToolTipText = "Display contacts";
+            this.contactsIcon.Text = resources.GetString("this.contactsIcon.Text");
+            this.contactsIcon.ToolTipText = resources.GetString("this.contactsIcon.ToolTipText");
             this.contactsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // factionalWarfareStatsIcon
@@ -575,8 +575,8 @@ namespace EVEMon.CharacterMonitoring
             this.factionalWarfareStatsIcon.Name = "factionalWarfareStatsIcon";
             this.factionalWarfareStatsIcon.Size = new System.Drawing.Size(28, 28);
             this.factionalWarfareStatsIcon.Tag = "factionalWarfareStatsPage";
-            this.factionalWarfareStatsIcon.Text = "Factional Warfare";
-            this.factionalWarfareStatsIcon.ToolTipText = "Display factional warfare stats";
+            this.factionalWarfareStatsIcon.Text = resources.GetString("this.factionalWarfareStatsIcon.Text");
+            this.factionalWarfareStatsIcon.ToolTipText = resources.GetString("this.factionalWarfareStatsIcon.ToolTipText");
             this.factionalWarfareStatsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // medalsIcon
@@ -587,8 +587,8 @@ namespace EVEMon.CharacterMonitoring
             this.medalsIcon.Name = "medalsIcon";
             this.medalsIcon.Size = new System.Drawing.Size(28, 28);
             this.medalsIcon.Tag = "medalsPage";
-            this.medalsIcon.Text = "Medals";
-            this.medalsIcon.ToolTipText = "Display medals";
+            this.medalsIcon.Text = resources.GetString("this.medalsIcon.Text");
+            this.medalsIcon.ToolTipText = resources.GetString("this.medalsIcon.ToolTipText");
             this.medalsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // killLogIcon
@@ -599,8 +599,8 @@ namespace EVEMon.CharacterMonitoring
             this.killLogIcon.Name = "killLogIcon";
             this.killLogIcon.Size = new System.Drawing.Size(28, 28);
             this.killLogIcon.Tag = "killLogPage";
-            this.killLogIcon.Text = "Combat Log";
-            this.killLogIcon.ToolTipText = "Display combat log";
+            this.killLogIcon.Text = resources.GetString("this.killLogIcon.Text");
+            this.killLogIcon.ToolTipText = resources.GetString("this.killLogIcon.ToolTipText");
             this.killLogIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // assetsIcon
@@ -611,8 +611,8 @@ namespace EVEMon.CharacterMonitoring
             this.assetsIcon.Name = "assetsIcon";
             this.assetsIcon.Size = new System.Drawing.Size(28, 28);
             this.assetsIcon.Tag = "assetsPage";
-            this.assetsIcon.Text = "Assets";
-            this.assetsIcon.ToolTipText = "Display assets";
+            this.assetsIcon.Text = resources.GetString("this.assetsIcon.Text");
+            this.assetsIcon.ToolTipText = resources.GetString("this.assetsIcon.ToolTipText");
             this.assetsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // ordersIcon
@@ -623,8 +623,8 @@ namespace EVEMon.CharacterMonitoring
             this.ordersIcon.Name = "ordersIcon";
             this.ordersIcon.Size = new System.Drawing.Size(28, 28);
             this.ordersIcon.Tag = "ordersPage";
-            this.ordersIcon.Text = "Market";
-            this.ordersIcon.ToolTipText = "Display market orders";
+            this.ordersIcon.Text = resources.GetString("this.ordersIcon.Text");
+            this.ordersIcon.ToolTipText = resources.GetString("this.ordersIcon.ToolTipText");
             this.ordersIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // contractsIcon
@@ -635,8 +635,8 @@ namespace EVEMon.CharacterMonitoring
             this.contractsIcon.Name = "contractsIcon";
             this.contractsIcon.Size = new System.Drawing.Size(28, 28);
             this.contractsIcon.Tag = "contractsPage";
-            this.contractsIcon.Text = "Contracts";
-            this.contractsIcon.ToolTipText = "Display contracts";
+            this.contractsIcon.Text = resources.GetString("this.contractsIcon.Text");
+            this.contractsIcon.ToolTipText = resources.GetString("this.contractsIcon.ToolTipText");
             this.contractsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // walletJournalIcon
@@ -647,8 +647,8 @@ namespace EVEMon.CharacterMonitoring
             this.walletJournalIcon.Name = "walletJournalIcon";
             this.walletJournalIcon.Size = new System.Drawing.Size(28, 28);
             this.walletJournalIcon.Tag = "walletJournalPage";
-            this.walletJournalIcon.Text = "Wallet Journal";
-            this.walletJournalIcon.ToolTipText = "Display wallet journal";
+            this.walletJournalIcon.Text = resources.GetString("this.walletJournalIcon.Text");
+            this.walletJournalIcon.ToolTipText = resources.GetString("this.walletJournalIcon.ToolTipText");
             this.walletJournalIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // walletTransactionsIcon
@@ -659,8 +659,8 @@ namespace EVEMon.CharacterMonitoring
             this.walletTransactionsIcon.Name = "walletTransactionsIcon";
             this.walletTransactionsIcon.Size = new System.Drawing.Size(28, 28);
             this.walletTransactionsIcon.Tag = "walletTransactionsPage";
-            this.walletTransactionsIcon.Text = "Wallet Transactions";
-            this.walletTransactionsIcon.ToolTipText = "Display wallet transactions";
+            this.walletTransactionsIcon.Text = resources.GetString("this.walletTransactionsIcon.Text");
+            this.walletTransactionsIcon.ToolTipText = resources.GetString("this.walletTransactionsIcon.ToolTipText");
             this.walletTransactionsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // jobsIcon
@@ -671,8 +671,8 @@ namespace EVEMon.CharacterMonitoring
             this.jobsIcon.Name = "jobsIcon";
             this.jobsIcon.Size = new System.Drawing.Size(28, 28);
             this.jobsIcon.Tag = "jobsPage";
-            this.jobsIcon.Text = "Industry";
-            this.jobsIcon.ToolTipText = "Display industry jobs";
+            this.jobsIcon.Text = resources.GetString("this.jobsIcon.Text");
+            this.jobsIcon.ToolTipText = resources.GetString("this.jobsIcon.ToolTipText");
             this.jobsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // loyaltyIcon
@@ -683,8 +683,8 @@ namespace EVEMon.CharacterMonitoring
             this.loyaltyIcon.Name = "loyaltyIcon";
             this.loyaltyIcon.Size = new System.Drawing.Size(28, 28);
             this.loyaltyIcon.Tag = "loyaltyPage";
-            this.loyaltyIcon.Text = "Loyalty Points";
-            this.loyaltyIcon.ToolTipText = "Display loyalty point balances";
+            this.loyaltyIcon.Text = resources.GetString("this.loyaltyIcon.Text");
+            this.loyaltyIcon.ToolTipText = resources.GetString("this.loyaltyIcon.ToolTipText");
             this.loyaltyIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // planetaryIcon
@@ -695,8 +695,8 @@ namespace EVEMon.CharacterMonitoring
             this.planetaryIcon.Name = "planetaryIcon";
             this.planetaryIcon.Size = new System.Drawing.Size(28, 28);
             this.planetaryIcon.Tag = "planetaryPage";
-            this.planetaryIcon.Text = "Planetary Colonies";
-            this.planetaryIcon.ToolTipText = "Display planetary colonies";
+            this.planetaryIcon.Text = resources.GetString("this.planetaryIcon.Text");
+            this.planetaryIcon.ToolTipText = resources.GetString("this.planetaryIcon.ToolTipText");
             this.planetaryIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // researchIcon
@@ -707,8 +707,8 @@ namespace EVEMon.CharacterMonitoring
             this.researchIcon.Name = "researchIcon";
             this.researchIcon.Size = new System.Drawing.Size(28, 28);
             this.researchIcon.Tag = "researchPage";
-            this.researchIcon.Text = "Research";
-            this.researchIcon.ToolTipText = "Display research points";
+            this.researchIcon.Text = resources.GetString("this.researchIcon.Text");
+            this.researchIcon.ToolTipText = resources.GetString("this.researchIcon.ToolTipText");
             this.researchIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // mailMessagesIcon
@@ -719,8 +719,8 @@ namespace EVEMon.CharacterMonitoring
             this.mailMessagesIcon.Name = "mailMessagesIcon";
             this.mailMessagesIcon.Size = new System.Drawing.Size(28, 28);
             this.mailMessagesIcon.Tag = "mailMessagesPage";
-            this.mailMessagesIcon.Text = "Mail";
-            this.mailMessagesIcon.ToolTipText = "Display EVE mails";
+            this.mailMessagesIcon.Text = resources.GetString("this.mailMessagesIcon.Text");
+            this.mailMessagesIcon.ToolTipText = resources.GetString("this.mailMessagesIcon.ToolTipText");
             this.mailMessagesIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // eveNotificationsIcon
@@ -731,8 +731,8 @@ namespace EVEMon.CharacterMonitoring
             this.eveNotificationsIcon.Name = "eveNotificationsIcon";
             this.eveNotificationsIcon.Size = new System.Drawing.Size(28, 28);
             this.eveNotificationsIcon.Tag = "eveNotificationsPage";
-            this.eveNotificationsIcon.Text = "Notification";
-            this.eveNotificationsIcon.ToolTipText = "Display EVE notifications";
+            this.eveNotificationsIcon.Text = resources.GetString("this.eveNotificationsIcon.Text");
+            this.eveNotificationsIcon.ToolTipText = resources.GetString("this.eveNotificationsIcon.ToolTipText");
             this.eveNotificationsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // calendarEventsIcon
@@ -743,8 +743,8 @@ namespace EVEMon.CharacterMonitoring
             this.calendarEventsIcon.Name = "calendarEventsIcon";
             this.calendarEventsIcon.Size = new System.Drawing.Size(28, 28);
             this.calendarEventsIcon.Tag = "calendarEventsPage";
-            this.calendarEventsIcon.Text = "Calendar";
-            this.calendarEventsIcon.ToolTipText = "Display calendar events";
+            this.calendarEventsIcon.Text = resources.GetString("this.calendarEventsIcon.Text");
+            this.calendarEventsIcon.ToolTipText = resources.GetString("this.calendarEventsIcon.ToolTipText");
             this.calendarEventsIcon.Click += new System.EventHandler(this.toolbarIcon_Click);
             // 
             // featuresMenu
@@ -760,8 +760,8 @@ namespace EVEMon.CharacterMonitoring
             this.featuresMenu.Name = "featuresMenu";
             this.featuresMenu.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.featuresMenu.Size = new System.Drawing.Size(37, 28);
-            this.featuresMenu.Text = "More features";
-            this.featuresMenu.ToolTipText = "Advanced features";
+            this.featuresMenu.Text = resources.GetString("this.featuresMenu.Text");
+            this.featuresMenu.ToolTipText = resources.GetString("this.featuresMenu.ToolTipText");
             this.featuresMenu.DropDownOpening += new System.EventHandler(this.featureMenu_DropDownOpening);
             this.featuresMenu.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.featuresMenu_DropDownItemClicked);
             // 
@@ -769,14 +769,14 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.EnableAllToolStripMenuItem.Name = "EnableAllToolStripMenuItem";
             this.EnableAllToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
-            this.EnableAllToolStripMenuItem.Text = "Enable All";
+            this.EnableAllToolStripMenuItem.Text = resources.GetString("this.EnableAllToolStripMenuItem.Text");
             this.EnableAllToolStripMenuItem.Click += new System.EventHandler(this.EnableAllToolStripMenuItem_Click);
             // 
             // DisableAllToolStripMenuItem
             // 
             this.DisableAllToolStripMenuItem.Name = "DisableAllToolStripMenuItem";
             this.DisableAllToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
-            this.DisableAllToolStripMenuItem.Text = "Disable All";
+            this.DisableAllToolStripMenuItem.Text = resources.GetString("this.DisableAllToolStripMenuItem.Text");
             this.DisableAllToolStripMenuItem.Click += new System.EventHandler(this.DisableAllToolStripMenuItem_Click);
             // 
             // SelectionToolStripSeparator
@@ -800,8 +800,8 @@ namespace EVEMon.CharacterMonitoring
             this.toggleSkillsIcon.Name = "toggleSkillsIcon";
             this.toggleSkillsIcon.Overflow = System.Windows.Forms.ToolStripItemOverflow.Never;
             this.toggleSkillsIcon.Size = new System.Drawing.Size(28, 28);
-            this.toggleSkillsIcon.Text = "Toggle All Skills";
-            this.toggleSkillsIcon.ToolTipText = "Toggle all skills";
+            this.toggleSkillsIcon.Text = resources.GetString("this.toggleSkillsIcon.Text");
+            this.toggleSkillsIcon.ToolTipText = resources.GetString("this.toggleSkillsIcon.ToolTipText");
             this.toggleSkillsIcon.Click += new System.EventHandler(this.toggleSkillsIcon_Click);
             // 
             // tsToggleSeparator
@@ -880,7 +880,7 @@ namespace EVEMon.CharacterMonitoring
             this.loyaltyPage.Size = new System.Drawing.Size(608, 181);
             this.loyaltyPage.TabIndex = 18;
             this.loyaltyPage.Tag = "LoyaltyPoints";
-            this.loyaltyPage.Text = "loyaltyPage";
+            this.loyaltyPage.Text = resources.GetString("this.loyaltyPage.Text");
             // 
             // loyaltyList
             // 
@@ -899,7 +899,7 @@ namespace EVEMon.CharacterMonitoring
             this.standingsPage.Size = new System.Drawing.Size(608, 181);
             this.standingsPage.TabIndex = 7;
             this.standingsPage.Tag = "Standings";
-            this.standingsPage.Text = "standingsPage";
+            this.standingsPage.Text = resources.GetString("this.standingsPage.Text");
             // 
             // standingsList
             // 
@@ -918,7 +918,7 @@ namespace EVEMon.CharacterMonitoring
             this.skillsPage.Size = new System.Drawing.Size(608, 181);
             this.skillsPage.TabIndex = 0;
             this.skillsPage.Tag = "CharacterSheet";
-            this.skillsPage.Text = "skillsPage";
+            this.skillsPage.Text = resources.GetString("this.skillsPage.Text");
             // 
             // skillsList
             // 
@@ -938,7 +938,7 @@ namespace EVEMon.CharacterMonitoring
             this.ordersPage.Size = new System.Drawing.Size(564, 181);
             this.ordersPage.TabIndex = 2;
             this.ordersPage.Tag = "MarketOrders";
-            this.ordersPage.Text = "ordersPage";
+            this.ordersPage.Text = resources.GetString("this.ordersPage.Text");
             // 
             // ordersList
             // 
@@ -959,7 +959,7 @@ namespace EVEMon.CharacterMonitoring
             this.skillQueuePage.Size = new System.Drawing.Size(568, 86);
             this.skillQueuePage.TabIndex = 1;
             this.skillQueuePage.Tag = "SkillQueue";
-            this.skillQueuePage.Text = "skillQueuePage";
+            this.skillQueuePage.Text = resources.GetString("this.skillQueuePage.Text");
             // 
             // skillQueueList
             // 
@@ -978,7 +978,7 @@ namespace EVEMon.CharacterMonitoring
             this.jobsPage.Size = new System.Drawing.Size(608, 181);
             this.jobsPage.TabIndex = 3;
             this.jobsPage.Tag = "IndustryJobs";
-            this.jobsPage.Text = "jobsPage";
+            this.jobsPage.Text = resources.GetString("this.jobsPage.Text");
             // 
             // jobsList
             // 
@@ -999,7 +999,7 @@ namespace EVEMon.CharacterMonitoring
             this.researchPage.Size = new System.Drawing.Size(568, 86);
             this.researchPage.TabIndex = 4;
             this.researchPage.Tag = "ResearchPoints";
-            this.researchPage.Text = "researchPage";
+            this.researchPage.Text = resources.GetString("this.researchPage.Text");
             // 
             // researchList
             // 
@@ -1020,7 +1020,7 @@ namespace EVEMon.CharacterMonitoring
             this.mailMessagesPage.Size = new System.Drawing.Size(608, 181);
             this.mailMessagesPage.TabIndex = 5;
             this.mailMessagesPage.Tag = "MailMessages";
-            this.mailMessagesPage.Text = "mailMessagesPage";
+            this.mailMessagesPage.Text = resources.GetString("this.mailMessagesPage.Text");
             // 
             // mailMessagesList
             // 
@@ -1041,7 +1041,7 @@ namespace EVEMon.CharacterMonitoring
             this.eveNotificationsPage.Size = new System.Drawing.Size(568, 86);
             this.eveNotificationsPage.TabIndex = 6;
             this.eveNotificationsPage.Tag = "Notifications";
-            this.eveNotificationsPage.Text = "eveNotificationsPage";
+            this.eveNotificationsPage.Text = resources.GetString("this.eveNotificationsPage.Text");
             // 
             // eveNotificationsList
             // 
@@ -1062,7 +1062,7 @@ namespace EVEMon.CharacterMonitoring
             this.employmentPage.Size = new System.Drawing.Size(568, 156);
             this.employmentPage.TabIndex = 8;
             this.employmentPage.Tag = "EmploymentHistory";
-            this.employmentPage.Text = "employmentPage";
+            this.employmentPage.Text = resources.GetString("this.employmentPage.Text");
             // 
             // employmentList
             // 
@@ -1081,7 +1081,7 @@ namespace EVEMon.CharacterMonitoring
             this.contractsPage.Size = new System.Drawing.Size(564, 181);
             this.contractsPage.TabIndex = 9;
             this.contractsPage.Tag = "Contracts";
-            this.contractsPage.Text = "contractsPage";
+            this.contractsPage.Text = resources.GetString("this.contractsPage.Text");
             // 
             // contractsList
             // 
@@ -1102,7 +1102,7 @@ namespace EVEMon.CharacterMonitoring
             this.assetsPage.Size = new System.Drawing.Size(568, 308);
             this.assetsPage.TabIndex = 10;
             this.assetsPage.Tag = "AssetList";
-            this.assetsPage.Text = "assetsPage";
+            this.assetsPage.Text = resources.GetString("this.assetsPage.Text");
             // 
             // assetsList
             // 
@@ -1123,7 +1123,7 @@ namespace EVEMon.CharacterMonitoring
             this.walletJournalPage.Size = new System.Drawing.Size(568, 86);
             this.walletJournalPage.TabIndex = 11;
             this.walletJournalPage.Tag = "WalletJournal";
-            this.walletJournalPage.Text = "walletJournalPage";
+            this.walletJournalPage.Text = resources.GetString("this.walletJournalPage.Text");
             // 
             // walletJournalList
             // 
@@ -1144,7 +1144,7 @@ namespace EVEMon.CharacterMonitoring
             this.walletTransactionsPage.Size = new System.Drawing.Size(568, 86);
             this.walletTransactionsPage.TabIndex = 12;
             this.walletTransactionsPage.Tag = "WalletTransactions";
-            this.walletTransactionsPage.Text = "walletTransactionsPage";
+            this.walletTransactionsPage.Text = resources.GetString("this.walletTransactionsPage.Text");
             // 
             // walletTransactionsList
             // 
@@ -1165,7 +1165,7 @@ namespace EVEMon.CharacterMonitoring
             this.factionalWarfareStatsPage.Size = new System.Drawing.Size(568, 156);
             this.factionalWarfareStatsPage.TabIndex = 13;
             this.factionalWarfareStatsPage.Tag = "FactionalWarfareStats";
-            this.factionalWarfareStatsPage.Text = "factionalWarfareStatsPage";
+            this.factionalWarfareStatsPage.Text = resources.GetString("this.factionalWarfareStatsPage.Text");
             // 
             // factionalWarfareStatsList
             // 
@@ -1184,7 +1184,7 @@ namespace EVEMon.CharacterMonitoring
             this.contactsPage.Size = new System.Drawing.Size(564, 181);
             this.contactsPage.TabIndex = 14;
             this.contactsPage.Tag = "ContactList";
-            this.contactsPage.Text = "contactsPage";
+            this.contactsPage.Text = resources.GetString("this.contactsPage.Text");
             // 
             // contactsList
             // 
@@ -1203,7 +1203,7 @@ namespace EVEMon.CharacterMonitoring
             this.medalsPage.Size = new System.Drawing.Size(608, 181);
             this.medalsPage.TabIndex = 15;
             this.medalsPage.Tag = "Medals";
-            this.medalsPage.Text = "medalsPage";
+            this.medalsPage.Text = resources.GetString("this.medalsPage.Text");
             // 
             // medalsList
             // 
@@ -1222,7 +1222,7 @@ namespace EVEMon.CharacterMonitoring
             this.killLogPage.Size = new System.Drawing.Size(608, 181);
             this.killLogPage.TabIndex = 16;
             this.killLogPage.Tag = "KillLog";
-            this.killLogPage.Text = "killLogPage";
+            this.killLogPage.Text = resources.GetString("this.killLogPage.Text");
             // 
             // killLogList
             // 
@@ -1242,7 +1242,7 @@ namespace EVEMon.CharacterMonitoring
             this.planetaryPage.Size = new System.Drawing.Size(608, 181);
             this.planetaryPage.TabIndex = 17;
             this.planetaryPage.Tag = "PlanetaryColonies";
-            this.planetaryPage.Text = "planetaryPage";
+            this.planetaryPage.Text = resources.GetString("this.planetaryPage.Text");
             // 
             // planetaryList
             // 
@@ -1266,7 +1266,7 @@ namespace EVEMon.CharacterMonitoring
             this.warningLabel.Name = "warningLabel";
             this.warningLabel.Size = new System.Drawing.Size(608, 17);
             this.warningLabel.TabIndex = 1;
-            this.warningLabel.Text = "This character has no associated API key, data won\'t be updated.";
+            this.warningLabel.Text = resources.GetString("this.warningLabel.Text");
             this.warningLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // notificationList

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.resx
@@ -1113,4 +1113,283 @@
         oVSW+RdE39jOuVjT+Ph6AAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.preferencesMenu.Text" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="this.preferencesMenu.ToolTipText" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="this.columnSettingsMenuItem.Text" xml:space="preserve">
+    <value>Column Settings</value>
+  </data>
+  <data name="this.autoSizeColumnMenuItem.Text" xml:space="preserve">
+    <value>Auto-Size Columns</value>
+  </data>
+  <data name="this.hideInactiveMenuItem.Text" xml:space="preserve">
+    <value>Hide Inactive Orders</value>
+  </data>
+  <data name="this.numberAbsFormatMenuItem.Text" xml:space="preserve">
+    <value>Number Abbreviating Format</value>
+  </data>
+  <data name="this.showOnlyCharMenuItem.Text" xml:space="preserve">
+    <value>Show Only Issued for Character</value>
+  </data>
+  <data name="this.showOnlyCorpMenuItem.Text" xml:space="preserve">
+    <value>Show Only Issued for Corporation</value>
+  </data>
+  <data name="this.readingPaneMenuItem.Text" xml:space="preserve">
+    <value>Reading Pane</value>
+  </data>
+  <data name="this.paneRightMenuItem.Text" xml:space="preserve">
+    <value>Right</value>
+  </data>
+  <data name="this.paneBottomMenuItem.Text" xml:space="preserve">
+    <value>Bottom</value>
+  </data>
+  <data name="this.paneOffMenuItem.Text" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="this.combatLogMenuItem.Text" xml:space="preserve">
+    <value>Show Condensed Combat Logs</value>
+  </data>
+  <data name="this.showOnlyExtractorMenuItem.Text" xml:space="preserve">
+    <value>Show Only Extractor Control Unit</value>
+  </data>
+  <data name="this.searchTextDel.Text" xml:space="preserve">
+    <value>searchTextDel</value>
+  </data>
+  <data name="this.searchTextDel.ToolTipText" xml:space="preserve">
+    <value>Delete search text</value>
+  </data>
+  <data name="this.searchTextBox.ToolTipText" xml:space="preserve">
+    <value>Search</value>
+  </data>
+  <data name="this.groupMenu.Text" xml:space="preserve">
+    <value>Group By...</value>
+  </data>
+  <data name="this.walletJournalCharts.Text" xml:space="preserve">
+    <value>Wallet Journal Charts</value>
+  </data>
+  <data name="this.walletJournalCharts.ToolTipText" xml:space="preserve">
+    <value>Charts</value>
+  </data>
+  <data name="this.allContacts.Text" xml:space="preserve">
+    <value>All contacts</value>
+  </data>
+  <data name="this.contactsExcellent.Text" xml:space="preserve">
+    <value>Excellent standing</value>
+  </data>
+  <data name="this.contactsGood.Text" xml:space="preserve">
+    <value>Good standing</value>
+  </data>
+  <data name="this.contactsNeutral.Text" xml:space="preserve">
+    <value>Neutral standing</value>
+  </data>
+  <data name="this.contactsBad.Text" xml:space="preserve">
+    <value>Bad standing</value>
+  </data>
+  <data name="this.contactsTerrible.Text" xml:space="preserve">
+    <value>Terrible standing</value>
+  </data>
+  <data name="this.inWatchList.Text" xml:space="preserve">
+    <value>Watch List</value>
+  </data>
+  <data name="this.skillsIcon.Text" xml:space="preserve">
+    <value>Skills</value>
+  </data>
+  <data name="this.skillsIcon.ToolTipText" xml:space="preserve">
+    <value>Display skills list</value>
+  </data>
+  <data name="this.skillQueueIcon.Text" xml:space="preserve">
+    <value>Queue</value>
+  </data>
+  <data name="this.skillQueueIcon.ToolTipText" xml:space="preserve">
+    <value>Display skills in queue</value>
+  </data>
+  <data name="this.employmentIcon.Text" xml:space="preserve">
+    <value>Employment History</value>
+  </data>
+  <data name="this.employmentIcon.ToolTipText" xml:space="preserve">
+    <value>Display employment history</value>
+  </data>
+  <data name="this.standingsIcon.Text" xml:space="preserve">
+    <value>Standings</value>
+  </data>
+  <data name="this.standingsIcon.ToolTipText" xml:space="preserve">
+    <value>Display standings</value>
+  </data>
+  <data name="this.contactsIcon.Text" xml:space="preserve">
+    <value>Contacts</value>
+  </data>
+  <data name="this.contactsIcon.ToolTipText" xml:space="preserve">
+    <value>Display contacts</value>
+  </data>
+  <data name="this.factionalWarfareStatsIcon.Text" xml:space="preserve">
+    <value>Factional Warfare</value>
+  </data>
+  <data name="this.factionalWarfareStatsIcon.ToolTipText" xml:space="preserve">
+    <value>Display factional warfare stats</value>
+  </data>
+  <data name="this.medalsIcon.Text" xml:space="preserve">
+    <value>Medals</value>
+  </data>
+  <data name="this.medalsIcon.ToolTipText" xml:space="preserve">
+    <value>Display medals</value>
+  </data>
+  <data name="this.killLogIcon.Text" xml:space="preserve">
+    <value>Combat Log</value>
+  </data>
+  <data name="this.killLogIcon.ToolTipText" xml:space="preserve">
+    <value>Display combat log</value>
+  </data>
+  <data name="this.assetsIcon.Text" xml:space="preserve">
+    <value>Assets</value>
+  </data>
+  <data name="this.assetsIcon.ToolTipText" xml:space="preserve">
+    <value>Display assets</value>
+  </data>
+  <data name="this.ordersIcon.Text" xml:space="preserve">
+    <value>Market</value>
+  </data>
+  <data name="this.ordersIcon.ToolTipText" xml:space="preserve">
+    <value>Display market orders</value>
+  </data>
+  <data name="this.contractsIcon.Text" xml:space="preserve">
+    <value>Contracts</value>
+  </data>
+  <data name="this.contractsIcon.ToolTipText" xml:space="preserve">
+    <value>Display contracts</value>
+  </data>
+  <data name="this.walletJournalIcon.Text" xml:space="preserve">
+    <value>Wallet Journal</value>
+  </data>
+  <data name="this.walletJournalIcon.ToolTipText" xml:space="preserve">
+    <value>Display wallet journal</value>
+  </data>
+  <data name="this.walletTransactionsIcon.Text" xml:space="preserve">
+    <value>Wallet Transactions</value>
+  </data>
+  <data name="this.walletTransactionsIcon.ToolTipText" xml:space="preserve">
+    <value>Display wallet transactions</value>
+  </data>
+  <data name="this.jobsIcon.Text" xml:space="preserve">
+    <value>Industry</value>
+  </data>
+  <data name="this.jobsIcon.ToolTipText" xml:space="preserve">
+    <value>Display industry jobs</value>
+  </data>
+  <data name="this.loyaltyIcon.Text" xml:space="preserve">
+    <value>Loyalty Points</value>
+  </data>
+  <data name="this.loyaltyIcon.ToolTipText" xml:space="preserve">
+    <value>Display loyalty point balances</value>
+  </data>
+  <data name="this.planetaryIcon.Text" xml:space="preserve">
+    <value>Planetary Colonies</value>
+  </data>
+  <data name="this.planetaryIcon.ToolTipText" xml:space="preserve">
+    <value>Display planetary colonies</value>
+  </data>
+  <data name="this.researchIcon.Text" xml:space="preserve">
+    <value>Research</value>
+  </data>
+  <data name="this.researchIcon.ToolTipText" xml:space="preserve">
+    <value>Display research points</value>
+  </data>
+  <data name="this.mailMessagesIcon.Text" xml:space="preserve">
+    <value>Mail</value>
+  </data>
+  <data name="this.mailMessagesIcon.ToolTipText" xml:space="preserve">
+    <value>Display EVE mails</value>
+  </data>
+  <data name="this.eveNotificationsIcon.Text" xml:space="preserve">
+    <value>Notification</value>
+  </data>
+  <data name="this.eveNotificationsIcon.ToolTipText" xml:space="preserve">
+    <value>Display EVE notifications</value>
+  </data>
+  <data name="this.calendarEventsIcon.Text" xml:space="preserve">
+    <value>Calendar</value>
+  </data>
+  <data name="this.calendarEventsIcon.ToolTipText" xml:space="preserve">
+    <value>Display calendar events</value>
+  </data>
+  <data name="this.featuresMenu.Text" xml:space="preserve">
+    <value>More features</value>
+  </data>
+  <data name="this.featuresMenu.ToolTipText" xml:space="preserve">
+    <value>Advanced features</value>
+  </data>
+  <data name="this.EnableAllToolStripMenuItem.Text" xml:space="preserve">
+    <value>Enable All</value>
+  </data>
+  <data name="this.DisableAllToolStripMenuItem.Text" xml:space="preserve">
+    <value>Disable All</value>
+  </data>
+  <data name="this.toggleSkillsIcon.Text" xml:space="preserve">
+    <value>Toggle All Skills</value>
+  </data>
+  <data name="this.toggleSkillsIcon.ToolTipText" xml:space="preserve">
+    <value>Toggle all skills</value>
+  </data>
+  <data name="this.loyaltyPage.Text" xml:space="preserve">
+    <value>loyaltyPage</value>
+  </data>
+  <data name="this.standingsPage.Text" xml:space="preserve">
+    <value>standingsPage</value>
+  </data>
+  <data name="this.skillsPage.Text" xml:space="preserve">
+    <value>skillsPage</value>
+  </data>
+  <data name="this.ordersPage.Text" xml:space="preserve">
+    <value>ordersPage</value>
+  </data>
+  <data name="this.skillQueuePage.Text" xml:space="preserve">
+    <value>skillQueuePage</value>
+  </data>
+  <data name="this.jobsPage.Text" xml:space="preserve">
+    <value>jobsPage</value>
+  </data>
+  <data name="this.researchPage.Text" xml:space="preserve">
+    <value>researchPage</value>
+  </data>
+  <data name="this.mailMessagesPage.Text" xml:space="preserve">
+    <value>mailMessagesPage</value>
+  </data>
+  <data name="this.eveNotificationsPage.Text" xml:space="preserve">
+    <value>eveNotificationsPage</value>
+  </data>
+  <data name="this.employmentPage.Text" xml:space="preserve">
+    <value>employmentPage</value>
+  </data>
+  <data name="this.contractsPage.Text" xml:space="preserve">
+    <value>contractsPage</value>
+  </data>
+  <data name="this.assetsPage.Text" xml:space="preserve">
+    <value>assetsPage</value>
+  </data>
+  <data name="this.walletJournalPage.Text" xml:space="preserve">
+    <value>walletJournalPage</value>
+  </data>
+  <data name="this.walletTransactionsPage.Text" xml:space="preserve">
+    <value>walletTransactionsPage</value>
+  </data>
+  <data name="this.factionalWarfareStatsPage.Text" xml:space="preserve">
+    <value>factionalWarfareStatsPage</value>
+  </data>
+  <data name="this.contactsPage.Text" xml:space="preserve">
+    <value>contactsPage</value>
+  </data>
+  <data name="this.medalsPage.Text" xml:space="preserve">
+    <value>medalsPage</value>
+  </data>
+  <data name="this.killLogPage.Text" xml:space="preserve">
+    <value>killLogPage</value>
+  </data>
+  <data name="this.planetaryPage.Text" xml:space="preserve">
+    <value>planetaryPage</value>
+  </data>
+  <data name="this.warningLabel.Text" xml:space="preserve">
+    <value>This character has no associated API key, data won\'t be updated.</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorBody.zh-CN.resx
@@ -1,0 +1,343 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.preferencesMenu.Text" xml:space="preserve">
+    <value>偏好设置</value>
+  </data>
+  <data name="this.preferencesMenu.ToolTipText" xml:space="preserve">
+    <value>偏好设置</value>
+  </data>
+  <data name="this.columnSettingsMenuItem.Text" xml:space="preserve">
+    <value>列设置</value>
+  </data>
+  <data name="this.autoSizeColumnMenuItem.Text" xml:space="preserve">
+    <value>自动调整列大小</value>
+  </data>
+  <data name="this.hideInactiveMenuItem.Text" xml:space="preserve">
+    <value>隐藏不活跃订单</value>
+  </data>
+  <data name="this.numberAbsFormatMenuItem.Text" xml:space="preserve">
+    <value>数字缩写格式</value>
+  </data>
+  <data name="this.showOnlyCharMenuItem.Text" xml:space="preserve">
+    <value>仅显示针对角色发布的内容</value>
+  </data>
+  <data name="this.showOnlyCorpMenuItem.Text" xml:space="preserve">
+    <value>仅显示为公司发行</value>
+  </data>
+  <data name="this.readingPaneMenuItem.Text" xml:space="preserve">
+    <value>阅读窗格</value>
+  </data>
+  <data name="this.paneRightMenuItem.Text" xml:space="preserve">
+    <value>右</value>
+  </data>
+  <data name="this.paneBottomMenuItem.Text" xml:space="preserve">
+    <value>底部</value>
+  </data>
+  <data name="this.paneOffMenuItem.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.combatLogMenuItem.Text" xml:space="preserve">
+    <value>显示浓缩的战斗日志</value>
+  </data>
+  <data name="this.showOnlyExtractorMenuItem.Text" xml:space="preserve">
+    <value>仅显示抽油烟机控制单元</value>
+  </data>
+  <data name="this.searchTextDel.Text" xml:space="preserve">
+    <value>搜索文本删除</value>
+  </data>
+  <data name="this.searchTextDel.ToolTipText" xml:space="preserve">
+    <value>删除搜索文本</value>
+  </data>
+  <data name="this.searchTextBox.ToolTipText" xml:space="preserve">
+    <value>搜索</value>
+  </data>
+  <data name="this.groupMenu.Text" xml:space="preserve">
+    <value>分组依据...</value>
+  </data>
+  <data name="this.walletJournalCharts.Text" xml:space="preserve">
+    <value>钱包日记图表</value>
+  </data>
+  <data name="this.walletJournalCharts.ToolTipText" xml:space="preserve">
+    <value>图表</value>
+  </data>
+  <data name="this.allContacts.Text" xml:space="preserve">
+    <value>所有联系人</value>
+  </data>
+  <data name="this.contactsExcellent.Text" xml:space="preserve">
+    <value>良好的信誉</value>
+  </data>
+  <data name="this.contactsGood.Text" xml:space="preserve">
+    <value>良好的信誉</value>
+  </data>
+  <data name="this.contactsNeutral.Text" xml:space="preserve">
+    <value>中立立场</value>
+  </data>
+  <data name="this.contactsBad.Text" xml:space="preserve">
+    <value>信誉不佳</value>
+  </data>
+  <data name="this.contactsTerrible.Text" xml:space="preserve">
+    <value>糟糕的站立状态</value>
+  </data>
+  <data name="this.inWatchList.Text" xml:space="preserve">
+    <value>观察名单</value>
+  </data>
+  <data name="this.skillsIcon.Text" xml:space="preserve">
+    <value>技能</value>
+  </data>
+  <data name="this.skillsIcon.ToolTipText" xml:space="preserve">
+    <value>显示技能列表</value>
+  </data>
+  <data name="this.skillQueueIcon.Text" xml:space="preserve">
+    <value>队列</value>
+  </data>
+  <data name="this.skillQueueIcon.ToolTipText" xml:space="preserve">
+    <value>在队列中显示技能</value>
+  </data>
+  <data name="this.employmentIcon.Text" xml:space="preserve">
+    <value>工作经历</value>
+  </data>
+  <data name="this.employmentIcon.ToolTipText" xml:space="preserve">
+    <value>显示工作经历</value>
+  </data>
+  <data name="this.standingsIcon.Text" xml:space="preserve">
+    <value>积分榜</value>
+  </data>
+  <data name="this.standingsIcon.ToolTipText" xml:space="preserve">
+    <value>显示积分榜</value>
+  </data>
+  <data name="this.contactsIcon.Text" xml:space="preserve">
+    <value>联系方式</value>
+  </data>
+  <data name="this.contactsIcon.ToolTipText" xml:space="preserve">
+    <value>显示联系人</value>
+  </data>
+  <data name="this.factionalWarfareStatsIcon.Text" xml:space="preserve">
+    <value>派系战争</value>
+  </data>
+  <data name="this.factionalWarfareStatsIcon.ToolTipText" xml:space="preserve">
+    <value>显示派系战争统计数据</value>
+  </data>
+  <data name="this.medalsIcon.Text" xml:space="preserve">
+    <value>奖牌</value>
+  </data>
+  <data name="this.medalsIcon.ToolTipText" xml:space="preserve">
+    <value>展示奖牌</value>
+  </data>
+  <data name="this.killLogIcon.Text" xml:space="preserve">
+    <value>战斗日志</value>
+  </data>
+  <data name="this.killLogIcon.ToolTipText" xml:space="preserve">
+    <value>显示战斗日志</value>
+  </data>
+  <data name="this.assetsIcon.Text" xml:space="preserve">
+    <value>资产</value>
+  </data>
+  <data name="this.assetsIcon.ToolTipText" xml:space="preserve">
+    <value>显示资产</value>
+  </data>
+  <data name="this.ordersIcon.Text" xml:space="preserve">
+    <value>市场</value>
+  </data>
+  <data name="this.ordersIcon.ToolTipText" xml:space="preserve">
+    <value>显示市价订单</value>
+  </data>
+  <data name="this.contractsIcon.Text" xml:space="preserve">
+    <value>合约</value>
+  </data>
+  <data name="this.contractsIcon.ToolTipText" xml:space="preserve">
+    <value>展示合同</value>
+  </data>
+  <data name="this.walletJournalIcon.Text" xml:space="preserve">
+    <value>钱包日记本</value>
+  </data>
+  <data name="this.walletJournalIcon.ToolTipText" xml:space="preserve">
+    <value>显示钱包日志</value>
+  </data>
+  <data name="this.walletTransactionsIcon.Text" xml:space="preserve">
+    <value>钱包交易</value>
+  </data>
+  <data name="this.walletTransactionsIcon.ToolTipText" xml:space="preserve">
+    <value>显示钱包交易</value>
+  </data>
+  <data name="this.jobsIcon.Text" xml:space="preserve">
+    <value>工业</value>
+  </data>
+  <data name="this.jobsIcon.ToolTipText" xml:space="preserve">
+    <value>显示行业职位</value>
+  </data>
+  <data name="this.loyaltyIcon.Text" xml:space="preserve">
+    <value>忠诚度积分</value>
+  </data>
+  <data name="this.loyaltyIcon.ToolTipText" xml:space="preserve">
+    <value>显示忠诚度积分余额</value>
+  </data>
+  <data name="this.planetaryIcon.Text" xml:space="preserve">
+    <value>行星殖民地</value>
+  </data>
+  <data name="this.planetaryIcon.ToolTipText" xml:space="preserve">
+    <value>显示行星殖民地</value>
+  </data>
+  <data name="this.researchIcon.Text" xml:space="preserve">
+    <value>研究</value>
+  </data>
+  <data name="this.researchIcon.ToolTipText" xml:space="preserve">
+    <value>显示研究点</value>
+  </data>
+  <data name="this.mailMessagesIcon.Text" xml:space="preserve">
+    <value>邮件</value>
+  </data>
+  <data name="this.mailMessagesIcon.ToolTipText" xml:space="preserve">
+    <value>显示 EVE 邮件</value>
+  </data>
+  <data name="this.eveNotificationsIcon.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="this.eveNotificationsIcon.ToolTipText" xml:space="preserve">
+    <value>显示 EVE 通知</value>
+  </data>
+  <data name="this.calendarEventsIcon.Text" xml:space="preserve">
+    <value>日历</value>
+  </data>
+  <data name="this.calendarEventsIcon.ToolTipText" xml:space="preserve">
+    <value>显示日历事件</value>
+  </data>
+  <data name="this.featuresMenu.Text" xml:space="preserve">
+    <value>更多功能</value>
+  </data>
+  <data name="this.featuresMenu.ToolTipText" xml:space="preserve">
+    <value>高级功能</value>
+  </data>
+  <data name="this.EnableAllToolStripMenuItem.Text" xml:space="preserve">
+    <value>全部启用</value>
+  </data>
+  <data name="this.DisableAllToolStripMenuItem.Text" xml:space="preserve">
+    <value>全部禁用</value>
+  </data>
+  <data name="this.toggleSkillsIcon.Text" xml:space="preserve">
+    <value>切换所有技能</value>
+  </data>
+  <data name="this.toggleSkillsIcon.ToolTipText" xml:space="preserve">
+    <value>切换所有技能</value>
+  </data>
+  <data name="this.loyaltyPage.Text" xml:space="preserve">
+    <value>忠诚度页面</value>
+  </data>
+  <data name="this.standingsPage.Text" xml:space="preserve">
+    <value>积分榜页面</value>
+  </data>
+  <data name="this.skillsPage.Text" xml:space="preserve">
+    <value>技能页面</value>
+  </data>
+  <data name="this.ordersPage.Text" xml:space="preserve">
+    <value>订单页面</value>
+  </data>
+  <data name="this.skillQueuePage.Text" xml:space="preserve">
+    <value>技能队列页面</value>
+  </data>
+  <data name="this.jobsPage.Text" xml:space="preserve">
+    <value>职位页面</value>
+  </data>
+  <data name="this.researchPage.Text" xml:space="preserve">
+    <value>研究页面</value>
+  </data>
+  <data name="this.mailMessagesPage.Text" xml:space="preserve">
+    <value>邮件消息页面</value>
+  </data>
+  <data name="this.eveNotificationsPage.Text" xml:space="preserve">
+    <value>前夕通知页面</value>
+  </data>
+  <data name="this.employmentPage.Text" xml:space="preserve">
+    <value>就业页面</value>
+  </data>
+  <data name="this.contractsPage.Text" xml:space="preserve">
+    <value>合同页</value>
+  </data>
+  <data name="this.assetsPage.Text" xml:space="preserve">
+    <value>资产页面</value>
+  </data>
+  <data name="this.walletJournalPage.Text" xml:space="preserve">
+    <value>钱包日记页</value>
+  </data>
+  <data name="this.walletTransactionsPage.Text" xml:space="preserve">
+    <value>钱包交易页面</value>
+  </data>
+  <data name="this.factionalWarfareStatsPage.Text" xml:space="preserve">
+    <value>派系战争统计页面</value>
+  </data>
+  <data name="this.contactsPage.Text" xml:space="preserve">
+    <value>联系人页面</value>
+  </data>
+  <data name="this.medalsPage.Text" xml:space="preserve">
+    <value>奖牌页</value>
+  </data>
+  <data name="this.killLogPage.Text" xml:space="preserve">
+    <value>杀死日志页</value>
+  </data>
+  <data name="this.planetaryPage.Text" xml:space="preserve">
+    <value>行星页面</value>
+  </data>
+  <data name="this.warningLabel.Text" xml:space="preserve">
+    <value>该角色没有关联的 API 密钥，数据不会更新。</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorFooter.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorFooter.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterMonitorHeader.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.Designer.cs
@@ -68,27 +68,27 @@
             this.showPlanetInBrowserMenuItem});
 			this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
 			this.showInBrowserMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.showInBrowserMenuItem.Text = "Show In Item Browser";
+			this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
 			// 
 			// showCommodityInBrowserMenuItem
 			// 
 			this.showCommodityInBrowserMenuItem.Name = "showCommodityInBrowserMenuItem";
 			this.showCommodityInBrowserMenuItem.Size = new System.Drawing.Size(147, 22);
-			this.showCommodityInBrowserMenuItem.Text = "Commodity...";
+			this.showCommodityInBrowserMenuItem.Text = resources.GetString("this.showCommodityInBrowserMenuItem.Text");
 			this.showCommodityInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
 			// 
 			// showInstallationInBrowserMenuItem
 			// 
 			this.showInstallationInBrowserMenuItem.Name = "showInstallationInBrowserMenuItem";
 			this.showInstallationInBrowserMenuItem.Size = new System.Drawing.Size(147, 22);
-			this.showInstallationInBrowserMenuItem.Text = "Installation...";
+			this.showInstallationInBrowserMenuItem.Text = resources.GetString("this.showInstallationInBrowserMenuItem.Text");
 			this.showInstallationInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
 			// 
 			// showPlanetInBrowserMenuItem
 			// 
 			this.showPlanetInBrowserMenuItem.Name = "showPlanetInBrowserMenuItem";
 			this.showPlanetInBrowserMenuItem.Size = new System.Drawing.Size(147, 22);
-			this.showPlanetInBrowserMenuItem.Text = "Planet...";
+			this.showPlanetInBrowserMenuItem.Text = resources.GetString("this.showPlanetInBrowserMenuItem.Text");
 			this.showPlanetInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
 			// 
 			// showInBrowserMenuSeparator
@@ -100,7 +100,7 @@
 			// 
 			this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
 			this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-			this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+			this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
 			this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
 			// 
 			// ilIcons
@@ -119,7 +119,7 @@
 			this.noPlanetaryColoniesLabel.Name = "noPlanetaryColoniesLabel";
 			this.noPlanetaryColoniesLabel.Size = new System.Drawing.Size(454, 434);
 			this.noPlanetaryColoniesLabel.TabIndex = 2;
-			this.noPlanetaryColoniesLabel.Text = "No planetary info is available.";
+			this.noPlanetaryColoniesLabel.Text = resources.GetString("this.noPlanetaryColoniesLabel.Text");
 			this.noPlanetaryColoniesLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
 			// lvPlanetary
@@ -148,35 +148,35 @@
 			// 
 			// chState
 			// 
-			this.chState.Text = "State";
+			this.chState.Text = resources.GetString("this.chState.Text");
 			// 
 			// chTTC
 			// 
-			this.chTTC.Text = "TTC";
+			this.chTTC.Text = resources.GetString("this.chTTC.Text");
 			this.chTTC.Width = 54;
 			// 
 			// chInstallation
 			// 
-			this.chInstallation.Text = "Installation";
+			this.chInstallation.Text = resources.GetString("this.chInstallation.Text");
 			this.chInstallation.Width = 62;
 			// 
 			// chCommodity
 			// 
-			this.chCommodity.Text = "Commodity";
+			this.chCommodity.Text = resources.GetString("this.chCommodity.Text");
 			this.chCommodity.Width = 65;
 			// 
 			// chQuantityPerCycle
 			// 
-			this.chQuantityPerCycle.Text = "Quantity / Cycle";
+			this.chQuantityPerCycle.Text = resources.GetString("this.chQuantityPerCycle.Text");
 			this.chQuantityPerCycle.Width = 92;
 			// 
 			// chQuantity
 			// 
-			this.chQuantity.Text = "Quantity";
+			this.chQuantity.Text = resources.GetString("this.chQuantity.Text");
 			// 
 			// chVolume
 			// 
-			this.chVolume.Text = "Volume";
+			this.chVolume.Text = resources.GetString("this.chVolume.Text");
 			// 
 			// CharacterPlanetaryList
 			// 

--- a/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.resx
@@ -134,4 +134,43 @@
         AgAB/AE/AfgBHwL/AgAB/gF/AfABDwL/AgAG/wIABv8CAAb/AgAG/wIABv8CAAb/AgAL
 </value>
   </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Item Browser</value>
+  </data>
+  <data name="this.showCommodityInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Commodity...</value>
+  </data>
+  <data name="this.showInstallationInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Installation...</value>
+  </data>
+  <data name="this.showPlanetInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Planet...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.noPlanetaryColoniesLabel.Text" xml:space="preserve">
+    <value>No planetary info is available.</value>
+  </data>
+  <data name="this.chState.Text" xml:space="preserve">
+    <value>State</value>
+  </data>
+  <data name="this.chTTC.Text" xml:space="preserve">
+    <value>TTC</value>
+  </data>
+  <data name="this.chInstallation.Text" xml:space="preserve">
+    <value>Installation</value>
+  </data>
+  <data name="this.chCommodity.Text" xml:space="preserve">
+    <value>Commodity</value>
+  </data>
+  <data name="this.chQuantityPerCycle.Text" xml:space="preserve">
+    <value>Quantity / Cycle</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>Quantity</value>
+  </data>
+  <data name="this.chVolume.Text" xml:space="preserve">
+    <value>Volume</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterPlanetaryList.zh-CN.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在项目浏览器中显示</value>
+  </data>
+  <data name="this.showCommodityInBrowserMenuItem.Text" xml:space="preserve">
+    <value>商品...</value>
+  </data>
+  <data name="this.showInstallationInBrowserMenuItem.Text" xml:space="preserve">
+    <value>安装...</value>
+  </data>
+  <data name="this.showPlanetInBrowserMenuItem.Text" xml:space="preserve">
+    <value>星球...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.noPlanetaryColoniesLabel.Text" xml:space="preserve">
+    <value>没有可用的行星信息。</value>
+  </data>
+  <data name="this.chState.Text" xml:space="preserve">
+    <value>状态</value>
+  </data>
+  <data name="this.chTTC.Text" xml:space="preserve">
+    <value>TTC</value>
+  </data>
+  <data name="this.chInstallation.Text" xml:space="preserve">
+    <value>安装</value>
+  </data>
+  <data name="this.chCommodity.Text" xml:space="preserve">
+    <value>商品</value>
+  </data>
+  <data name="this.chQuantityPerCycle.Text" xml:space="preserve">
+    <value>数量/周期</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>数量</value>
+  </data>
+  <data name="this.chVolume.Text" xml:space="preserve">
+    <value>体积</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.Designer.cs
@@ -54,7 +54,7 @@ namespace EVEMon.CharacterMonitoring
             this.noResearchPointsLabel.Name = "noResearchPointsLabel";
             this.noResearchPointsLabel.Size = new System.Drawing.Size(454, 434);
             this.noResearchPointsLabel.TabIndex = 1;
-            this.noResearchPointsLabel.Text = "No research points are available.";
+            this.noResearchPointsLabel.Text = resources.GetString("this.noResearchPointsLabel.Text");
             this.noResearchPointsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // ilIcons
@@ -67,23 +67,23 @@ namespace EVEMon.CharacterMonitoring
             // 
             // chAgentName
             // 
-            this.chAgentName.Text = "Agent";
+            this.chAgentName.Text = resources.GetString("this.chAgentName.Text");
             // 
             // chSolarSystem
             // 
-            this.chSolarSystem.Text = "System";
+            this.chSolarSystem.Text = resources.GetString("this.chSolarSystem.Text");
             // 
             // chSkill
             // 
-            this.chSkill.Text = "Field";
+            this.chSkill.Text = resources.GetString("this.chSkill.Text");
             // 
             // chCurrentRP
             // 
-            this.chCurrentRP.Text = "Current RP";
+            this.chCurrentRP.Text = resources.GetString("this.chCurrentRP.Text");
             // 
             // chPRPerDay
             // 
-            this.chPRPerDay.Text = "RP/Day";
+            this.chPRPerDay.Text = resources.GetString("this.chPRPerDay.Text");
             // 
             // lvResearchPoints
             // 
@@ -122,14 +122,14 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.showInSkillBrowserMenuItem.Name = "showInSkillBrowserMenuItem";
             this.showInSkillBrowserMenuItem.Size = new System.Drawing.Size(260, 22);
-            this.showInSkillBrowserMenuItem.Text = "Show Field In Skill Browser...";
+            this.showInSkillBrowserMenuItem.Text = resources.GetString("this.showInSkillBrowserMenuItem.Text");
             this.showInSkillBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showObjectInBrowserMenuItem
             // 
             this.showObjectInBrowserMenuItem.Name = "showObjectInBrowserMenuItem";
             this.showObjectInBrowserMenuItem.Size = new System.Drawing.Size(260, 22);
-            this.showObjectInBrowserMenuItem.Text = "Show Researchable In Item Browser...";
+            this.showObjectInBrowserMenuItem.Text = resources.GetString("this.showObjectInBrowserMenuItem.Text");
             this.showObjectInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // showInSkillBrowserMenuSeparator
@@ -141,7 +141,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(260, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // CharacterResearchPointsList

--- a/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.resx
@@ -134,4 +134,31 @@
   <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>103, 17</value>
   </metadata>
+  <data name="this.noResearchPointsLabel.Text" xml:space="preserve">
+    <value>No research points are available.</value>
+  </data>
+  <data name="this.chAgentName.Text" xml:space="preserve">
+    <value>Agent</value>
+  </data>
+  <data name="this.chSolarSystem.Text" xml:space="preserve">
+    <value>System</value>
+  </data>
+  <data name="this.chSkill.Text" xml:space="preserve">
+    <value>Field</value>
+  </data>
+  <data name="this.chCurrentRP.Text" xml:space="preserve">
+    <value>Current RP</value>
+  </data>
+  <data name="this.chPRPerDay.Text" xml:space="preserve">
+    <value>RP/Day</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show Field In Skill Browser...</value>
+  </data>
+  <data name="this.showObjectInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show Researchable In Item Browser...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterResearchPointsList.zh-CN.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noResearchPointsLabel.Text" xml:space="preserve">
+    <value>没有可用的研究点。</value>
+  </data>
+  <data name="this.chAgentName.Text" xml:space="preserve">
+    <value>代理</value>
+  </data>
+  <data name="this.chSolarSystem.Text" xml:space="preserve">
+    <value>系统</value>
+  </data>
+  <data name="this.chSkill.Text" xml:space="preserve">
+    <value>领域</value>
+  </data>
+  <data name="this.chCurrentRP.Text" xml:space="preserve">
+    <value>当前RP</value>
+  </data>
+  <data name="this.chPRPerDay.Text" xml:space="preserve">
+    <value>RP/天</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>在技能浏览器中显示字段...</value>
+  </data>
+  <data name="this.showObjectInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在项目浏览器中显示可研究...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsList.Designer.cs
@@ -58,7 +58,7 @@ namespace EVEMon.CharacterMonitoring
             this.showInSkillExplorerMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("showInSkillExplorerMenuItem.Image")));
             this.showInSkillExplorerMenuItem.Name = "showInSkillExplorerMenuItem";
             this.showInSkillExplorerMenuItem.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillExplorerMenuItem.Text = "Show In Skill &Explorer...";
+            this.showInSkillExplorerMenuItem.Text = resources.GetString("this.showInSkillExplorerMenuItem.Text");
             this.showInSkillExplorerMenuItem.Click += new System.EventHandler(this.showInSkillExplorerMenuItem_Click);
             // 
             // showInMenuSeparator
@@ -70,7 +70,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.tsmiAddSkill.Name = "tsmiAddSkill";
             this.tsmiAddSkill.Size = new System.Drawing.Size(194, 22);
-            this.tsmiAddSkill.Text = "Add skill";
+            this.tsmiAddSkill.Text = resources.GetString("this.tsmiAddSkill.Text");
             // 
             // ttToolTip
             // 
@@ -89,7 +89,7 @@ namespace EVEMon.CharacterMonitoring
             this.noSkillsLabel.Name = "noSkillsLabel";
             this.noSkillsLabel.Size = new System.Drawing.Size(287, 320);
             this.noSkillsLabel.TabIndex = 4;
-            this.noSkillsLabel.Text = "Skills information not available.";
+            this.noSkillsLabel.Text = resources.GetString("this.noSkillsLabel.Text");
             this.noSkillsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lbSkills
@@ -115,7 +115,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.showInSkillBrowserMenuItem.Name = "showInSkillBrowserMenuItem";
             this.showInSkillBrowserMenuItem.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillBrowserMenuItem.Text = "Show In Skill &Browser...";
+            this.showInSkillBrowserMenuItem.Text = resources.GetString("this.showInSkillBrowserMenuItem.Text");
             this.showInSkillBrowserMenuItem.Click += new System.EventHandler(this.showInSkillBrowserMenuItem_Click);
             // 
             // CharacterSkillsList

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsList.resx
@@ -140,4 +140,16 @@
   <metadata name="ttToolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="this.showInSkillExplorerMenuItem.Text" xml:space="preserve">
+    <value>Show In Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.tsmiAddSkill.Text" xml:space="preserve">
+    <value>Add skill</value>
+  </data>
+  <data name="this.noSkillsLabel.Text" xml:space="preserve">
+    <value>Skills information not available.</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Skill &amp;Browser...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsList.zh-CN.resx
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.showInSkillExplorerMenuItem.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.tsmiAddSkill.Text" xml:space="preserve">
+    <value>添加技能</value>
+  </data>
+  <data name="this.noSkillsLabel.Text" xml:space="preserve">
+    <value>技能信息不可用。</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.Designer.cs
@@ -55,7 +55,7 @@ namespace EVEMon.CharacterMonitoring
             this.noSkillsQueueLabel.Name = "noSkillsQueueLabel";
             this.noSkillsQueueLabel.Size = new System.Drawing.Size(287, 320);
             this.noSkillsQueueLabel.TabIndex = 0;
-            this.noSkillsQueueLabel.Text = "Skills Queue information not available.";
+            this.noSkillsQueueLabel.Text = resources.GetString("this.noSkillsQueueLabel.Text");
             this.noSkillsQueueLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // ttToolTip
@@ -83,7 +83,7 @@ namespace EVEMon.CharacterMonitoring
             this.showInSkillExplorerMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("showInSkillExplorerMenuItem.Image")));
             this.showInSkillExplorerMenuItem.Name = "showInSkillExplorerMenuItem";
             this.showInSkillExplorerMenuItem.Size = new System.Drawing.Size(234, 22);
-            this.showInSkillExplorerMenuItem.Text = "Show In Skill &Explorer...";
+            this.showInSkillExplorerMenuItem.Text = resources.GetString("this.showInSkillExplorerMenuItem.Text");
             this.showInSkillExplorerMenuItem.Click += new System.EventHandler(this.showInSkillExplorerMenuItem_Click);
             // 
             // showInMenuSeparator
@@ -95,7 +95,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.tsmiAddSkill.Name = "tsmiAddSkill";
             this.tsmiAddSkill.Size = new System.Drawing.Size(234, 22);
-            this.tsmiAddSkill.Text = "Add skill";
+            this.tsmiAddSkill.Text = resources.GetString("this.tsmiAddSkill.Text");
             // 
             // addSkillSeparator
             // 
@@ -107,7 +107,7 @@ namespace EVEMon.CharacterMonitoring
             this.tsmiCreatePlanFromSkillQueue.Image = ((System.Drawing.Image)(resources.GetObject("tsmiCreatePlanFromSkillQueue.Image")));
             this.tsmiCreatePlanFromSkillQueue.Name = "tsmiCreatePlanFromSkillQueue";
             this.tsmiCreatePlanFromSkillQueue.Size = new System.Drawing.Size(234, 22);
-            this.tsmiCreatePlanFromSkillQueue.Text = "Create Plan from Skill Queue...";
+            this.tsmiCreatePlanFromSkillQueue.Text = resources.GetString("this.tsmiCreatePlanFromSkillQueue.Text");
             this.tsmiCreatePlanFromSkillQueue.Click += new System.EventHandler(this.tsmiCreatePlanFromSkillQueue_Click);
             // 
             // lbSkillsQueue
@@ -133,7 +133,7 @@ namespace EVEMon.CharacterMonitoring
             // 
             this.showInSkillBrowserMenuItem.Name = "showInSkillBrowserMenuItem";
             this.showInSkillBrowserMenuItem.Size = new System.Drawing.Size(234, 22);
-            this.showInSkillBrowserMenuItem.Text = "Show In Skill Browser...";
+            this.showInSkillBrowserMenuItem.Text = resources.GetString("this.showInSkillBrowserMenuItem.Text");
             this.showInSkillBrowserMenuItem.Click += new System.EventHandler(this.showInSkillBrowserMenuItem_Click);
             // 
             // CharacterSkillsQueueList

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.resx
@@ -161,4 +161,19 @@
         SUVORK5CYII=
 </value>
   </data>
+  <data name="this.noSkillsQueueLabel.Text" xml:space="preserve">
+    <value>Skills Queue information not available.</value>
+  </data>
+  <data name="this.showInSkillExplorerMenuItem.Text" xml:space="preserve">
+    <value>Show In Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.tsmiAddSkill.Text" xml:space="preserve">
+    <value>Add skill</value>
+  </data>
+  <data name="this.tsmiCreatePlanFromSkillQueue.Text" xml:space="preserve">
+    <value>Create Plan from Skill Queue...</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Skill Browser...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterSkillsQueueList.zh-CN.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noSkillsQueueLabel.Text" xml:space="preserve">
+    <value>技能队列信息不可用。</value>
+  </data>
+  <data name="this.showInSkillExplorerMenuItem.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.tsmiAddSkill.Text" xml:space="preserve">
+    <value>添加技能</value>
+  </data>
+  <data name="this.tsmiCreatePlanFromSkillQueue.Text" xml:space="preserve">
+    <value>从技能队列创建计划...</value>
+  </data>
+  <data name="this.showInSkillBrowserMenuItem.Text" xml:space="preserve">
+    <value>在技能浏览器中显示...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterStandingsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterStandingsList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.Designer.cs
@@ -50,7 +50,7 @@
             this.noWalletJournalLabel.Name = "noWalletJournalLabel";
             this.noWalletJournalLabel.Size = new System.Drawing.Size(454, 434);
             this.noWalletJournalLabel.TabIndex = 3;
-            this.noWalletJournalLabel.Text = "No wallet journal is available.";
+            this.noWalletJournalLabel.Text = resources.GetString("this.noWalletJournalLabel.Text");
             this.noWalletJournalLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lvWalletJournal
@@ -76,22 +76,22 @@
             // 
             // chDate
             // 
-            this.chDate.Text = "Date";
+            this.chDate.Text = resources.GetString("this.chDate.Text");
             this.chDate.Width = 106;
             // 
             // chType
             // 
-            this.chType.Text = "Type";
+            this.chType.Text = resources.GetString("this.chType.Text");
             this.chType.Width = 100;
             // 
             // chAmount
             // 
-            this.chAmount.Text = "Amount";
+            this.chAmount.Text = resources.GetString("this.chAmount.Text");
             this.chAmount.Width = 99;
             // 
             // chBalance
             // 
-            this.chBalance.Text = "Balance";
+            this.chBalance.Text = resources.GetString("this.chBalance.Text");
             this.chBalance.Width = 106;
             // 
             // ilIcons
@@ -113,7 +113,7 @@
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // CharacterWalletJournalList

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.resx
@@ -134,4 +134,22 @@
         AgAB/AE/AfgBHwL/AgAB/gF/AfABDwL/AgAG/wIABv8CAAb/AgAG/wIABv8CAAb/AgAL
 </value>
   </data>
+  <data name="this.noWalletJournalLabel.Text" xml:space="preserve">
+    <value>No wallet journal is available.</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="this.chAmount.Text" xml:space="preserve">
+    <value>Amount</value>
+  </data>
+  <data name="this.chBalance.Text" xml:space="preserve">
+    <value>Balance</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletJournalList.zh-CN.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noWalletJournalLabel.Text" xml:space="preserve">
+    <value>没有可用的钱包日记。</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="this.chType.Text" xml:space="preserve">
+    <value>类型</value>
+  </data>
+  <data name="this.chAmount.Text" xml:space="preserve">
+    <value>金额</value>
+  </data>
+  <data name="this.chBalance.Text" xml:space="preserve">
+    <value>平衡</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.Designer.cs
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.Designer.cs
@@ -50,7 +50,7 @@
             this.noWalletTransactionsLabel.Name = "noWalletTransactionsLabel";
             this.noWalletTransactionsLabel.Size = new System.Drawing.Size(454, 434);
             this.noWalletTransactionsLabel.TabIndex = 3;
-            this.noWalletTransactionsLabel.Text = "No wallet transactions are available.";
+            this.noWalletTransactionsLabel.Text = resources.GetString("this.noWalletTransactionsLabel.Text");
             this.noWalletTransactionsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lvWalletTransactions
@@ -76,22 +76,22 @@
             // 
             // chDate
             // 
-            this.chDate.Text = "Date";
+            this.chDate.Text = resources.GetString("this.chDate.Text");
             this.chDate.Width = 125;
             // 
             // chItem
             // 
-            this.chItem.Text = "Item";
+            this.chItem.Text = resources.GetString("this.chItem.Text");
             this.chItem.Width = 169;
             // 
             // chPrice
             // 
-            this.chPrice.Text = "Price";
+            this.chPrice.Text = resources.GetString("this.chPrice.Text");
             this.chPrice.Width = 77;
             // 
             // chQuantity
             // 
-            this.chQuantity.Text = "Quantity";
+            this.chQuantity.Text = resources.GetString("this.chQuantity.Text");
             this.chQuantity.Width = 81;
             // 
             // contextMenu
@@ -105,7 +105,7 @@
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // ilIcons

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.resx
@@ -134,4 +134,22 @@
         AgAB/AE/AfgBHwL/AgAB/gF/AfABDwL/AgAG/wIABv8CAAb/AgAG/wIABv8CAAb/AgAL
 </value>
   </data>
+  <data name="this.noWalletTransactionsLabel.Text" xml:space="preserve">
+    <value>No wallet transactions are available.</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="this.chItem.Text" xml:space="preserve">
+    <value>Item</value>
+  </data>
+  <data name="this.chPrice.Text" xml:space="preserve">
+    <value>Price</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>Quantity</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
 </root>

--- a/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.zh-CN.resx
+++ b/src/EVEMon/CharacterMonitoring/CharacterWalletTransactionsList.zh-CN.resx
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.noWalletTransactionsLabel.Text" xml:space="preserve">
+    <value>没有可用的钱包交易。</value>
+  </data>
+  <data name="this.chDate.Text" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="this.chItem.Text" xml:space="preserve">
+    <value>项目</value>
+  </data>
+  <data name="this.chPrice.Text" xml:space="preserve">
+    <value>价格</value>
+  </data>
+  <data name="this.chQuantity.Text" xml:space="preserve">
+    <value>数量</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+</root>

--- a/src/EVEMon/CharactersComparison/CharactersComparisonWindow.Designer.cs
+++ b/src/EVEMon/CharactersComparison/CharactersComparisonWindow.Designer.cs
@@ -101,7 +101,7 @@
 			// 
 			// chCharacters
 			// 
-			this.chCharacters.Text = "Characters";
+			this.chCharacters.Text = resources.GetString("this.chCharacters.Text");
 			this.chCharacters.Width = 190;
 			// 
 			// filterPanel
@@ -136,7 +136,7 @@
 			this.filterLabel.Name = "filterLabel";
 			this.filterLabel.Size = new System.Drawing.Size(32, 13);
 			this.filterLabel.TabIndex = 0;
-			this.filterLabel.Text = "Filter:";
+			this.filterLabel.Text = resources.GetString("this.filterLabel.Text");
 			// 
 			// gbSkills
 			// 
@@ -147,7 +147,7 @@
 			this.gbSkills.Size = new System.Drawing.Size(574, 436);
 			this.gbSkills.TabIndex = 1;
 			this.gbSkills.TabStop = false;
-			this.gbSkills.Text = "Skills";
+			this.gbSkills.Text = resources.GetString("this.gbSkills.Text");
 			// 
 			// lvCharacterInfo
 			// 
@@ -172,12 +172,12 @@
 			// 
 			// chSkill
 			// 
-			this.chSkill.Text = "Skill";
+			this.chSkill.Text = resources.GetString("this.chSkill.Text");
 			this.chSkill.Width = 166;
 			// 
 			// chCharacter
 			// 
-			this.chCharacter.Text = "Character Name";
+			this.chCharacter.Text = resources.GetString("this.chCharacter.Text");
 			this.chCharacter.Width = 131;
 			// 
 			// characterInfoContextMenu
@@ -193,14 +193,14 @@
 			// 
 			this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Name = "exportSelectedSkillsAsPlanFromToolStripMenuItem";
 			this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
-			this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Text = "Export Selected Skills as Plan from...";
+			this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Text = resources.GetString("this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Text");
 			this.exportSelectedSkillsAsPlanFromToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.exportSelectedSkillsAsPlanFromToolStripMenuItem_DropDownItemClicked);
 			// 
 			// exportToCSVToolStripMenuItem
 			// 
 			this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
 			this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(261, 22);
-			this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+			this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
 			this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
 			// 
 			// lblHelp
@@ -231,7 +231,7 @@
 			this.exportCharacterSkillsAsPlanToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("exportCharacterSkillsAsPlanToolStripMenuItem.Image")));
 			this.exportCharacterSkillsAsPlanToolStripMenuItem.Name = "exportCharacterSkillsAsPlanToolStripMenuItem";
 			this.exportCharacterSkillsAsPlanToolStripMenuItem.Size = new System.Drawing.Size(239, 22);
-			this.exportCharacterSkillsAsPlanToolStripMenuItem.Text = "Export Character Skills as Plan...";
+			this.exportCharacterSkillsAsPlanToolStripMenuItem.Text = resources.GetString("this.exportCharacterSkillsAsPlanToolStripMenuItem.Text");
 			// 
 			// CharactersComparisonWindow
 			// 
@@ -241,7 +241,7 @@
 			this.Controls.Add(this.persistentSplitContainer);
 			this.MinimumSize = new System.Drawing.Size(800, 480);
 			this.Name = "CharactersComparisonWindow";
-			this.Text = "Characters Comparison";
+			this.Text = resources.GetString("this.Text");
 			this.persistentSplitContainer.Panel1.ResumeLayout(false);
 			this.persistentSplitContainer.Panel2.ResumeLayout(false);
 			this.persistentSplitContainer.Panel2.PerformLayout();

--- a/src/EVEMon/CharactersComparison/CharactersComparisonWindow.resx
+++ b/src/EVEMon/CharactersComparison/CharactersComparisonWindow.resx
@@ -189,4 +189,31 @@
         Uxe2tXRje6sGL8l68JxEjc0NWhSoB+LHg939FEQGF8RGtoOJcPE/gxI4ZT68SM4AAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.chCharacters.Text" xml:space="preserve">
+    <value>Characters</value>
+  </data>
+  <data name="this.filterLabel.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="this.gbSkills.Text" xml:space="preserve">
+    <value>Skills</value>
+  </data>
+  <data name="this.chSkill.Text" xml:space="preserve">
+    <value>Skill</value>
+  </data>
+  <data name="this.chCharacter.Text" xml:space="preserve">
+    <value>Character Name</value>
+  </data>
+  <data name="this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export Selected Skills as Plan from...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.exportCharacterSkillsAsPlanToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export Character Skills as Plan...</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Characters Comparison</value>
+  </data>
 </root>

--- a/src/EVEMon/CharactersComparison/CharactersComparisonWindow.zh-CN.resx
+++ b/src/EVEMon/CharactersComparison/CharactersComparisonWindow.zh-CN.resx
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.chCharacters.Text" xml:space="preserve">
+    <value>人物</value>
+  </data>
+  <data name="this.filterLabel.Text" xml:space="preserve">
+    <value>过滤器：</value>
+  </data>
+  <data name="this.gbSkills.Text" xml:space="preserve">
+    <value>技能</value>
+  </data>
+  <data name="this.chSkill.Text" xml:space="preserve">
+    <value>技能</value>
+  </data>
+  <data name="this.chCharacter.Text" xml:space="preserve">
+    <value>角色名称</value>
+  </data>
+  <data name="this.exportSelectedSkillsAsPlanFromToolStripMenuItem.Text" xml:space="preserve">
+    <value>将选定的技能导出为计划...</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.exportCharacterSkillsAsPlanToolStripMenuItem.Text" xml:space="preserve">
+    <value>将角色技能导出为计划...</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>人物比较</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/KillReportAttacker.Designer.cs
+++ b/src/EVEMon/Controls/KillReportAttacker.Designer.cs
@@ -79,7 +79,7 @@
             this.DamageDoneLabel.Name = "DamageDoneLabel";
             this.DamageDoneLabel.Size = new System.Drawing.Size(72, 13);
             this.DamageDoneLabel.TabIndex = 0;
-            this.DamageDoneLabel.Text = "{0:N0} ({1:P1})";
+            this.DamageDoneLabel.Text = resources.GetString("this.DamageDoneLabel.Text");
             // 
             // CharacterPictureBox
             // 
@@ -142,7 +142,7 @@
             this.CharacterNameLabel.Name = "CharacterNameLabel";
             this.CharacterNameLabel.Size = new System.Drawing.Size(112, 11);
             this.CharacterNameLabel.TabIndex = 0;
-            this.CharacterNameLabel.Text = "Character Name";
+            this.CharacterNameLabel.Text = resources.GetString("this.CharacterNameLabel.Text");
             // 
             // AllianceNameLabel
             // 
@@ -154,7 +154,7 @@
             this.AllianceNameLabel.Name = "AllianceNameLabel";
             this.AllianceNameLabel.Size = new System.Drawing.Size(112, 11);
             this.AllianceNameLabel.TabIndex = 2;
-            this.AllianceNameLabel.Text = "Alliance Name";
+            this.AllianceNameLabel.Text = resources.GetString("this.AllianceNameLabel.Text");
             // 
             // CorpNameLabel
             // 
@@ -166,7 +166,7 @@
             this.CorpNameLabel.Name = "CorpNameLabel";
             this.CorpNameLabel.Size = new System.Drawing.Size(112, 11);
             this.CorpNameLabel.TabIndex = 1;
-            this.CorpNameLabel.Text = "Corporation Name";
+            this.CorpNameLabel.Text = resources.GetString("this.CorpNameLabel.Text");
             // 
             // contextMenuStrip
             // 
@@ -180,7 +180,7 @@
             // 
             this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
             this.showInBrowserMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showInBrowserMenuItem.Text = "Show In Browser...";
+            this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
             this.showInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // KillReportAttacker

--- a/src/EVEMon/Controls/KillReportAttacker.resx
+++ b/src/EVEMon/Controls/KillReportAttacker.resx
@@ -207,4 +207,19 @@
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="this.DamageDoneLabel.Text" xml:space="preserve">
+    <value>{0:N0} ({1:P1})</value>
+  </data>
+  <data name="this.CharacterNameLabel.Text" xml:space="preserve">
+    <value>Character Name</value>
+  </data>
+  <data name="this.AllianceNameLabel.Text" xml:space="preserve">
+    <value>Alliance Name</value>
+  </data>
+  <data name="this.CorpNameLabel.Text" xml:space="preserve">
+    <value>Corporation Name</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
 </root>

--- a/src/EVEMon/Controls/KillReportAttacker.zh-CN.resx
+++ b/src/EVEMon/Controls/KillReportAttacker.zh-CN.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.DamageDoneLabel.Text" xml:space="preserve">
+    <value>{0:N0} ({1:P1})</value>
+  </data>
+  <data name="this.CharacterNameLabel.Text" xml:space="preserve">
+    <value>角色名称</value>
+  </data>
+  <data name="this.AllianceNameLabel.Text" xml:space="preserve">
+    <value>联盟名称</value>
+  </data>
+  <data name="this.CorpNameLabel.Text" xml:space="preserve">
+    <value>公司名称</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/KillReportFittingContent.Designer.cs
+++ b/src/EVEMon/Controls/KillReportFittingContent.Designer.cs
@@ -102,7 +102,7 @@
             this.ToggleColorKeyPictureBox.Size = new System.Drawing.Size(16, 16);
             this.ToggleColorKeyPictureBox.TabIndex = 2;
             this.ToggleColorKeyPictureBox.TabStop = false;
-            this.toolTip.SetToolTip(this.ToggleColorKeyPictureBox, "Toggle Color Key");
+            this.toolTip.SetToolTip(this.ToggleColorKeyPictureBox, resources.GetString("this.ToggleColorKeyPictureBox.ToolTip"));
             this.ToggleColorKeyPictureBox.Click += new System.EventHandler(this.ToggleColorKeyPictureBox_Click);
             // 
             // SaveFittingButton
@@ -113,7 +113,7 @@
             this.SaveFittingButton.Name = "SaveFittingButton";
             this.SaveFittingButton.Size = new System.Drawing.Size(75, 23);
             this.SaveFittingButton.TabIndex = 1;
-            this.SaveFittingButton.Text = "Save Fitting";
+            this.SaveFittingButton.Text = resources.GetString("this.SaveFittingButton.Text");
             this.SaveFittingButton.UseVisualStyleBackColor = true;
             // 
             // FittingContentLabel
@@ -124,7 +124,7 @@
             this.FittingContentLabel.Name = "FittingContentLabel";
             this.FittingContentLabel.Size = new System.Drawing.Size(117, 16);
             this.FittingContentLabel.TabIndex = 0;
-            this.FittingContentLabel.Text = "Fitting and Content";
+            this.FittingContentLabel.Text = resources.GetString("this.FittingContentLabel.Text");
             // 
             // FooterPanel
             // 
@@ -148,7 +148,7 @@
             this.ItemsCostLabel.Name = "ItemsCostLabel";
             this.ItemsCostLabel.Size = new System.Drawing.Size(63, 16);
             this.ItemsCostLabel.TabIndex = 0;
-            this.ItemsCostLabel.Text = "Unknown";
+            this.ItemsCostLabel.Text = resources.GetString("this.ItemsCostLabel.Text");
             // 
             // EstimatedTotalLossLabel
             // 
@@ -158,7 +158,7 @@
             this.EstimatedTotalLossLabel.Name = "EstimatedTotalLossLabel";
             this.EstimatedTotalLossLabel.Size = new System.Drawing.Size(99, 16);
             this.EstimatedTotalLossLabel.TabIndex = 2;
-            this.EstimatedTotalLossLabel.Text = "Est. Total Loss:";
+            this.EstimatedTotalLossLabel.Text = resources.GetString("this.EstimatedTotalLossLabel.Text");
             // 
             // BorderPanel
             // 
@@ -184,7 +184,7 @@
             this.noItemsLabel.Name = "noItemsLabel";
             this.noItemsLabel.Size = new System.Drawing.Size(335, 447);
             this.noItemsLabel.TabIndex = 5;
-            this.noItemsLabel.Text = "No Items Found.";
+            this.noItemsLabel.Text = resources.GetString("this.noItemsLabel.Text");
             this.noItemsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // FittingContentListBox
@@ -225,7 +225,7 @@
             this.ColorKeyGroupBox.Size = new System.Drawing.Size(338, 38);
             this.ColorKeyGroupBox.TabIndex = 2;
             this.ColorKeyGroupBox.TabStop = false;
-            this.ColorKeyGroupBox.Text = "Color Keys";
+            this.ColorKeyGroupBox.Text = resources.GetString("this.ColorKeyGroupBox.Text");
             // 
             // ColorKeyGroupBoxPanel
             // 
@@ -246,7 +246,7 @@
             this.DroppedItemLabel.Name = "DroppedItemLabel";
             this.DroppedItemLabel.Size = new System.Drawing.Size(71, 19);
             this.DroppedItemLabel.TabIndex = 0;
-            this.DroppedItemLabel.Text = "Dropped Item";
+            this.DroppedItemLabel.Text = resources.GetString("this.DroppedItemLabel.Text");
             this.DroppedItemLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // DestroyedItemLabel
@@ -257,7 +257,7 @@
             this.DestroyedItemLabel.Name = "DestroyedItemLabel";
             this.DestroyedItemLabel.Size = new System.Drawing.Size(80, 19);
             this.DestroyedItemLabel.TabIndex = 1;
-            this.DestroyedItemLabel.Text = "Destroyed Item";
+            this.DestroyedItemLabel.Text = resources.GetString("this.DestroyedItemLabel.Text");
             this.DestroyedItemLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // imageList
@@ -287,7 +287,7 @@
             // 
             this.showInBrowserMenuItem.Name = "showInBrowserMenuItem";
             this.showInBrowserMenuItem.Size = new System.Drawing.Size(170, 22);
-            this.showInBrowserMenuItem.Text = "Show In Browser...";
+            this.showInBrowserMenuItem.Text = resources.GetString("this.showInBrowserMenuItem.Text");
             this.showInBrowserMenuItem.Click += new System.EventHandler(this.showInBrowserMenuItem_Click);
             // 
             // KillReportFittingContent

--- a/src/EVEMon/Controls/KillReportFittingContent.resx
+++ b/src/EVEMon/Controls/KillReportFittingContent.resx
@@ -562,4 +562,34 @@
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>210, 17</value>
   </metadata>
+  <data name="this.SaveFittingButton.Text" xml:space="preserve">
+    <value>Save Fitting</value>
+  </data>
+  <data name="this.FittingContentLabel.Text" xml:space="preserve">
+    <value>Fitting and Content</value>
+  </data>
+  <data name="this.ItemsCostLabel.Text" xml:space="preserve">
+    <value>Unknown</value>
+  </data>
+  <data name="this.EstimatedTotalLossLabel.Text" xml:space="preserve">
+    <value>Est. Total Loss:</value>
+  </data>
+  <data name="this.noItemsLabel.Text" xml:space="preserve">
+    <value>No Items Found.</value>
+  </data>
+  <data name="this.ColorKeyGroupBox.Text" xml:space="preserve">
+    <value>Color Keys</value>
+  </data>
+  <data name="this.DroppedItemLabel.Text" xml:space="preserve">
+    <value>Dropped Item</value>
+  </data>
+  <data name="this.DestroyedItemLabel.Text" xml:space="preserve">
+    <value>Destroyed Item</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
+  <data name="this.ToggleColorKeyPictureBox.ToolTip" xml:space="preserve">
+    <value>Toggle Color Key</value>
+  </data>
 </root>

--- a/src/EVEMon/Controls/KillReportFittingContent.zh-CN.resx
+++ b/src/EVEMon/Controls/KillReportFittingContent.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.SaveFittingButton.Text" xml:space="preserve">
+    <value>保存配件</value>
+  </data>
+  <data name="this.FittingContentLabel.Text" xml:space="preserve">
+    <value>装修及内容</value>
+  </data>
+  <data name="this.ItemsCostLabel.Text" xml:space="preserve">
+    <value>未知</value>
+  </data>
+  <data name="this.EstimatedTotalLossLabel.Text" xml:space="preserve">
+    <value>预计。总损失：</value>
+  </data>
+  <data name="this.noItemsLabel.Text" xml:space="preserve">
+    <value>未找到任何项目。</value>
+  </data>
+  <data name="this.ColorKeyGroupBox.Text" xml:space="preserve">
+    <value>颜色键</value>
+  </data>
+  <data name="this.DroppedItemLabel.Text" xml:space="preserve">
+    <value>掉落物品</value>
+  </data>
+  <data name="this.DestroyedItemLabel.Text" xml:space="preserve">
+    <value>被毁坏的物品</value>
+  </data>
+  <data name="this.showInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+  <data name="this.ToggleColorKeyPictureBox.ToolTip" xml:space="preserve">
+    <value>切换颜色键</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/KillReportInvolvedParties.zh-CN.resx
+++ b/src/EVEMon/Controls/KillReportInvolvedParties.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/KillReportVictim.Designer.cs
+++ b/src/EVEMon/Controls/KillReportVictim.Designer.cs
@@ -163,7 +163,7 @@
             this.KillTimeLabel.Padding = new System.Windows.Forms.Padding(0, 3, 0, 0);
             this.KillTimeLabel.Size = new System.Drawing.Size(46, 16);
             this.KillTimeLabel.TabIndex = 5;
-            this.KillTimeLabel.Text = "Kill Time";
+            this.KillTimeLabel.Text = resources.GetString("this.KillTimeLabel.Text");
             // 
             // SolarSystemFlowLayoutPanel
             // 
@@ -191,7 +191,7 @@
             this.SolarSystemLabel.Name = "SolarSystemLabel";
             this.SolarSystemLabel.Size = new System.Drawing.Size(80, 13);
             this.SolarSystemLabel.TabIndex = 0;
-            this.SolarSystemLabel.Text = "Solar System";
+            this.SolarSystemLabel.Text = resources.GetString("this.SolarSystemLabel.Text");
             // 
             // SecStatusLabel
             // 
@@ -222,7 +222,7 @@
             this.ConstelationLabel.Name = "ConstelationLabel";
             this.ConstelationLabel.Size = new System.Drawing.Size(77, 13);
             this.ConstelationLabel.TabIndex = 2;
-            this.ConstelationLabel.Text = "Constelation";
+            this.ConstelationLabel.Text = resources.GetString("this.ConstelationLabel.Text");
             // 
             // Separator2Label
             // 
@@ -243,7 +243,7 @@
             this.RegionLabel.Name = "RegionLabel";
             this.RegionLabel.Size = new System.Drawing.Size(47, 13);
             this.RegionLabel.TabIndex = 5;
-            this.RegionLabel.Text = "Region";
+            this.RegionLabel.Text = resources.GetString("this.RegionLabel.Text");
             // 
             // CorpAllianceFlowLayoutPanel
             // 
@@ -266,7 +266,7 @@
             this.CorpNameLabel.Name = "CorpNameLabel";
             this.CorpNameLabel.Size = new System.Drawing.Size(108, 13);
             this.CorpNameLabel.TabIndex = 4;
-            this.CorpNameLabel.Text = "Corporation Name";
+            this.CorpNameLabel.Text = resources.GetString("this.CorpNameLabel.Text");
             // 
             // AllianceNameLabel
             // 
@@ -276,7 +276,7 @@
             this.AllianceNameLabel.Name = "AllianceNameLabel";
             this.AllianceNameLabel.Size = new System.Drawing.Size(88, 13);
             this.AllianceNameLabel.TabIndex = 5;
-            this.AllianceNameLabel.Text = "Alliance Name";
+            this.AllianceNameLabel.Text = resources.GetString("this.AllianceNameLabel.Text");
             // 
             // ShipNameGroupFlowLayoutPanel
             // 
@@ -300,7 +300,7 @@
             this.ShipNameLabel.Name = "ShipNameLabel";
             this.ShipNameLabel.Size = new System.Drawing.Size(68, 13);
             this.ShipNameLabel.TabIndex = 3;
-            this.ShipNameLabel.Text = "Ship Name";
+            this.ShipNameLabel.Text = resources.GetString("this.ShipNameLabel.Text");
             // 
             // ShipGroupLabel
             // 
@@ -332,7 +332,7 @@
             this.CopyPictureBox.Size = new System.Drawing.Size(16, 16);
             this.CopyPictureBox.TabIndex = 1;
             this.CopyPictureBox.TabStop = false;
-            this.toolTip.SetToolTip(this.CopyPictureBox, "Copy Kill Information to Clipboard");
+            this.toolTip.SetToolTip(this.CopyPictureBox, resources.GetString("this.CopyPictureBox.ToolTip"));
             this.CopyPictureBox.Click += new System.EventHandler(this.CopyPictureBox_Click);
             // 
             // CharacterNameLabel
@@ -344,7 +344,7 @@
             this.CharacterNameLabel.Name = "CharacterNameLabel";
             this.CharacterNameLabel.Size = new System.Drawing.Size(146, 20);
             this.CharacterNameLabel.TabIndex = 0;
-            this.CharacterNameLabel.Text = "Character Name";
+            this.CharacterNameLabel.Text = resources.GetString("this.CharacterNameLabel.Text");
             // 
             // contextMenuStrip
             // 
@@ -357,7 +357,7 @@
             // 
             this.showInShipBrowserMenuItem.Name = "showInShipBrowserMenuItem";
             this.showInShipBrowserMenuItem.Size = new System.Drawing.Size(196, 22);
-            this.showInShipBrowserMenuItem.Text = "Show In Ship Browser...";
+            this.showInShipBrowserMenuItem.Text = resources.GetString("this.showInShipBrowserMenuItem.Text");
             this.showInShipBrowserMenuItem.Click += new System.EventHandler(this.showInShipBrowserMenuItem_Click);
             // 
             // KillReportVictim

--- a/src/EVEMon/Controls/KillReportVictim.resx
+++ b/src/EVEMon/Controls/KillReportVictim.resx
@@ -401,4 +401,34 @@
   <metadata name="contextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>107, 17</value>
   </metadata>
+  <data name="this.KillTimeLabel.Text" xml:space="preserve">
+    <value>Kill Time</value>
+  </data>
+  <data name="this.SolarSystemLabel.Text" xml:space="preserve">
+    <value>Solar System</value>
+  </data>
+  <data name="this.ConstelationLabel.Text" xml:space="preserve">
+    <value>Constelation</value>
+  </data>
+  <data name="this.RegionLabel.Text" xml:space="preserve">
+    <value>Region</value>
+  </data>
+  <data name="this.CorpNameLabel.Text" xml:space="preserve">
+    <value>Corporation Name</value>
+  </data>
+  <data name="this.AllianceNameLabel.Text" xml:space="preserve">
+    <value>Alliance Name</value>
+  </data>
+  <data name="this.ShipNameLabel.Text" xml:space="preserve">
+    <value>Ship Name</value>
+  </data>
+  <data name="this.CharacterNameLabel.Text" xml:space="preserve">
+    <value>Character Name</value>
+  </data>
+  <data name="this.showInShipBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Ship Browser...</value>
+  </data>
+  <data name="this.CopyPictureBox.ToolTip" xml:space="preserve">
+    <value>Copy Kill Information to Clipboard</value>
+  </data>
 </root>

--- a/src/EVEMon/Controls/KillReportVictim.zh-CN.resx
+++ b/src/EVEMon/Controls/KillReportVictim.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.KillTimeLabel.Text" xml:space="preserve">
+    <value>消磨时间</value>
+  </data>
+  <data name="this.SolarSystemLabel.Text" xml:space="preserve">
+    <value>太阳能系统</value>
+  </data>
+  <data name="this.ConstelationLabel.Text" xml:space="preserve">
+    <value>星座</value>
+  </data>
+  <data name="this.RegionLabel.Text" xml:space="preserve">
+    <value>地区</value>
+  </data>
+  <data name="this.CorpNameLabel.Text" xml:space="preserve">
+    <value>公司名称</value>
+  </data>
+  <data name="this.AllianceNameLabel.Text" xml:space="preserve">
+    <value>联盟名称</value>
+  </data>
+  <data name="this.ShipNameLabel.Text" xml:space="preserve">
+    <value>船名</value>
+  </data>
+  <data name="this.CharacterNameLabel.Text" xml:space="preserve">
+    <value>角色名称</value>
+  </data>
+  <data name="this.showInShipBrowserMenuItem.Text" xml:space="preserve">
+    <value>在船舶浏览器中显示...</value>
+  </data>
+  <data name="this.CopyPictureBox.ToolTip" xml:space="preserve">
+    <value>将杀死信息复制到剪贴板</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/NotificationList.zh-CN.resx
+++ b/src/EVEMon/Controls/NotificationList.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/Overview.zh-CN.resx
+++ b/src/EVEMon/Controls/Overview.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/OverviewItem.zh-CN.resx
+++ b/src/EVEMon/Controls/OverviewItem.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Controls/ReadingPane.zh-CN.resx
+++ b/src/EVEMon/Controls/ReadingPane.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/DetailsWindow/ContractDetailsWindow.Designer.cs
+++ b/src/EVEMon/DetailsWindow/ContractDetailsWindow.Designer.cs
@@ -64,7 +64,7 @@ namespace EVEMon.DetailsWindow
             this.BidsButton.Name = "BidsButton";
             this.BidsButton.Size = new System.Drawing.Size(95, 23);
             this.BidsButton.TabIndex = 1;
-            this.BidsButton.Text = "Show Bids";
+            this.BidsButton.Text = resources.GetString("this.BidsButton.Text");
             this.BidsButton.UseVisualStyleBackColor = true;
             this.BidsButton.Click += new System.EventHandler(this.BidsButton_Click);
             // 
@@ -124,7 +124,7 @@ namespace EVEMon.DetailsWindow
             this.CurrentToStartLinkLabel.Size = new System.Drawing.Size(59, 17);
             this.CurrentToStartLinkLabel.TabIndex = 9;
             this.CurrentToStartLinkLabel.TabStop = true;
-            this.CurrentToStartLinkLabel.Text = "show route";
+            this.CurrentToStartLinkLabel.Text = resources.GetString("this.CurrentToStartLinkLabel.Text");
             this.CurrentToStartLinkLabel.UseCompatibleTextRendering = true;
             this.CurrentToStartLinkLabel.Visible = false;
             this.CurrentToStartLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.CurrentToStartLinkLabel_LinkClicked);
@@ -138,7 +138,7 @@ namespace EVEMon.DetailsWindow
             this.CurrentToEndLinkLabel.Size = new System.Drawing.Size(59, 17);
             this.CurrentToEndLinkLabel.TabIndex = 10;
             this.CurrentToEndLinkLabel.TabStop = true;
-            this.CurrentToEndLinkLabel.Text = "show route";
+            this.CurrentToEndLinkLabel.Text = resources.GetString("this.CurrentToEndLinkLabel.Text");
             this.CurrentToEndLinkLabel.UseCompatibleTextRendering = true;
             this.CurrentToEndLinkLabel.Visible = false;
             this.CurrentToEndLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.CurrentToEndLinkLabel_LinkClicked);
@@ -152,7 +152,7 @@ namespace EVEMon.DetailsWindow
             this.StartToEndLinkLabel.Size = new System.Drawing.Size(59, 17);
             this.StartToEndLinkLabel.TabIndex = 11;
             this.StartToEndLinkLabel.TabStop = true;
-            this.StartToEndLinkLabel.Text = "show route";
+            this.StartToEndLinkLabel.Text = resources.GetString("this.StartToEndLinkLabel.Text");
             this.StartToEndLinkLabel.UseCompatibleTextRendering = true;
             this.StartToEndLinkLabel.Visible = false;
             this.StartToEndLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.StartToEndLinkLabel_LinkClicked);
@@ -184,7 +184,7 @@ namespace EVEMon.DetailsWindow
             this.MaximumSize = new System.Drawing.Size(480, 1280);
             this.MinimumSize = new System.Drawing.Size(480, 465);
             this.Name = "ContractDetailsWindow";
-            this.Text = "Contract Details";
+            this.Text = resources.GetString("this.Text");
             this.ButtonPanel.ResumeLayout(false);
             this.RoutePanelParent.ResumeLayout(false);
             this.ResumeLayout(false);

--- a/src/EVEMon/DetailsWindow/ContractDetailsWindow.resx
+++ b/src/EVEMon/DetailsWindow/ContractDetailsWindow.resx
@@ -979,4 +979,19 @@
   <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>252, 17</value>
   </metadata>
+  <data name="this.BidsButton.Text" xml:space="preserve">
+    <value>Show Bids</value>
+  </data>
+  <data name="this.CurrentToStartLinkLabel.Text" xml:space="preserve">
+    <value>show route</value>
+  </data>
+  <data name="this.CurrentToEndLinkLabel.Text" xml:space="preserve">
+    <value>show route</value>
+  </data>
+  <data name="this.StartToEndLinkLabel.Text" xml:space="preserve">
+    <value>show route</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Contract Details</value>
+  </data>
 </root>

--- a/src/EVEMon/DetailsWindow/ContractDetailsWindow.zh-CN.resx
+++ b/src/EVEMon/DetailsWindow/ContractDetailsWindow.zh-CN.resx
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.BidsButton.Text" xml:space="preserve">
+    <value>显示出价</value>
+  </data>
+  <data name="this.CurrentToStartLinkLabel.Text" xml:space="preserve">
+    <value>显示路线</value>
+  </data>
+  <data name="this.CurrentToEndLinkLabel.Text" xml:space="preserve">
+    <value>显示路线</value>
+  </data>
+  <data name="this.StartToEndLinkLabel.Text" xml:space="preserve">
+    <value>显示路线</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>合约详情</value>
+  </data>
+</root>

--- a/src/EVEMon/DetailsWindow/EveMessageWindow.zh-CN.resx
+++ b/src/EVEMon/DetailsWindow/EveMessageWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/DetailsWindow/KillReportWindow.zh-CN.resx
+++ b/src/EVEMon/DetailsWindow/KillReportWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/DetailsWindow/WalletJournalChartWindow.zh-CN.resx
+++ b/src/EVEMon/DetailsWindow/WalletJournalChartWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.Designer.cs
+++ b/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.Designer.cs
@@ -146,7 +146,7 @@ namespace EVEMon.ExceptionHandling
             this.ReportLinkLabel.Size = new System.Drawing.Size(515, 30);
             this.ReportLinkLabel.TabIndex = 8;
             this.ReportLinkLabel.TabStop = true;
-            this.ReportLinkLabel.Text = "If none of that worked, please report the problem\r\n";
+            this.ReportLinkLabel.Text = resources.GetString("this.ReportLinkLabel.Text");
             this.ReportLinkLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.ReportLinkLabel.UseCompatibleTextRendering = true;
             this.ReportLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.llblReport_LinkClicked);
@@ -199,7 +199,7 @@ namespace EVEMon.ExceptionHandling
             this.WhatCanYouDoLabel.Name = "WhatCanYouDoLabel";
             this.WhatCanYouDoLabel.Size = new System.Drawing.Size(98, 13);
             this.WhatCanYouDoLabel.TabIndex = 9;
-            this.WhatCanYouDoLabel.Text = "What can you do ?";
+            this.WhatCanYouDoLabel.Text = resources.GetString("this.WhatCanYouDoLabel.Text");
             // 
             // CopyDetailsLinkLabel
             // 
@@ -210,7 +210,7 @@ namespace EVEMon.ExceptionHandling
             this.CopyDetailsLinkLabel.Size = new System.Drawing.Size(64, 13);
             this.CopyDetailsLinkLabel.TabIndex = 6;
             this.CopyDetailsLinkLabel.TabStop = true;
-            this.CopyDetailsLinkLabel.Text = "Copy details";
+            this.CopyDetailsLinkLabel.Text = resources.GetString("this.CopyDetailsLinkLabel.Text");
             this.CopyDetailsLinkLabel.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.CopyDetailsLinkLabel_LinkClicked);
             // 
             // TitleLabel
@@ -220,7 +220,7 @@ namespace EVEMon.ExceptionHandling
             this.TitleLabel.Name = "TitleLabel";
             this.TitleLabel.Size = new System.Drawing.Size(233, 13);
             this.TitleLabel.TabIndex = 0;
-            this.TitleLabel.Text = "EVEMon has encountered an unexpected error.";
+            this.TitleLabel.Text = resources.GetString("this.TitleLabel.Text");
             // 
             // TechnicalDetailsLabel
             // 
@@ -229,7 +229,7 @@ namespace EVEMon.ExceptionHandling
             this.TechnicalDetailsLabel.Name = "TechnicalDetailsLabel";
             this.TechnicalDetailsLabel.Size = new System.Drawing.Size(145, 13);
             this.TechnicalDetailsLabel.TabIndex = 2;
-            this.TechnicalDetailsLabel.Text = "Technical details of this error:";
+            this.TechnicalDetailsLabel.Text = resources.GetString("this.TechnicalDetailsLabel.Text");
             // 
             // DataDirectoryButton
             // 
@@ -239,7 +239,7 @@ namespace EVEMon.ExceptionHandling
             this.DataDirectoryButton.Name = "DataDirectoryButton";
             this.DataDirectoryButton.Size = new System.Drawing.Size(106, 23);
             this.DataDirectoryButton.TabIndex = 4;
-            this.DataDirectoryButton.Text = "Data Directory";
+            this.DataDirectoryButton.Text = resources.GetString("this.DataDirectoryButton.Text");
             this.DataDirectoryButton.UseVisualStyleBackColor = true;
             this.DataDirectoryButton.Click += new System.EventHandler(this.DataDirectoryButton_Click);
             // 
@@ -251,7 +251,7 @@ namespace EVEMon.ExceptionHandling
             this.CloseButton.Name = "CloseButton";
             this.CloseButton.Size = new System.Drawing.Size(106, 23);
             this.CloseButton.TabIndex = 5;
-            this.CloseButton.Text = "Close EVEMon";
+            this.CloseButton.Text = resources.GetString("this.CloseButton.Text");
             this.CloseButton.UseVisualStyleBackColor = true;
             this.CloseButton.Click += new System.EventHandler(this.CloseButton_Click);
             // 
@@ -270,7 +270,7 @@ namespace EVEMon.ExceptionHandling
             this.MinimizeBox = false;
             this.Name = "UnhandledExceptionWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "EVEMon Error";
+            this.Text = resources.GetString("this.Text");
             this.Load += new System.EventHandler(this.UnhandledExceptionWindow_Load);
             this.MainPanel.ResumeLayout(false);
             this.MainPanel.PerformLayout();

--- a/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.resx
+++ b/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.resx
@@ -155,4 +155,29 @@ go to EVEMon's data directory (by clicking on the related button below) and dele
         DyJn8xIVAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.ReportLinkLabel.Text" xml:space="preserve">
+    <value>If none of that worked, please report the problem
+</value>
+  </data>
+  <data name="this.WhatCanYouDoLabel.Text" xml:space="preserve">
+    <value>What can you do ?</value>
+  </data>
+  <data name="this.CopyDetailsLinkLabel.Text" xml:space="preserve">
+    <value>Copy details</value>
+  </data>
+  <data name="this.TitleLabel.Text" xml:space="preserve">
+    <value>EVEMon has encountered an unexpected error.</value>
+  </data>
+  <data name="this.TechnicalDetailsLabel.Text" xml:space="preserve">
+    <value>Technical details of this error:</value>
+  </data>
+  <data name="this.DataDirectoryButton.Text" xml:space="preserve">
+    <value>Data Directory</value>
+  </data>
+  <data name="this.CloseButton.Text" xml:space="preserve">
+    <value>Close EVEMon</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>EVEMon Error</value>
+  </data>
 </root>

--- a/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.zh-CN.resx
+++ b/src/EVEMon/ExceptionHandling/UnhandledExceptionWindow.zh-CN.resx
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="LatestBinariesLinkLabel.Text" xml:space="preserve">
+    <value>使用最新的快照二进制文件（测试版），因为问题可能已经解决或 
+转到 EVEMon 的数据目录（通过单击下面的相关按钮）并删除您的设置文件 
+（备份后），缓存文件夹和数据文件（*.gzip），看看问题是否仍然存在。</value>
+  </data>
+  <data name="this.ReportLinkLabel.Text" xml:space="preserve">
+    <value>如果这些都不起作用，请报告问题
+</value>
+  </data>
+  <data name="this.WhatCanYouDoLabel.Text" xml:space="preserve">
+    <value>你能做什么？</value>
+  </data>
+  <data name="this.CopyDetailsLinkLabel.Text" xml:space="preserve">
+    <value>复制详细信息</value>
+  </data>
+  <data name="this.TitleLabel.Text" xml:space="preserve">
+    <value>EVEMon 遇到意外错误。</value>
+  </data>
+  <data name="this.TechnicalDetailsLabel.Text" xml:space="preserve">
+    <value>此错误的技术细节：</value>
+  </data>
+  <data name="this.DataDirectoryButton.Text" xml:space="preserve">
+    <value>数据目录</value>
+  </data>
+  <data name="this.CloseButton.Text" xml:space="preserve">
+    <value>关闭 EVEMon</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>EVEMon错误</value>
+  </data>
+</root>

--- a/src/EVEMon/ImplantControls/ImplantSetsWindow.zh-CN.resx
+++ b/src/EVEMon/ImplantControls/ImplantSetsWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/ImplantControls/ImplantTooltip.zh-CN.resx
+++ b/src/EVEMon/ImplantControls/ImplantTooltip.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/MainWindow.Designer.cs
+++ b/src/EVEMon/MainWindow.Designer.cs
@@ -173,7 +173,7 @@ namespace EVEMon
 			// 
 			this.planToolStripMenuItem.Name = "planToolStripMenuItem";
 			this.planToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.planToolStripMenuItem.Text = "Plans";
+			this.planToolStripMenuItem.Text = resources.GetString("this.planToolStripMenuItem.Text");
 			// 
 			// plansStripSeparator
 			// 
@@ -187,21 +187,21 @@ namespace EVEMon
             this.trayTestCharacterNotificationTSMI});
 			this.testTrayToolStripMenuItem.Name = "testTrayToolStripMenuItem";
 			this.testTrayToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.testTrayToolStripMenuItem.Text = "Test";
+			this.testTrayToolStripMenuItem.Text = resources.GetString("this.testTrayToolStripMenuItem.Text");
 			this.testTrayToolStripMenuItem.Visible = false;
 			// 
 			// trayTestNotificationTSMI
 			// 
 			this.trayTestNotificationTSMI.Name = "trayTestNotificationTSMI";
 			this.trayTestNotificationTSMI.Size = new System.Drawing.Size(191, 22);
-			this.trayTestNotificationTSMI.Text = "Notification";
+			this.trayTestNotificationTSMI.Text = resources.GetString("this.trayTestNotificationTSMI.Text");
 			this.trayTestNotificationTSMI.Click += new System.EventHandler(this.testNotificationToolstripMenuItem_Click);
 			// 
 			// trayTestCharacterNotificationTSMI
 			// 
 			this.trayTestCharacterNotificationTSMI.Name = "trayTestCharacterNotificationTSMI";
 			this.trayTestCharacterNotificationTSMI.Size = new System.Drawing.Size(191, 22);
-			this.trayTestCharacterNotificationTSMI.Text = "Character Notification";
+			this.trayTestCharacterNotificationTSMI.Text = resources.GetString("this.trayTestCharacterNotificationTSMI.Text");
 			this.trayTestCharacterNotificationTSMI.Click += new System.EventHandler(this.testCharacterNotificationToolStripMenuItem_Click);
 			// 
 			// testsToolStripSeperator
@@ -214,14 +214,14 @@ namespace EVEMon
 			// 
 			this.restoreToolStripMenuItem.Name = "restoreToolStripMenuItem";
 			this.restoreToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.restoreToolStripMenuItem.Text = "Restore";
+			this.restoreToolStripMenuItem.Text = resources.GetString("this.restoreToolStripMenuItem.Text");
 			this.restoreToolStripMenuItem.Click += new System.EventHandler(this.restoreToolStripMenuItem_Click);
 			// 
 			// closeToolStripMenuItem
 			// 
 			this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
 			this.closeToolStripMenuItem.Size = new System.Drawing.Size(113, 22);
-			this.closeToolStripMenuItem.Text = "Close";
+			this.closeToolStripMenuItem.Text = resources.GetString("this.closeToolStripMenuItem.Text");
 			this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
 			// 
 			// statusStrip
@@ -245,19 +245,19 @@ namespace EVEMon
 			this.lblTraining.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
 			this.lblTraining.Name = "lblTraining";
 			this.lblTraining.Size = new System.Drawing.Size(0, 17);
-			this.lblTraining.Text = "toolStripStatusLabel1";
+			this.lblTraining.Text = resources.GetString("this.lblTraining.Text");
 			// 
 			// lblStatus
 			// 
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(59, 17);
-			this.lblStatus.Text = "EVE Time:";
+			this.lblStatus.Text = resources.GetString("this.lblStatus.Text");
 			// 
 			// lblServerStatus
 			// 
 			this.lblServerStatus.Name = "lblServerStatus";
 			this.lblServerStatus.Size = new System.Drawing.Size(137, 17);
-			this.lblServerStatus.Text = "|  Server Status Unknown";
+			this.lblServerStatus.Text = resources.GetString("this.lblServerStatus.Text");
 			// 
 			// toolStripStatusSpacerLabel
 			// 
@@ -269,7 +269,7 @@ namespace EVEMon
 			// 
 			this.lblCSSProviderStatus.Name = "lblCSSProviderStatus";
 			this.lblCSSProviderStatus.Size = new System.Drawing.Size(143, 17);
-			this.lblCSSProviderStatus.Text = "Uploading to CSSProvider";
+			this.lblCSSProviderStatus.Text = resources.GetString("this.lblCSSProviderStatus.Text");
 			this.lblCSSProviderStatus.Visible = false;
 			// 
 			// tsDatafilesLoadingProgressBar
@@ -278,24 +278,24 @@ namespace EVEMon
 			this.tsDatafilesLoadingProgressBar.Name = "tsDatafilesLoadingProgressBar";
 			this.tsDatafilesLoadingProgressBar.Size = new System.Drawing.Size(100, 16);
 			this.tsDatafilesLoadingProgressBar.Style = System.Windows.Forms.ProgressBarStyle.Continuous;
-			this.tsDatafilesLoadingProgressBar.ToolTipText = "Loading data files";
+			this.tsDatafilesLoadingProgressBar.ToolTipText = resources.GetString("this.tsDatafilesLoadingProgressBar.ToolTipText");
 			// 
 			// saveFileDialog
 			// 
 			this.saveFileDialog.DefaultExt = "bak";
 			this.saveFileDialog.FileName = "settings.xml.bak";
-			this.saveFileDialog.Filter = "EVEMon Settings Backup Files (*.bak)|*.bak";
+			this.saveFileDialog.Filter = resources.GetString("this.saveFileDialog.Filter");
 			this.saveFileDialog.RestoreDirectory = true;
-			this.saveFileDialog.Title = "Backup EVEMon settings file";
+			this.saveFileDialog.Title = resources.GetString("this.saveFileDialog.Title");
 			// 
 			// openFileDialog
 			// 
 			this.openFileDialog.DefaultExt = "bak";
 			this.openFileDialog.FileName = "settings.xml.bak";
-			this.openFileDialog.Filter = "EVEMon Settings Backup Files (*.bak)|*.bak";
+			this.openFileDialog.Filter = resources.GetString("this.openFileDialog.Filter");
 			this.openFileDialog.RestoreDirectory = true;
 			this.openFileDialog.ShowHelp = true;
-			this.openFileDialog.Title = "Restore EVEMon settings file";
+			this.openFileDialog.Title = resources.GetString("this.openFileDialog.Title");
 			// 
 			// mainMenuBar
 			// 
@@ -313,7 +313,7 @@ namespace EVEMon
 			this.mainMenuBar.Name = "mainMenuBar";
 			this.mainMenuBar.Size = new System.Drawing.Size(600, 24);
 			this.mainMenuBar.TabIndex = 3;
-			this.mainMenuBar.Text = "menuStrip1";
+			this.mainMenuBar.Text = resources.GetString("this.mainMenuBar.Text");
 			this.mainMenuBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.mainMenuBar_MouseDown);
 			this.mainMenuBar.MouseMove += new System.Windows.Forms.MouseEventHandler(this.mainMenuBar_MouseMove);
 			// 
@@ -331,14 +331,14 @@ namespace EVEMon
 			// 
 			this.menubarToolStripMenuItem.Name = "menubarToolStripMenuItem";
 			this.menubarToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
-			this.menubarToolStripMenuItem.Text = "&Menubar";
+			this.menubarToolStripMenuItem.Text = resources.GetString("this.menubarToolStripMenuItem.Text");
 			this.menubarToolStripMenuItem.Click += new System.EventHandler(this.menubarToolStripMenuItem_Click);
 			// 
 			// toolbarToolStripMenuItem
 			// 
 			this.toolbarToolStripMenuItem.Name = "toolbarToolStripMenuItem";
 			this.toolbarToolStripMenuItem.Size = new System.Drawing.Size(122, 22);
-			this.toolbarToolStripMenuItem.Text = "&Toolbar";
+			this.toolbarToolStripMenuItem.Text = resources.GetString("this.toolbarToolStripMenuItem.Text");
 			this.toolbarToolStripMenuItem.Click += new System.EventHandler(this.toolbarToolStripMenuItem_Click);
 			// 
 			// fileToolStripMenuItem
@@ -360,14 +360,14 @@ namespace EVEMon
             this.exitToolStripMenuItem});
 			this.fileToolStripMenuItem.Name = "fileToolStripMenuItem";
 			this.fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
-			this.fileToolStripMenuItem.Text = "&File";
+			this.fileToolStripMenuItem.Text = resources.GetString("this.fileToolStripMenuItem.Text");
 			// 
 			// addAPIKeyMenu
 			// 
 			this.addAPIKeyMenu.Image = ((System.Drawing.Image)(resources.GetObject("addAPIKeyMenu.Image")));
 			this.addAPIKeyMenu.Name = "addAPIKeyMenu";
 			this.addAPIKeyMenu.Size = new System.Drawing.Size(185, 22);
-			this.addAPIKeyMenu.Text = "&Add Character...";
+			this.addAPIKeyMenu.Text = resources.GetString("this.addAPIKeyMenu.Text");
 			this.addAPIKeyMenu.Click += new System.EventHandler(this.addAPIKeyMenu_Click);
 			// 
 			// manageAPIKeysMenuItem
@@ -375,7 +375,7 @@ namespace EVEMon
 			this.manageAPIKeysMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("manageAPIKeysMenuItem.Image")));
 			this.manageAPIKeysMenuItem.Name = "manageAPIKeysMenuItem";
 			this.manageAPIKeysMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.manageAPIKeysMenuItem.Text = "&Manage Characters...";
+			this.manageAPIKeysMenuItem.Text = resources.GetString("this.manageAPIKeysMenuItem.Text");
 			this.manageAPIKeysMenuItem.Click += new System.EventHandler(this.manageAPIKeysMenuItem_Click);
 			// 
 			// fileManagerHideToolStripSeparator
@@ -388,7 +388,7 @@ namespace EVEMon
 			this.deleteCharacterMenu.Image = ((System.Drawing.Image)(resources.GetObject("deleteCharacterMenu.Image")));
 			this.deleteCharacterMenu.Name = "deleteCharacterMenu";
 			this.deleteCharacterMenu.Size = new System.Drawing.Size(185, 22);
-			this.deleteCharacterMenu.Text = "&Delete Character...";
+			this.deleteCharacterMenu.Text = resources.GetString("this.deleteCharacterMenu.Text");
 			this.deleteCharacterMenu.Click += new System.EventHandler(this.deleteCharacterMenu_Click);
 			// 
 			// exportCharacterMenu
@@ -396,7 +396,7 @@ namespace EVEMon
 			this.exportCharacterMenu.Image = ((System.Drawing.Image)(resources.GetObject("exportCharacterMenu.Image")));
 			this.exportCharacterMenu.Name = "exportCharacterMenu";
 			this.exportCharacterMenu.Size = new System.Drawing.Size(185, 22);
-			this.exportCharacterMenu.Text = "&Export Character...";
+			this.exportCharacterMenu.Text = resources.GetString("this.exportCharacterMenu.Text");
 			this.exportCharacterMenu.Click += new System.EventHandler(this.saveCharacterInfosMenuItem_Click);
 			// 
 			// hideCharacterMenu
@@ -404,7 +404,7 @@ namespace EVEMon
 			this.hideCharacterMenu.Image = ((System.Drawing.Image)(resources.GetObject("hideCharacterMenu.Image")));
 			this.hideCharacterMenu.Name = "hideCharacterMenu";
 			this.hideCharacterMenu.Size = new System.Drawing.Size(185, 22);
-			this.hideCharacterMenu.Text = "&Hide Character";
+			this.hideCharacterMenu.Text = resources.GetString("this.hideCharacterMenu.Text");
 			this.hideCharacterMenu.Click += new System.EventHandler(this.hideCharacterMenu_Click);
 			// 
 			// fileExportSaveToolStripSeparator
@@ -417,7 +417,7 @@ namespace EVEMon
 			this.loadSettingsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("loadSettingsToolStripMenuItem.Image")));
 			this.loadSettingsToolStripMenuItem.Name = "loadSettingsToolStripMenuItem";
 			this.loadSettingsToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.loadSettingsToolStripMenuItem.Text = "R&estore Settings...";
+			this.loadSettingsToolStripMenuItem.Text = resources.GetString("this.loadSettingsToolStripMenuItem.Text");
 			this.loadSettingsToolStripMenuItem.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
 			// 
 			// saveSettingsToolStripMenuItem
@@ -425,7 +425,7 @@ namespace EVEMon
 			this.saveSettingsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("saveSettingsToolStripMenuItem.Image")));
 			this.saveSettingsToolStripMenuItem.Name = "saveSettingsToolStripMenuItem";
 			this.saveSettingsToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.saveSettingsToolStripMenuItem.Text = "Sa&ve Settings...";
+			this.saveSettingsToolStripMenuItem.Text = resources.GetString("this.saveSettingsToolStripMenuItem.Text");
 			this.saveSettingsToolStripMenuItem.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
 			// 
 			// resetSettingsToolStripMenuItem
@@ -433,7 +433,7 @@ namespace EVEMon
 			this.resetSettingsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("resetSettingsToolStripMenuItem.Image")));
 			this.resetSettingsToolStripMenuItem.Name = "resetSettingsToolStripMenuItem";
 			this.resetSettingsToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.resetSettingsToolStripMenuItem.Text = "&Reset Settings";
+			this.resetSettingsToolStripMenuItem.Text = resources.GetString("this.resetSettingsToolStripMenuItem.Text");
 			this.resetSettingsToolStripMenuItem.Click += new System.EventHandler(this.resetSettingsToolStripMenuItem_Click);
 			// 
 			// fileRestoreResetToolStripSeparator
@@ -446,7 +446,7 @@ namespace EVEMon
 			this.clearCacheToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("clearCacheToolStripMenuItem.Image")));
 			this.clearCacheToolStripMenuItem.Name = "clearCacheToolStripMenuItem";
 			this.clearCacheToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.clearCacheToolStripMenuItem.Text = "&Clear Cache";
+			this.clearCacheToolStripMenuItem.Text = resources.GetString("this.clearCacheToolStripMenuItem.Text");
 			this.clearCacheToolStripMenuItem.Click += new System.EventHandler(this.clearCacheToolStripMenuItem_Click);
 			// 
 			// fileResetExitToolStripSeparator
@@ -459,7 +459,7 @@ namespace EVEMon
 			this.exitToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("exitToolStripMenuItem.Image")));
 			this.exitToolStripMenuItem.Name = "exitToolStripMenuItem";
 			this.exitToolStripMenuItem.Size = new System.Drawing.Size(185, 22);
-			this.exitToolStripMenuItem.Text = "E&xit";
+			this.exitToolStripMenuItem.Text = resources.GetString("this.exitToolStripMenuItem.Text");
 			this.exitToolStripMenuItem.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
 			// 
 			// editToolStripMenuItem
@@ -468,7 +468,7 @@ namespace EVEMon
             this.copySkillsToClipboardBBFormatToolStripMenuItem});
 			this.editToolStripMenuItem.Name = "editToolStripMenuItem";
 			this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 20);
-			this.editToolStripMenuItem.Text = "&Edit";
+			this.editToolStripMenuItem.Text = resources.GetString("this.editToolStripMenuItem.Text");
 			this.editToolStripMenuItem.DropDownOpening += new System.EventHandler(this.editToolStripMenuItem_DropDownOpening);
 			// 
 			// copySkillsToClipboardBBFormatToolStripMenuItem
@@ -476,7 +476,7 @@ namespace EVEMon
 			this.copySkillsToClipboardBBFormatToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("copySkillsToClipboardBBFormatToolStripMenuItem.Image")));
 			this.copySkillsToClipboardBBFormatToolStripMenuItem.Name = "copySkillsToClipboardBBFormatToolStripMenuItem";
 			this.copySkillsToClipboardBBFormatToolStripMenuItem.Size = new System.Drawing.Size(266, 22);
-			this.copySkillsToClipboardBBFormatToolStripMenuItem.Text = "&Copy Skills to Clipboard (BB Format)";
+			this.copySkillsToClipboardBBFormatToolStripMenuItem.Text = resources.GetString("this.copySkillsToClipboardBBFormatToolStripMenuItem.Text");
 			this.copySkillsToClipboardBBFormatToolStripMenuItem.Click += new System.EventHandler(this.copySkillsToClipboardBBFormatToolStripMenuItem_Click);
 			// 
 			// plansToolStripMenuItem
@@ -489,7 +489,7 @@ namespace EVEMon
             this.plansSeparator});
 			this.plansToolStripMenuItem.Name = "plansToolStripMenuItem";
 			this.plansToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
-			this.plansToolStripMenuItem.Text = "&Plans";
+			this.plansToolStripMenuItem.Text = resources.GetString("this.plansToolStripMenuItem.Text");
 			this.plansToolStripMenuItem.DropDownOpening += new System.EventHandler(this.plansToolStripMenuItem_DropDownOpening);
 			// 
 			// tsmiNewPlan
@@ -497,7 +497,7 @@ namespace EVEMon
 			this.tsmiNewPlan.Image = ((System.Drawing.Image)(resources.GetObject("tsmiNewPlan.Image")));
 			this.tsmiNewPlan.Name = "tsmiNewPlan";
 			this.tsmiNewPlan.Size = new System.Drawing.Size(234, 22);
-			this.tsmiNewPlan.Text = "&New Plan…";
+			this.tsmiNewPlan.Text = resources.GetString("this.tsmiNewPlan.Text");
 			this.tsmiNewPlan.Click += new System.EventHandler(this.tsmiNewPlan_Click);
 			// 
 			// tsmiCreatePlanFromSkillQueue
@@ -505,7 +505,7 @@ namespace EVEMon
 			this.tsmiCreatePlanFromSkillQueue.Image = ((System.Drawing.Image)(resources.GetObject("tsmiCreatePlanFromSkillQueue.Image")));
 			this.tsmiCreatePlanFromSkillQueue.Name = "tsmiCreatePlanFromSkillQueue";
 			this.tsmiCreatePlanFromSkillQueue.Size = new System.Drawing.Size(234, 22);
-			this.tsmiCreatePlanFromSkillQueue.Text = "Create Plan from Skill Queue...";
+			this.tsmiCreatePlanFromSkillQueue.Text = resources.GetString("this.tsmiCreatePlanFromSkillQueue.Text");
 			this.tsmiCreatePlanFromSkillQueue.Click += new System.EventHandler(this.tsmiCreatePlanFromSkillQueue_Click);
 			// 
 			// tsmiImportPlanFromFile
@@ -513,7 +513,7 @@ namespace EVEMon
 			this.tsmiImportPlanFromFile.Image = ((System.Drawing.Image)(resources.GetObject("tsmiImportPlanFromFile.Image")));
 			this.tsmiImportPlanFromFile.Name = "tsmiImportPlanFromFile";
 			this.tsmiImportPlanFromFile.Size = new System.Drawing.Size(234, 22);
-			this.tsmiImportPlanFromFile.Text = "&Import Plan from File...";
+			this.tsmiImportPlanFromFile.Text = resources.GetString("this.tsmiImportPlanFromFile.Text");
 			this.tsmiImportPlanFromFile.Click += new System.EventHandler(this.tsmiImportPlanFromFile_Click);
 			// 
 			// tsmiManagePlans
@@ -521,7 +521,7 @@ namespace EVEMon
 			this.tsmiManagePlans.Image = ((System.Drawing.Image)(resources.GetObject("tsmiManagePlans.Image")));
 			this.tsmiManagePlans.Name = "tsmiManagePlans";
 			this.tsmiManagePlans.Size = new System.Drawing.Size(234, 22);
-			this.tsmiManagePlans.Text = "&Manage Plans...";
+			this.tsmiManagePlans.Text = resources.GetString("this.tsmiManagePlans.Text");
 			this.tsmiManagePlans.Click += new System.EventHandler(this.manageToolStripMenuItem_Click);
 			// 
 			// plansSeparator
@@ -543,14 +543,14 @@ namespace EVEMon
             this.optionsToolStripMenuItem});
 			this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
 			this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 20);
-			this.toolsToolStripMenuItem.Text = "&Tools";
+			this.toolsToolStripMenuItem.Text = resources.GetString("this.toolsToolStripMenuItem.Text");
 			// 
 			// charactersComparisonMenuItem
 			// 
 			this.charactersComparisonMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("charactersComparisonMenuItem.Image")));
 			this.charactersComparisonMenuItem.Name = "charactersComparisonMenuItem";
 			this.charactersComparisonMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.charactersComparisonMenuItem.Text = "&Characters Comparison...";
+			this.charactersComparisonMenuItem.Text = resources.GetString("this.charactersComparisonMenuItem.Text");
 			this.charactersComparisonMenuItem.Click += new System.EventHandler(this.charactersComparisonToolStripMenuItem_Click);
 			// 
 			// blankCreatorToolStripMenuItem
@@ -558,7 +558,7 @@ namespace EVEMon
 			this.blankCreatorToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("blankCreatorToolStripMenuItem.Image")));
 			this.blankCreatorToolStripMenuItem.Name = "blankCreatorToolStripMenuItem";
 			this.blankCreatorToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.blankCreatorToolStripMenuItem.Text = "&Blank Character Creator...";
+			this.blankCreatorToolStripMenuItem.Text = resources.GetString("this.blankCreatorToolStripMenuItem.Text");
 			this.blankCreatorToolStripMenuItem.Click += new System.EventHandler(this.blankCreatorToolStripMenuItem_Click);
 			// 
 			// dataBrowserMenuItem
@@ -572,41 +572,41 @@ namespace EVEMon
 			this.dataBrowserMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("dataBrowserMenuItem.Image")));
 			this.dataBrowserMenuItem.Name = "dataBrowserMenuItem";
 			this.dataBrowserMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.dataBrowserMenuItem.Text = "&Data Browser";
+			this.dataBrowserMenuItem.Text = resources.GetString("this.dataBrowserMenuItem.Text");
 			// 
 			// skillBrowserMenuItem
 			// 
 			this.skillBrowserMenuItem.Name = "skillBrowserMenuItem";
 			this.skillBrowserMenuItem.Size = new System.Drawing.Size(182, 22);
-			this.skillBrowserMenuItem.Text = "&Skill Browser...";
+			this.skillBrowserMenuItem.Text = resources.GetString("this.skillBrowserMenuItem.Text");
 			this.skillBrowserMenuItem.Click += new System.EventHandler(this.skillBrowserMenuItem_Click);
 			// 
 			// certificateBrowserMenuItem
 			// 
 			this.certificateBrowserMenuItem.Name = "certificateBrowserMenuItem";
 			this.certificateBrowserMenuItem.Size = new System.Drawing.Size(182, 22);
-			this.certificateBrowserMenuItem.Text = "&Certificate Browser...";
+			this.certificateBrowserMenuItem.Text = resources.GetString("this.certificateBrowserMenuItem.Text");
 			this.certificateBrowserMenuItem.Click += new System.EventHandler(this.certificateBrowserMenuItem_Click);
 			// 
 			// shipBrowserMenuItem
 			// 
 			this.shipBrowserMenuItem.Name = "shipBrowserMenuItem";
 			this.shipBrowserMenuItem.Size = new System.Drawing.Size(182, 22);
-			this.shipBrowserMenuItem.Text = "S&hip Browser...";
+			this.shipBrowserMenuItem.Text = resources.GetString("this.shipBrowserMenuItem.Text");
 			this.shipBrowserMenuItem.Click += new System.EventHandler(this.shipBrowserMenuItem_Click);
 			// 
 			// itemBrowserMenuItem
 			// 
 			this.itemBrowserMenuItem.Name = "itemBrowserMenuItem";
 			this.itemBrowserMenuItem.Size = new System.Drawing.Size(182, 22);
-			this.itemBrowserMenuItem.Text = "&Item Browser...";
+			this.itemBrowserMenuItem.Text = resources.GetString("this.itemBrowserMenuItem.Text");
 			this.itemBrowserMenuItem.Click += new System.EventHandler(this.itemBrowserMenuItem_Click);
 			// 
 			// blueprintBrowserMenuItem
 			// 
 			this.blueprintBrowserMenuItem.Name = "blueprintBrowserMenuItem";
 			this.blueprintBrowserMenuItem.Size = new System.Drawing.Size(182, 22);
-			this.blueprintBrowserMenuItem.Text = "&Blueprint Browser...";
+			this.blueprintBrowserMenuItem.Text = resources.GetString("this.blueprintBrowserMenuItem.Text");
 			this.blueprintBrowserMenuItem.Click += new System.EventHandler(this.blueprintBrowserMenuItem_Click);
 			// 
 			// skillsPieChartMenuItem
@@ -615,7 +615,7 @@ namespace EVEMon
 			this.skillsPieChartMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.skillsPieChartMenuItem.Name = "skillsPieChartMenuItem";
 			this.skillsPieChartMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.skillsPieChartMenuItem.Text = "Skills &Pie Chart...";
+			this.skillsPieChartMenuItem.Text = resources.GetString("this.skillsPieChartMenuItem.Text");
 			this.skillsPieChartMenuItem.Click += new System.EventHandler(this.tsSkillsPieChartTool_Click);
 			// 
 			// firstSeparator
@@ -628,7 +628,7 @@ namespace EVEMon
 			this.implantsMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("implantsMenuItem.Image")));
 			this.implantsMenuItem.Name = "implantsMenuItem";
 			this.implantsMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.implantsMenuItem.Text = "&Implant Groups...";
+			this.implantsMenuItem.Text = resources.GetString("this.implantsMenuItem.Text");
 			this.implantsMenuItem.Click += new System.EventHandler(this.manualImplantGroupsToolStripMenuItem_Click);
 			// 
 			// showOwnedSkillbooksMenuItem
@@ -636,7 +636,7 @@ namespace EVEMon
 			this.showOwnedSkillbooksMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("showOwnedSkillbooksMenuItem.Image")));
 			this.showOwnedSkillbooksMenuItem.Name = "showOwnedSkillbooksMenuItem";
 			this.showOwnedSkillbooksMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.showOwnedSkillbooksMenuItem.Text = "O&wned Skillbooks...";
+			this.showOwnedSkillbooksMenuItem.Text = resources.GetString("this.showOwnedSkillbooksMenuItem.Text");
 			this.showOwnedSkillbooksMenuItem.Click += new System.EventHandler(this.tsShowOwnedSkillbooks_Click);
 			// 
 			// secondSeparator
@@ -649,7 +649,7 @@ namespace EVEMon
 			this.optionsToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("optionsToolStripMenuItem.Image")));
 			this.optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
 			this.optionsToolStripMenuItem.Size = new System.Drawing.Size(208, 22);
-			this.optionsToolStripMenuItem.Text = "&Options...";
+			this.optionsToolStripMenuItem.Text = resources.GetString("this.optionsToolStripMenuItem.Text");
 			this.optionsToolStripMenuItem.Click += new System.EventHandler(this.optionsMenuItem_Click);
 			// 
 			// helpToolStripMenuItem
@@ -662,14 +662,14 @@ namespace EVEMon
             this.aboutMenuItem});
 			this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
 			this.helpToolStripMenuItem.Size = new System.Drawing.Size(44, 20);
-			this.helpToolStripMenuItem.Text = "&Help";
+			this.helpToolStripMenuItem.Text = resources.GetString("this.helpToolStripMenuItem.Text");
 			// 
 			// forumsMenuItem
 			// 
 			this.forumsMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("forumsMenuItem.Image")));
 			this.forumsMenuItem.Name = "forumsMenuItem";
 			this.forumsMenuItem.Size = new System.Drawing.Size(224, 22);
-			this.forumsMenuItem.Text = "&Forums";
+			this.forumsMenuItem.Text = resources.GetString("this.forumsMenuItem.Text");
 			this.forumsMenuItem.Click += new System.EventHandler(this.forumsMenuItem_Click);
 			// 
 			// issuesFeaturesMenuItem
@@ -677,7 +677,7 @@ namespace EVEMon
 			this.issuesFeaturesMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("issuesFeaturesMenuItem.Image")));
 			this.issuesFeaturesMenuItem.Name = "issuesFeaturesMenuItem";
 			this.issuesFeaturesMenuItem.Size = new System.Drawing.Size(224, 22);
-			this.issuesFeaturesMenuItem.Text = "I&ssues and Features (GitHub)";
+			this.issuesFeaturesMenuItem.Text = resources.GetString("this.issuesFeaturesMenuItem.Text");
 			this.issuesFeaturesMenuItem.Click += new System.EventHandler(this.issuesFeaturesMenuItem_Click);
 			// 
 			// readTheDocsManualToolStripMenuItem
@@ -685,7 +685,7 @@ namespace EVEMon
 			this.readTheDocsManualToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("readTheDocsManualToolStripMenuItem.Image")));
 			this.readTheDocsManualToolStripMenuItem.Name = "readTheDocsManualToolStripMenuItem";
 			this.readTheDocsManualToolStripMenuItem.Size = new System.Drawing.Size(224, 22);
-			this.readTheDocsManualToolStripMenuItem.Text = "Read The Docs (Manual)";
+			this.readTheDocsManualToolStripMenuItem.Text = resources.GetString("this.readTheDocsManualToolStripMenuItem.Text");
 			this.readTheDocsManualToolStripMenuItem.Click += new System.EventHandler(this.readTheDocsManualMenuItem_Click);
 			// 
 			// helpAboutKnownProblemsToolStripSeparator
@@ -698,7 +698,7 @@ namespace EVEMon
 			this.aboutMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("aboutMenuItem.Image")));
 			this.aboutMenuItem.Name = "aboutMenuItem";
 			this.aboutMenuItem.Size = new System.Drawing.Size(224, 22);
-			this.aboutMenuItem.Text = "&About...";
+			this.aboutMenuItem.Text = resources.GetString("this.aboutMenuItem.Text");
 			this.aboutMenuItem.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
 			// 
 			// testsToolStripMenuItem
@@ -712,7 +712,7 @@ namespace EVEMon
             this.restartToolStripMenuItem});
 			this.testsToolStripMenuItem.Name = "testsToolStripMenuItem";
 			this.testsToolStripMenuItem.Size = new System.Drawing.Size(40, 20);
-			this.testsToolStripMenuItem.Text = "Te&st";
+			this.testsToolStripMenuItem.Text = resources.GetString("this.testsToolStripMenuItem.Text");
 			this.testsToolStripMenuItem.Visible = false;
 			this.testsToolStripMenuItem.DropDownOpening += new System.EventHandler(this.testToolStripMenuItem_DropDownOpening);
 			// 
@@ -720,42 +720,42 @@ namespace EVEMon
 			// 
 			this.exceptionWindowToolStripMenuItem.Name = "exceptionWindowToolStripMenuItem";
 			this.exceptionWindowToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.exceptionWindowToolStripMenuItem.Text = "Exception Window";
+			this.exceptionWindowToolStripMenuItem.Text = resources.GetString("this.exceptionWindowToolStripMenuItem.Text");
 			this.exceptionWindowToolStripMenuItem.Click += new System.EventHandler(this.ExceptionWindowToolStripMenuItem_Click);
 			// 
 			// exceptionWindowRecursiveExceptionToolStripMenuItem
 			// 
 			this.exceptionWindowRecursiveExceptionToolStripMenuItem.Name = "exceptionWindowRecursiveExceptionToolStripMenuItem";
 			this.exceptionWindowRecursiveExceptionToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.exceptionWindowRecursiveExceptionToolStripMenuItem.Text = "Exception Window (Recursive Exception)";
+			this.exceptionWindowRecursiveExceptionToolStripMenuItem.Text = resources.GetString("this.exceptionWindowRecursiveExceptionToolStripMenuItem.Text");
 			this.exceptionWindowRecursiveExceptionToolStripMenuItem.Click += new System.EventHandler(this.exceptionWindowRecursiveExceptionToolStripMenuItem_Click);
 			// 
 			// testNotificationToolStripMenuItem
 			// 
 			this.testNotificationToolStripMenuItem.Name = "testNotificationToolStripMenuItem";
 			this.testNotificationToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.testNotificationToolStripMenuItem.Text = "Notification";
+			this.testNotificationToolStripMenuItem.Text = resources.GetString("this.testNotificationToolStripMenuItem.Text");
 			this.testNotificationToolStripMenuItem.Click += new System.EventHandler(this.testNotificationToolstripMenuItem_Click);
 			// 
 			// testCharacterNotificationToolStripMenuItem
 			// 
 			this.testCharacterNotificationToolStripMenuItem.Name = "testCharacterNotificationToolStripMenuItem";
 			this.testCharacterNotificationToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.testCharacterNotificationToolStripMenuItem.Text = "Character Notification";
+			this.testCharacterNotificationToolStripMenuItem.Text = resources.GetString("this.testCharacterNotificationToolStripMenuItem.Text");
 			this.testCharacterNotificationToolStripMenuItem.Click += new System.EventHandler(this.testCharacterNotificationToolStripMenuItem_Click);
 			// 
 			// testTimeoutOneSecToolStripMenuItem
 			// 
 			this.testTimeoutOneSecToolStripMenuItem.Name = "testTimeoutOneSecToolStripMenuItem";
 			this.testTimeoutOneSecToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.testTimeoutOneSecToolStripMenuItem.Text = "Set Timeout to 1 Second";
+			this.testTimeoutOneSecToolStripMenuItem.Text = resources.GetString("this.testTimeoutOneSecToolStripMenuItem.Text");
 			this.testTimeoutOneSecToolStripMenuItem.Click += new System.EventHandler(this.testTimeoutOneSecToolStripMenuItem_Click);
 			// 
 			// restartToolStripMenuItem
 			// 
 			this.restartToolStripMenuItem.Name = "restartToolStripMenuItem";
 			this.restartToolStripMenuItem.Size = new System.Drawing.Size(287, 22);
-			this.restartToolStripMenuItem.Text = "Restart";
+			this.restartToolStripMenuItem.Text = resources.GetString("this.restartToolStripMenuItem.Text");
 			this.restartToolStripMenuItem.Click += new System.EventHandler(this.restartToolStripMenuItem_Click);
 			// 
 			// mainToolBar
@@ -792,7 +792,7 @@ namespace EVEMon
 			this.mainToolBar.Name = "mainToolBar";
 			this.mainToolBar.Size = new System.Drawing.Size(600, 25);
 			this.mainToolBar.TabIndex = 5;
-			this.mainToolBar.Text = "toolStrip1";
+			this.mainToolBar.Text = resources.GetString("this.mainToolBar.Text");
 			this.mainToolBar.MouseDown += new System.Windows.Forms.MouseEventHandler(this.mainToolBar_MouseDown);
 			this.mainToolBar.MouseMove += new System.Windows.Forms.MouseEventHandler(this.mainToolBar_MouseMove);
 			// 
@@ -803,7 +803,7 @@ namespace EVEMon
 			this.addAPIKeyTbMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.addAPIKeyTbMenu.Name = "addAPIKeyTbMenu";
 			this.addAPIKeyTbMenu.Size = new System.Drawing.Size(23, 22);
-			this.addAPIKeyTbMenu.ToolTipText = "Add API key";
+			this.addAPIKeyTbMenu.ToolTipText = resources.GetString("this.addAPIKeyTbMenu.ToolTipText");
 			this.addAPIKeyTbMenu.Click += new System.EventHandler(this.addAPIKeyMenu_Click);
 			// 
 			// apiKeysManagementTbMenu
@@ -812,7 +812,7 @@ namespace EVEMon
 			this.apiKeysManagementTbMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.apiKeysManagementTbMenu.Name = "apiKeysManagementTbMenu";
 			this.apiKeysManagementTbMenu.Size = new System.Drawing.Size(23, 22);
-			this.apiKeysManagementTbMenu.ToolTipText = "Manage accounts";
+			this.apiKeysManagementTbMenu.ToolTipText = resources.GetString("this.apiKeysManagementTbMenu.ToolTipText");
 			this.apiKeysManagementTbMenu.Click += new System.EventHandler(this.manageAPIKeysMenuItem_Click);
 			// 
 			// apiKeysSettingsToolStripSeparator
@@ -831,15 +831,15 @@ namespace EVEMon
 			this.manageCharacterTbMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.manageCharacterTbMenu.Name = "manageCharacterTbMenu";
 			this.manageCharacterTbMenu.Size = new System.Drawing.Size(29, 22);
-			this.manageCharacterTbMenu.Text = "Manage Character";
-			this.manageCharacterTbMenu.ToolTipText = "Manage Character";
+			this.manageCharacterTbMenu.Text = resources.GetString("this.manageCharacterTbMenu.Text");
+			this.manageCharacterTbMenu.ToolTipText = resources.GetString("this.manageCharacterTbMenu.ToolTipText");
 			// 
 			// toolStripMenuItem1
 			// 
 			this.toolStripMenuItem1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripMenuItem1.Image")));
 			this.toolStripMenuItem1.Name = "toolStripMenuItem1";
 			this.toolStripMenuItem1.Size = new System.Drawing.Size(170, 22);
-			this.toolStripMenuItem1.Text = "&Delete Character...";
+			this.toolStripMenuItem1.Text = resources.GetString("this.toolStripMenuItem1.Text");
 			this.toolStripMenuItem1.Click += new System.EventHandler(this.deleteCharacterMenu_Click);
 			// 
 			// toolStripMenuItem2
@@ -847,7 +847,7 @@ namespace EVEMon
 			this.toolStripMenuItem2.Image = ((System.Drawing.Image)(resources.GetObject("toolStripMenuItem2.Image")));
 			this.toolStripMenuItem2.Name = "toolStripMenuItem2";
 			this.toolStripMenuItem2.Size = new System.Drawing.Size(170, 22);
-			this.toolStripMenuItem2.Text = "&Export Character...";
+			this.toolStripMenuItem2.Text = resources.GetString("this.toolStripMenuItem2.Text");
 			this.toolStripMenuItem2.Click += new System.EventHandler(this.saveCharacterInfosMenuItem_Click);
 			// 
 			// toolStripMenuItem3
@@ -855,7 +855,7 @@ namespace EVEMon
 			this.toolStripMenuItem3.Image = ((System.Drawing.Image)(resources.GetObject("toolStripMenuItem3.Image")));
 			this.toolStripMenuItem3.Name = "toolStripMenuItem3";
 			this.toolStripMenuItem3.Size = new System.Drawing.Size(170, 22);
-			this.toolStripMenuItem3.Text = "&Hide Character";
+			this.toolStripMenuItem3.Text = resources.GetString("this.toolStripMenuItem3.Text");
 			this.toolStripMenuItem3.Click += new System.EventHandler(this.hideCharacterMenu_Click);
 			// 
 			// manageCharacterToolStripSeparator
@@ -873,15 +873,15 @@ namespace EVEMon
 			this.tsdbSettings.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsdbSettings.Name = "tsdbSettings";
 			this.tsdbSettings.Size = new System.Drawing.Size(29, 22);
-			this.tsdbSettings.Text = "tsddbSettings";
-			this.tsdbSettings.ToolTipText = "Save/Restore Settings";
+			this.tsdbSettings.Text = resources.GetString("this.tsdbSettings.Text");
+			this.tsdbSettings.ToolTipText = resources.GetString("this.tsdbSettings.ToolTipText");
 			// 
 			// tsLoadSettings
 			// 
 			this.tsLoadSettings.Image = ((System.Drawing.Image)(resources.GetObject("tsLoadSettings.Image")));
 			this.tsLoadSettings.Name = "tsLoadSettings";
 			this.tsLoadSettings.Size = new System.Drawing.Size(167, 22);
-			this.tsLoadSettings.Text = "Restore Settings...";
+			this.tsLoadSettings.Text = resources.GetString("this.tsLoadSettings.Text");
 			this.tsLoadSettings.Click += new System.EventHandler(this.loadSettingsToolStripMenuItem_Click);
 			// 
 			// tsSaveSettings
@@ -889,7 +889,7 @@ namespace EVEMon
 			this.tsSaveSettings.Image = ((System.Drawing.Image)(resources.GetObject("tsSaveSettings.Image")));
 			this.tsSaveSettings.Name = "tsSaveSettings";
 			this.tsSaveSettings.Size = new System.Drawing.Size(167, 22);
-			this.tsSaveSettings.Text = "Save Settings...";
+			this.tsSaveSettings.Text = resources.GetString("this.tsSaveSettings.Text");
 			this.tsSaveSettings.Click += new System.EventHandler(this.saveSettingsToolStripMenuItem_Click);
 			// 
 			// settingsToolStripSeparator
@@ -904,7 +904,7 @@ namespace EVEMon
 			this.clearCacheToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.clearCacheToolStripButton.Name = "clearCacheToolStripButton";
 			this.clearCacheToolStripButton.Size = new System.Drawing.Size(23, 22);
-			this.clearCacheToolStripButton.Text = "Clear Cache";
+			this.clearCacheToolStripButton.Text = resources.GetString("this.clearCacheToolStripButton.Text");
 			this.clearCacheToolStripButton.Click += new System.EventHandler(this.clearCacheToolStripMenuItem_Click);
 			// 
 			// resetSettingsToolStripButton
@@ -914,7 +914,7 @@ namespace EVEMon
 			this.resetSettingsToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.resetSettingsToolStripButton.Name = "resetSettingsToolStripButton";
 			this.resetSettingsToolStripButton.Size = new System.Drawing.Size(23, 22);
-			this.resetSettingsToolStripButton.Text = "Reset Settings";
+			this.resetSettingsToolStripButton.Text = resources.GetString("this.resetSettingsToolStripButton.Text");
 			this.resetSettingsToolStripButton.Click += new System.EventHandler(this.resetSettingsToolStripMenuItem_Click);
 			// 
 			// cacheResetToolStripSeparator
@@ -929,7 +929,7 @@ namespace EVEMon
 			this.exitToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.exitToolStripButton.Name = "exitToolStripButton";
 			this.exitToolStripButton.Size = new System.Drawing.Size(23, 22);
-			this.exitToolStripButton.Text = "Exit";
+			this.exitToolStripButton.Text = resources.GetString("this.exitToolStripButton.Text");
 			this.exitToolStripButton.Click += new System.EventHandler(this.exitToolStripMenuItem_Click);
 			// 
 			// exitToolStripSeparator
@@ -944,7 +944,7 @@ namespace EVEMon
 			this.tsbManagePlans.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsbManagePlans.Name = "tsbManagePlans";
 			this.tsbManagePlans.Size = new System.Drawing.Size(23, 22);
-			this.tsbManagePlans.Text = "Manage Plans";
+			this.tsbManagePlans.Text = resources.GetString("this.tsbManagePlans.Text");
 			this.tsbManagePlans.Click += new System.EventHandler(this.manageToolStripMenuItem_Click);
 			// 
 			// plansTbMenu
@@ -954,7 +954,7 @@ namespace EVEMon
 			this.plansTbMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.plansTbMenu.Name = "plansTbMenu";
 			this.plansTbMenu.Size = new System.Drawing.Size(57, 22);
-			this.plansTbMenu.Text = "Plans...";
+			this.plansTbMenu.Text = resources.GetString("this.plansTbMenu.Text");
 			this.plansTbMenu.DropDownOpening += new System.EventHandler(this.tsdbPlans_DropDownOpening);
 			// 
 			// plansToolStripSeparator
@@ -969,7 +969,7 @@ namespace EVEMon
 			this.characterComparisonToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.characterComparisonToolStripButton.Name = "characterComparisonToolStripButton";
 			this.characterComparisonToolStripButton.Size = new System.Drawing.Size(23, 22);
-			this.characterComparisonToolStripButton.Text = "Character Comparison...";
+			this.characterComparisonToolStripButton.Text = resources.GetString("this.characterComparisonToolStripButton.Text");
 			this.characterComparisonToolStripButton.Click += new System.EventHandler(this.charactersComparisonToolStripMenuItem_Click);
 			// 
 			// tsbMineralSheet
@@ -984,7 +984,7 @@ namespace EVEMon
 			this.skillsPieChartTbMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.skillsPieChartTbMenu.Name = "skillsPieChartTbMenu";
 			this.skillsPieChartTbMenu.Size = new System.Drawing.Size(23, 22);
-			this.skillsPieChartTbMenu.Text = "Skill Group Pie Chart...";
+			this.skillsPieChartTbMenu.Text = resources.GetString("this.skillsPieChartTbMenu.Text");
 			this.skillsPieChartTbMenu.Click += new System.EventHandler(this.tsSkillsPieChartTool_Click);
 			// 
 			// tsbSchedule
@@ -999,7 +999,7 @@ namespace EVEMon
 			this.tsbImplantGroups.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsbImplantGroups.Name = "tsbImplantGroups";
 			this.tsbImplantGroups.Size = new System.Drawing.Size(23, 22);
-			this.tsbImplantGroups.Text = "Implant AllGroups...";
+			this.tsbImplantGroups.Text = resources.GetString("this.tsbImplantGroups.Text");
 			this.tsbImplantGroups.Click += new System.EventHandler(this.manualImplantGroupsToolStripMenuItem_Click);
 			// 
 			// tsbShowOwned
@@ -1009,7 +1009,7 @@ namespace EVEMon
 			this.tsbShowOwned.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsbShowOwned.Name = "tsbShowOwned";
 			this.tsbShowOwned.Size = new System.Drawing.Size(23, 22);
-			this.tsbShowOwned.Text = "Show Owned Skillbooks...";
+			this.tsbShowOwned.Text = resources.GetString("this.tsbShowOwned.Text");
 			this.tsbShowOwned.Click += new System.EventHandler(this.tsShowOwnedSkillbooks_Click);
 			// 
 			// toolsToolStripSeparator
@@ -1024,7 +1024,7 @@ namespace EVEMon
 			this.tsbOptions.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsbOptions.Name = "tsbOptions";
 			this.tsbOptions.Size = new System.Drawing.Size(23, 22);
-			this.tsbOptions.Text = "Options...";
+			this.tsbOptions.Text = resources.GetString("this.tsbOptions.Text");
 			this.tsbOptions.Click += new System.EventHandler(this.optionsMenuItem_Click);
 			// 
 			// tsbAbout
@@ -1034,21 +1034,21 @@ namespace EVEMon
 			this.tsbAbout.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.tsbAbout.Name = "tsbAbout";
 			this.tsbAbout.Size = new System.Drawing.Size(23, 22);
-			this.tsbAbout.Text = "About...";
+			this.tsbAbout.Text = resources.GetString("this.tsbAbout.Text");
 			this.tsbAbout.Click += new System.EventHandler(this.aboutToolStripMenuItem_Click);
 			// 
 			// niAlertIcon
 			// 
 			this.niAlertIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("niAlertIcon.Icon")));
-			this.niAlertIcon.Text = "EVEMon notifications";
+			this.niAlertIcon.Text = resources.GetString("this.niAlertIcon.Text");
 			this.niAlertIcon.BalloonTipClicked += new System.EventHandler(this.niAlertIcon_BalloonTipClicked);
 			this.niAlertIcon.Click += new System.EventHandler(this.niAlertIcon_Click);
 			this.niAlertIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.niAlertIcon_MouseClick);
 			// 
 			// ofdOpenDialog
 			// 
-			this.ofdOpenDialog.Filter = "Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*";
-			this.ofdOpenDialog.Title = "Open Plan File";
+			this.ofdOpenDialog.Filter = resources.GetString("this.ofdOpenDialog.Filter");
+			this.ofdOpenDialog.Title = resources.GetString("this.ofdOpenDialog.Title");
 			// 
 			// tcCharacterTabs
 			// 
@@ -1074,7 +1074,7 @@ namespace EVEMon
 			this.tpOverview.Name = "tpOverview";
 			this.tpOverview.Size = new System.Drawing.Size(592, 477);
 			this.tpOverview.TabIndex = 0;
-			this.tpOverview.Text = "Overview";
+			this.tpOverview.Text = resources.GetString("this.tpOverview.Text");
 			this.tpOverview.UseVisualStyleBackColor = true;
 			// 
 			// overview
@@ -1109,7 +1109,7 @@ namespace EVEMon
 			this.tabLoadingLabel.Name = "tabLoadingLabel";
 			this.tabLoadingLabel.Size = new System.Drawing.Size(600, 503);
 			this.tabLoadingLabel.TabIndex = 7;
-			this.tabLoadingLabel.Text = "Loading...\r\n\r\nPlease Wait.";
+			this.tabLoadingLabel.Text = resources.GetString("this.tabLoadingLabel.Text");
 			this.tabLoadingLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
 			// 
 			// noCharactersLabel

--- a/src/EVEMon/MainWindow.resx
+++ b/src/EVEMon/MainWindow.resx
@@ -3447,4 +3447,273 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>92</value>
   </metadata>
+  <data name="this.planToolStripMenuItem.Text" xml:space="preserve">
+    <value>Plans</value>
+  </data>
+  <data name="this.testTrayToolStripMenuItem.Text" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="this.trayTestNotificationTSMI.Text" xml:space="preserve">
+    <value>Notification</value>
+  </data>
+  <data name="this.trayTestCharacterNotificationTSMI.Text" xml:space="preserve">
+    <value>Character Notification</value>
+  </data>
+  <data name="this.restoreToolStripMenuItem.Text" xml:space="preserve">
+    <value>Restore</value>
+  </data>
+  <data name="this.closeToolStripMenuItem.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="this.lblTraining.Text" xml:space="preserve">
+    <value>toolStripStatusLabel1</value>
+  </data>
+  <data name="this.lblStatus.Text" xml:space="preserve">
+    <value>EVE Time:</value>
+  </data>
+  <data name="this.lblServerStatus.Text" xml:space="preserve">
+    <value>|  Server Status Unknown</value>
+  </data>
+  <data name="this.lblCSSProviderStatus.Text" xml:space="preserve">
+    <value>Uploading to CSSProvider</value>
+  </data>
+  <data name="this.tsDatafilesLoadingProgressBar.ToolTipText" xml:space="preserve">
+    <value>Loading data files</value>
+  </data>
+  <data name="this.saveFileDialog.Filter" xml:space="preserve">
+    <value>EVEMon Settings Backup Files (*.bak)|*.bak</value>
+  </data>
+  <data name="this.saveFileDialog.Title" xml:space="preserve">
+    <value>Backup EVEMon settings file</value>
+  </data>
+  <data name="this.openFileDialog.Filter" xml:space="preserve">
+    <value>EVEMon Settings Backup Files (*.bak)|*.bak</value>
+  </data>
+  <data name="this.openFileDialog.Title" xml:space="preserve">
+    <value>Restore EVEMon settings file</value>
+  </data>
+  <data name="this.mainMenuBar.Text" xml:space="preserve">
+    <value>menuStrip1</value>
+  </data>
+  <data name="this.menubarToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Menubar</value>
+  </data>
+  <data name="this.toolbarToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Toolbar</value>
+  </data>
+  <data name="this.fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;File</value>
+  </data>
+  <data name="this.addAPIKeyMenu.Text" xml:space="preserve">
+    <value>&amp;Add Character...</value>
+  </data>
+  <data name="this.manageAPIKeysMenuItem.Text" xml:space="preserve">
+    <value>&amp;Manage Characters...</value>
+  </data>
+  <data name="this.deleteCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Delete Character...</value>
+  </data>
+  <data name="this.exportCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Export Character...</value>
+  </data>
+  <data name="this.hideCharacterMenu.Text" xml:space="preserve">
+    <value>&amp;Hide Character</value>
+  </data>
+  <data name="this.loadSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>R&amp;estore Settings...</value>
+  </data>
+  <data name="this.saveSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Sa&amp;ve Settings...</value>
+  </data>
+  <data name="this.resetSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Reset Settings</value>
+  </data>
+  <data name="this.clearCacheToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Clear Cache</value>
+  </data>
+  <data name="this.exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>E&amp;xit</value>
+  </data>
+  <data name="this.editToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Edit</value>
+  </data>
+  <data name="this.copySkillsToClipboardBBFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Copy Skills to Clipboard (BB Format)</value>
+  </data>
+  <data name="this.plansToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Plans</value>
+  </data>
+  <data name="this.tsmiNewPlan.Text" xml:space="preserve">
+    <value>&amp;New Plan…</value>
+  </data>
+  <data name="this.tsmiCreatePlanFromSkillQueue.Text" xml:space="preserve">
+    <value>Create Plan from Skill Queue...</value>
+  </data>
+  <data name="this.tsmiImportPlanFromFile.Text" xml:space="preserve">
+    <value>&amp;Import Plan from File...</value>
+  </data>
+  <data name="this.tsmiManagePlans.Text" xml:space="preserve">
+    <value>&amp;Manage Plans...</value>
+  </data>
+  <data name="this.toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Tools</value>
+  </data>
+  <data name="this.charactersComparisonMenuItem.Text" xml:space="preserve">
+    <value>&amp;Characters Comparison...</value>
+  </data>
+  <data name="this.blankCreatorToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Blank Character Creator...</value>
+  </data>
+  <data name="this.dataBrowserMenuItem.Text" xml:space="preserve">
+    <value>&amp;Data Browser</value>
+  </data>
+  <data name="this.skillBrowserMenuItem.Text" xml:space="preserve">
+    <value>&amp;Skill Browser...</value>
+  </data>
+  <data name="this.certificateBrowserMenuItem.Text" xml:space="preserve">
+    <value>&amp;Certificate Browser...</value>
+  </data>
+  <data name="this.shipBrowserMenuItem.Text" xml:space="preserve">
+    <value>S&amp;hip Browser...</value>
+  </data>
+  <data name="this.itemBrowserMenuItem.Text" xml:space="preserve">
+    <value>&amp;Item Browser...</value>
+  </data>
+  <data name="this.blueprintBrowserMenuItem.Text" xml:space="preserve">
+    <value>&amp;Blueprint Browser...</value>
+  </data>
+  <data name="this.skillsPieChartMenuItem.Text" xml:space="preserve">
+    <value>Skills &amp;Pie Chart...</value>
+  </data>
+  <data name="this.implantsMenuItem.Text" xml:space="preserve">
+    <value>&amp;Implant Groups...</value>
+  </data>
+  <data name="this.showOwnedSkillbooksMenuItem.Text" xml:space="preserve">
+    <value>O&amp;wned Skillbooks...</value>
+  </data>
+  <data name="this.optionsToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Options...</value>
+  </data>
+  <data name="this.helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Help</value>
+  </data>
+  <data name="this.forumsMenuItem.Text" xml:space="preserve">
+    <value>&amp;Forums</value>
+  </data>
+  <data name="this.issuesFeaturesMenuItem.Text" xml:space="preserve">
+    <value>I&amp;ssues and Features (GitHub)</value>
+  </data>
+  <data name="this.readTheDocsManualToolStripMenuItem.Text" xml:space="preserve">
+    <value>Read The Docs (Manual)</value>
+  </data>
+  <data name="this.aboutMenuItem.Text" xml:space="preserve">
+    <value>&amp;About...</value>
+  </data>
+  <data name="this.testsToolStripMenuItem.Text" xml:space="preserve">
+    <value>Te&amp;st</value>
+  </data>
+  <data name="this.exceptionWindowToolStripMenuItem.Text" xml:space="preserve">
+    <value>Exception Window</value>
+  </data>
+  <data name="this.exceptionWindowRecursiveExceptionToolStripMenuItem.Text" xml:space="preserve">
+    <value>Exception Window (Recursive Exception)</value>
+  </data>
+  <data name="this.testNotificationToolStripMenuItem.Text" xml:space="preserve">
+    <value>Notification</value>
+  </data>
+  <data name="this.testCharacterNotificationToolStripMenuItem.Text" xml:space="preserve">
+    <value>Character Notification</value>
+  </data>
+  <data name="this.testTimeoutOneSecToolStripMenuItem.Text" xml:space="preserve">
+    <value>Set Timeout to 1 Second</value>
+  </data>
+  <data name="this.restartToolStripMenuItem.Text" xml:space="preserve">
+    <value>Restart</value>
+  </data>
+  <data name="this.mainToolBar.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="this.addAPIKeyTbMenu.ToolTipText" xml:space="preserve">
+    <value>Add API key</value>
+  </data>
+  <data name="this.apiKeysManagementTbMenu.ToolTipText" xml:space="preserve">
+    <value>Manage accounts</value>
+  </data>
+  <data name="this.manageCharacterTbMenu.Text" xml:space="preserve">
+    <value>Manage Character</value>
+  </data>
+  <data name="this.manageCharacterTbMenu.ToolTipText" xml:space="preserve">
+    <value>Manage Character</value>
+  </data>
+  <data name="this.toolStripMenuItem1.Text" xml:space="preserve">
+    <value>&amp;Delete Character...</value>
+  </data>
+  <data name="this.toolStripMenuItem2.Text" xml:space="preserve">
+    <value>&amp;Export Character...</value>
+  </data>
+  <data name="this.toolStripMenuItem3.Text" xml:space="preserve">
+    <value>&amp;Hide Character</value>
+  </data>
+  <data name="this.tsdbSettings.Text" xml:space="preserve">
+    <value>tsddbSettings</value>
+  </data>
+  <data name="this.tsdbSettings.ToolTipText" xml:space="preserve">
+    <value>Save/Restore Settings</value>
+  </data>
+  <data name="this.tsLoadSettings.Text" xml:space="preserve">
+    <value>Restore Settings...</value>
+  </data>
+  <data name="this.tsSaveSettings.Text" xml:space="preserve">
+    <value>Save Settings...</value>
+  </data>
+  <data name="this.clearCacheToolStripButton.Text" xml:space="preserve">
+    <value>Clear Cache</value>
+  </data>
+  <data name="this.resetSettingsToolStripButton.Text" xml:space="preserve">
+    <value>Reset Settings</value>
+  </data>
+  <data name="this.exitToolStripButton.Text" xml:space="preserve">
+    <value>Exit</value>
+  </data>
+  <data name="this.tsbManagePlans.Text" xml:space="preserve">
+    <value>Manage Plans</value>
+  </data>
+  <data name="this.plansTbMenu.Text" xml:space="preserve">
+    <value>Plans...</value>
+  </data>
+  <data name="this.characterComparisonToolStripButton.Text" xml:space="preserve">
+    <value>Character Comparison...</value>
+  </data>
+  <data name="this.skillsPieChartTbMenu.Text" xml:space="preserve">
+    <value>Skill Group Pie Chart...</value>
+  </data>
+  <data name="this.tsbImplantGroups.Text" xml:space="preserve">
+    <value>Implant AllGroups...</value>
+  </data>
+  <data name="this.tsbShowOwned.Text" xml:space="preserve">
+    <value>Show Owned Skillbooks...</value>
+  </data>
+  <data name="this.tsbOptions.Text" xml:space="preserve">
+    <value>Options...</value>
+  </data>
+  <data name="this.tsbAbout.Text" xml:space="preserve">
+    <value>About...</value>
+  </data>
+  <data name="this.niAlertIcon.Text" xml:space="preserve">
+    <value>EVEMon notifications</value>
+  </data>
+  <data name="this.ofdOpenDialog.Filter" xml:space="preserve">
+    <value>Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*</value>
+  </data>
+  <data name="this.ofdOpenDialog.Title" xml:space="preserve">
+    <value>Open Plan File</value>
+  </data>
+  <data name="this.tpOverview.Text" xml:space="preserve">
+    <value>Overview</value>
+  </data>
+  <data name="this.tabLoadingLabel.Text" xml:space="preserve">
+    <value>Loading...
+
+Please Wait.</value>
+  </data>
 </root>

--- a/src/EVEMon/MainWindow.zh-CN.resx
+++ b/src/EVEMon/MainWindow.zh-CN.resx
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.planToolStripMenuItem.Text" xml:space="preserve">
+    <value>计划</value>
+  </data>
+  <data name="this.testTrayToolStripMenuItem.Text" xml:space="preserve">
+    <value>测试</value>
+  </data>
+  <data name="this.trayTestNotificationTSMI.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="this.trayTestCharacterNotificationTSMI.Text" xml:space="preserve">
+    <value>角色通知</value>
+  </data>
+  <data name="this.restoreToolStripMenuItem.Text" xml:space="preserve">
+    <value>恢复</value>
+  </data>
+  <data name="this.closeToolStripMenuItem.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.lblTraining.Text" xml:space="preserve">
+    <value>工具条状态标签1</value>
+  </data>
+  <data name="this.lblStatus.Text" xml:space="preserve">
+    <value>夏娃时间：</value>
+  </data>
+  <data name="this.lblServerStatus.Text" xml:space="preserve">
+    <value>|  服务器状态未知</value>
+  </data>
+  <data name="this.lblCSSProviderStatus.Text" xml:space="preserve">
+    <value>上传至 CSSProvider</value>
+  </data>
+  <data name="this.tsDatafilesLoadingProgressBar.ToolTipText" xml:space="preserve">
+    <value>加载数据文件</value>
+  </data>
+  <data name="this.saveFileDialog.Filter" xml:space="preserve">
+    <value>EVEMon Settings Backup Files (*.bak)|*.bak</value>
+  </data>
+  <data name="this.saveFileDialog.Title" xml:space="preserve">
+    <value>备份 EVEMon 设置文件</value>
+  </data>
+  <data name="this.openFileDialog.Filter" xml:space="preserve">
+    <value>EVEMon Settings Backup Files (*.bak)|*.bak</value>
+  </data>
+  <data name="this.openFileDialog.Title" xml:space="preserve">
+    <value>恢复 EVEMon 设置文件</value>
+  </data>
+  <data name="this.mainMenuBar.Text" xml:space="preserve">
+    <value>菜单条1</value>
+  </data>
+  <data name="this.menubarToolStripMenuItem.Text" xml:space="preserve">
+    <value>菜单栏(&amp;M)</value>
+  </data>
+  <data name="this.toolbarToolStripMenuItem.Text" xml:space="preserve">
+    <value>工具栏(&amp;T)</value>
+  </data>
+  <data name="this.fileToolStripMenuItem.Text" xml:space="preserve">
+    <value>文件(&amp;F)</value>
+  </data>
+  <data name="this.addAPIKeyMenu.Text" xml:space="preserve">
+    <value>添加字符(&amp;A)...</value>
+  </data>
+  <data name="this.manageAPIKeysMenuItem.Text" xml:space="preserve">
+    <value>管理角色(&amp;M)...</value>
+  </data>
+  <data name="this.deleteCharacterMenu.Text" xml:space="preserve">
+    <value>删除字符(&amp;D)...</value>
+  </data>
+  <data name="this.exportCharacterMenu.Text" xml:space="preserve">
+    <value>导出字符(&amp;A)...</value>
+  </data>
+  <data name="this.hideCharacterMenu.Text" xml:space="preserve">
+    <value>隐藏字符(&amp;H)</value>
+  </data>
+  <data name="this.loadSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>恢复设置(&amp;E)...</value>
+  </data>
+  <data name="this.saveSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>保存设置(&amp;V)...</value>
+  </data>
+  <data name="this.resetSettingsToolStripMenuItem.Text" xml:space="preserve">
+    <value>重置设置(&amp;R)</value>
+  </data>
+  <data name="this.clearCacheToolStripMenuItem.Text" xml:space="preserve">
+    <value>清除缓存(&amp;C)</value>
+  </data>
+  <data name="this.exitToolStripMenuItem.Text" xml:space="preserve">
+    <value>退出​​(&amp;X)</value>
+  </data>
+  <data name="this.editToolStripMenuItem.Text" xml:space="preserve">
+    <value>编辑(&amp;E)</value>
+  </data>
+  <data name="this.copySkillsToClipboardBBFormatToolStripMenuItem.Text" xml:space="preserve">
+    <value>将技能复制到剪贴板(&amp;C)（BB 格式）</value>
+  </data>
+  <data name="this.plansToolStripMenuItem.Text" xml:space="preserve">
+    <value>计划(&amp;P)</value>
+  </data>
+  <data name="this.tsmiNewPlan.Text" xml:space="preserve">
+    <value>新计划(&amp;N)...</value>
+  </data>
+  <data name="this.tsmiCreatePlanFromSkillQueue.Text" xml:space="preserve">
+    <value>从技能队列创建计划...</value>
+  </data>
+  <data name="this.tsmiImportPlanFromFile.Text" xml:space="preserve">
+    <value>从文件导入计划(&amp;I)...</value>
+  </data>
+  <data name="this.tsmiManagePlans.Text" xml:space="preserve">
+    <value>管理计划(&amp;M)...</value>
+  </data>
+  <data name="this.toolsToolStripMenuItem.Text" xml:space="preserve">
+    <value>工具(&amp;T)</value>
+  </data>
+  <data name="this.charactersComparisonMenuItem.Text" xml:space="preserve">
+    <value>人物比较(&amp;C)...</value>
+  </data>
+  <data name="this.blankCreatorToolStripMenuItem.Text" xml:space="preserve">
+    <value>空白字符创建器(&amp;C)...</value>
+  </data>
+  <data name="this.dataBrowserMenuItem.Text" xml:space="preserve">
+    <value>数据浏览器(&amp;D)</value>
+  </data>
+  <data name="this.skillBrowserMenuItem.Text" xml:space="preserve">
+    <value>技能浏览器(&amp;S)...</value>
+  </data>
+  <data name="this.certificateBrowserMenuItem.Text" xml:space="preserve">
+    <value>证书浏览器(&amp;C)...</value>
+  </data>
+  <data name="this.shipBrowserMenuItem.Text" xml:space="preserve">
+    <value>船舶浏览器(&amp;H)...</value>
+  </data>
+  <data name="this.itemBrowserMenuItem.Text" xml:space="preserve">
+    <value>项目浏览器(&amp;I)...</value>
+  </data>
+  <data name="this.blueprintBrowserMenuItem.Text" xml:space="preserve">
+    <value>蓝图浏览器(&amp;L)...</value>
+  </data>
+  <data name="this.skillsPieChartMenuItem.Text" xml:space="preserve">
+    <value>技能和饼图...</value>
+  </data>
+  <data name="this.implantsMenuItem.Text" xml:space="preserve">
+    <value>种植体组(&amp;I)...</value>
+  </data>
+  <data name="this.showOwnedSkillbooksMenuItem.Text" xml:space="preserve">
+    <value>拥有的技能书​​(&amp;W)...</value>
+  </data>
+  <data name="this.optionsToolStripMenuItem.Text" xml:space="preserve">
+    <value>选项(&amp;O)...</value>
+  </data>
+  <data name="this.helpToolStripMenuItem.Text" xml:space="preserve">
+    <value>帮助(&amp;H)</value>
+  </data>
+  <data name="this.forumsMenuItem.Text" xml:space="preserve">
+    <value>论坛(&amp;F)</value>
+  </data>
+  <data name="this.issuesFeaturesMenuItem.Text" xml:space="preserve">
+    <value>问题和功能 (GitHub)</value>
+  </data>
+  <data name="this.readTheDocsManualToolStripMenuItem.Text" xml:space="preserve">
+    <value>阅读文档（手册）</value>
+  </data>
+  <data name="this.aboutMenuItem.Text" xml:space="preserve">
+    <value>关于...</value>
+  </data>
+  <data name="this.testsToolStripMenuItem.Text" xml:space="preserve">
+    <value>测试(&amp;S)</value>
+  </data>
+  <data name="this.exceptionWindowToolStripMenuItem.Text" xml:space="preserve">
+    <value>异常窗口</value>
+  </data>
+  <data name="this.exceptionWindowRecursiveExceptionToolStripMenuItem.Text" xml:space="preserve">
+    <value>异常窗口（递归异常）</value>
+  </data>
+  <data name="this.testNotificationToolStripMenuItem.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="this.testCharacterNotificationToolStripMenuItem.Text" xml:space="preserve">
+    <value>角色通知</value>
+  </data>
+  <data name="this.testTimeoutOneSecToolStripMenuItem.Text" xml:space="preserve">
+    <value>将超时设置为 1 秒</value>
+  </data>
+  <data name="this.restartToolStripMenuItem.Text" xml:space="preserve">
+    <value>重新启动</value>
+  </data>
+  <data name="this.mainToolBar.Text" xml:space="preserve">
+    <value>工具条1</value>
+  </data>
+  <data name="this.addAPIKeyTbMenu.ToolTipText" xml:space="preserve">
+    <value>添加API密钥</value>
+  </data>
+  <data name="this.apiKeysManagementTbMenu.ToolTipText" xml:space="preserve">
+    <value>管理账户</value>
+  </data>
+  <data name="this.manageCharacterTbMenu.Text" xml:space="preserve">
+    <value>管理角色</value>
+  </data>
+  <data name="this.manageCharacterTbMenu.ToolTipText" xml:space="preserve">
+    <value>管理角色</value>
+  </data>
+  <data name="this.toolStripMenuItem1.Text" xml:space="preserve">
+    <value>删除字符(&amp;D)...</value>
+  </data>
+  <data name="this.toolStripMenuItem2.Text" xml:space="preserve">
+    <value>导出字符(&amp;A)...</value>
+  </data>
+  <data name="this.toolStripMenuItem3.Text" xml:space="preserve">
+    <value>隐藏字符(&amp;H)</value>
+  </data>
+  <data name="this.tsdbSettings.Text" xml:space="preserve">
+    <value>tsddb设置</value>
+  </data>
+  <data name="this.tsdbSettings.ToolTipText" xml:space="preserve">
+    <value>保存/恢复设置</value>
+  </data>
+  <data name="this.tsLoadSettings.Text" xml:space="preserve">
+    <value>恢复设置...</value>
+  </data>
+  <data name="this.tsSaveSettings.Text" xml:space="preserve">
+    <value>保存设置...</value>
+  </data>
+  <data name="this.clearCacheToolStripButton.Text" xml:space="preserve">
+    <value>清除缓存</value>
+  </data>
+  <data name="this.resetSettingsToolStripButton.Text" xml:space="preserve">
+    <value>重置设置</value>
+  </data>
+  <data name="this.exitToolStripButton.Text" xml:space="preserve">
+    <value>退出</value>
+  </data>
+  <data name="this.tsbManagePlans.Text" xml:space="preserve">
+    <value>管理计划</value>
+  </data>
+  <data name="this.plansTbMenu.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.characterComparisonToolStripButton.Text" xml:space="preserve">
+    <value>人物比较...</value>
+  </data>
+  <data name="this.skillsPieChartTbMenu.Text" xml:space="preserve">
+    <value>技能组饼图...</value>
+  </data>
+  <data name="this.tsbImplantGroups.Text" xml:space="preserve">
+    <value>植入所有组...</value>
+  </data>
+  <data name="this.tsbShowOwned.Text" xml:space="preserve">
+    <value>显示拥有的技能书...</value>
+  </data>
+  <data name="this.tsbOptions.Text" xml:space="preserve">
+    <value>选项...</value>
+  </data>
+  <data name="this.tsbAbout.Text" xml:space="preserve">
+    <value>关于...</value>
+  </data>
+  <data name="this.niAlertIcon.Text" xml:space="preserve">
+    <value>EVEMon 通知</value>
+  </data>
+  <data name="this.ofdOpenDialog.Filter" xml:space="preserve">
+    <value>Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*</value>
+  </data>
+  <data name="this.ofdOpenDialog.Title" xml:space="preserve">
+    <value>打开计划文件</value>
+  </data>
+  <data name="this.tpOverview.Text" xml:space="preserve">
+    <value>概述</value>
+  </data>
+  <data name="this.tabLoadingLabel.Text" xml:space="preserve">
+    <value>正在加载...
+
+请稍候。</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/ContractsWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/ContractsWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/IndustryJobsWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/IndustryJobsWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/MarketOrdersWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/MarketOrdersWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/OwnedSkillBooksWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/OwnedSkillBooksWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/PlanetaryPinsWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/PlanetaryPinsWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/SkillCompletionWindow.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/SkillCompletionWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/NotificationWindow/TimeCheckNotification.Designer.cs
+++ b/src/EVEMon/NotificationWindow/TimeCheckNotification.Designer.cs
@@ -68,7 +68,7 @@ namespace EVEMon.NotificationWindow
             this.uxCloseButton.Name = "uxCloseButton";
             this.uxCloseButton.Size = new System.Drawing.Size(75, 23);
             this.uxCloseButton.TabIndex = 0;
-            this.uxCloseButton.Text = "Close";
+            this.uxCloseButton.Text = resources.GetString("this.uxCloseButton.Text");
             this.uxCloseButton.UseVisualStyleBackColor = true;
             this.uxCloseButton.Click += new System.EventHandler(this.uxCloseButton_Click);
             // 
@@ -100,7 +100,7 @@ namespace EVEMon.NotificationWindow
             this.uxTitleLabel.Name = "uxTitleLabel";
             this.uxTitleLabel.Size = new System.Drawing.Size(322, 32);
             this.uxTitleLabel.TabIndex = 1;
-            this.uxTitleLabel.Text = "Your system\'s clock settings may be wrong.";
+            this.uxTitleLabel.Text = resources.GetString("this.uxTitleLabel.Text");
             this.uxTitleLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // uxContentPanel
@@ -148,7 +148,7 @@ namespace EVEMon.NotificationWindow
             this.uxTimeZoneLabel.Name = "uxTimeZoneLabel";
             this.uxTimeZoneLabel.Size = new System.Drawing.Size(91, 19);
             this.uxTimeZoneLabel.TabIndex = 3;
-            this.uxTimeZoneLabel.Text = "Your Time Zone:";
+            this.uxTimeZoneLabel.Text = resources.GetString("this.uxTimeZoneLabel.Text");
             this.uxTimeZoneLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // uxExpectedTimeLabel
@@ -159,7 +159,7 @@ namespace EVEMon.NotificationWindow
             this.uxExpectedTimeLabel.Name = "uxExpectedTimeLabel";
             this.uxExpectedTimeLabel.Size = new System.Drawing.Size(91, 19);
             this.uxExpectedTimeLabel.TabIndex = 4;
-            this.uxExpectedTimeLabel.Text = "Expected Time:";
+            this.uxExpectedTimeLabel.Text = resources.GetString("this.uxExpectedTimeLabel.Text");
             this.uxExpectedTimeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // uxActualTimeLabel
@@ -170,7 +170,7 @@ namespace EVEMon.NotificationWindow
             this.uxActualTimeLabel.Name = "uxActualTimeLabel";
             this.uxActualTimeLabel.Size = new System.Drawing.Size(91, 20);
             this.uxActualTimeLabel.TabIndex = 5;
-            this.uxActualTimeLabel.Text = "Your Actual Time:";
+            this.uxActualTimeLabel.Text = resources.GetString("this.uxActualTimeLabel.Text");
             this.uxActualTimeLabel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // uxTimeZoneField
@@ -181,7 +181,7 @@ namespace EVEMon.NotificationWindow
             this.uxTimeZoneField.Name = "uxTimeZoneField";
             this.uxTimeZoneField.Size = new System.Drawing.Size(222, 19);
             this.uxTimeZoneField.TabIndex = 6;
-            this.uxTimeZoneField.Text = "TimeZone";
+            this.uxTimeZoneField.Text = resources.GetString("this.uxTimeZoneField.Text");
             this.uxTimeZoneField.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // uxExpectedTimeField
@@ -192,7 +192,7 @@ namespace EVEMon.NotificationWindow
             this.uxExpectedTimeField.Name = "uxExpectedTimeField";
             this.uxExpectedTimeField.Size = new System.Drawing.Size(222, 19);
             this.uxExpectedTimeField.TabIndex = 7;
-            this.uxExpectedTimeField.Text = "ServerTime";
+            this.uxExpectedTimeField.Text = resources.GetString("this.uxExpectedTimeField.Text");
             this.uxExpectedTimeField.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // uxActualTimeField
@@ -203,7 +203,7 @@ namespace EVEMon.NotificationWindow
             this.uxActualTimeField.Name = "uxActualTimeField";
             this.uxActualTimeField.Size = new System.Drawing.Size(222, 20);
             this.uxActualTimeField.TabIndex = 8;
-            this.uxActualTimeField.Text = "SystemTime";
+            this.uxActualTimeField.Text = resources.GetString("this.uxActualTimeField.Text");
             this.uxActualTimeField.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // uxMessageLabel1
@@ -224,7 +224,7 @@ namespace EVEMon.NotificationWindow
             this.uxCheckTimeOnStartUpCheckBox.Name = "uxCheckTimeOnStartUpCheckBox";
             this.uxCheckTimeOnStartUpCheckBox.Size = new System.Drawing.Size(246, 17);
             this.uxCheckTimeOnStartUpCheckBox.TabIndex = 1;
-            this.uxCheckTimeOnStartUpCheckBox.Text = "Check my system\'s clock when EVEMon starts";
+            this.uxCheckTimeOnStartUpCheckBox.Text = resources.GetString("this.uxCheckTimeOnStartUpCheckBox.Text");
             this.uxCheckTimeOnStartUpCheckBox.UseVisualStyleBackColor = true;
             // 
             // uxMessageLabel
@@ -252,7 +252,7 @@ namespace EVEMon.NotificationWindow
             this.MinimizeBox = false;
             this.Name = "TimeCheckNotification";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Time Synchronisation Problem";
+            this.Text = resources.GetString("this.Text");
             this.uxButtonPanel.ResumeLayout(false);
             this.uxTitlePanel.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.uxWarningIconPictureBox)).EndInit();

--- a/src/EVEMon/NotificationWindow/TimeCheckNotification.resx
+++ b/src/EVEMon/NotificationWindow/TimeCheckNotification.resx
@@ -161,4 +161,34 @@
   <data name="uxMessageLabel1.Text" xml:space="preserve">
     <value>EVEMon checked your system's time compared to NIST and found that they do not agree on what your current time is. This may be because your Time Zone is not set correctly, or your clock is set to the wrong time. </value>
   </data>
+  <data name="this.uxCloseButton.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="this.uxTitleLabel.Text" xml:space="preserve">
+    <value>Your system\'s clock settings may be wrong.</value>
+  </data>
+  <data name="this.uxTimeZoneLabel.Text" xml:space="preserve">
+    <value>Your Time Zone:</value>
+  </data>
+  <data name="this.uxExpectedTimeLabel.Text" xml:space="preserve">
+    <value>Expected Time:</value>
+  </data>
+  <data name="this.uxActualTimeLabel.Text" xml:space="preserve">
+    <value>Your Actual Time:</value>
+  </data>
+  <data name="this.uxTimeZoneField.Text" xml:space="preserve">
+    <value>TimeZone</value>
+  </data>
+  <data name="this.uxExpectedTimeField.Text" xml:space="preserve">
+    <value>ServerTime</value>
+  </data>
+  <data name="this.uxActualTimeField.Text" xml:space="preserve">
+    <value>SystemTime</value>
+  </data>
+  <data name="this.uxCheckTimeOnStartUpCheckBox.Text" xml:space="preserve">
+    <value>Check my system\'s clock when EVEMon starts</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Time Synchronisation Problem</value>
+  </data>
 </root>

--- a/src/EVEMon/NotificationWindow/TimeCheckNotification.zh-CN.resx
+++ b/src/EVEMon/NotificationWindow/TimeCheckNotification.zh-CN.resx
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="uxMessageLabel1.Text" xml:space="preserve">
+    <value>EVEMon 检查了您的系统时间与 NIST 的比较，发现他们对您当前的时间不一致。这可能是因为您的时区设置不正确，或者您的时钟设置为错误的时间。 </value>
+  </data>
+  <data name="this.uxCloseButton.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.uxTitleLabel.Text" xml:space="preserve">
+    <value>您的系统时钟设置可能有误。</value>
+  </data>
+  <data name="this.uxTimeZoneLabel.Text" xml:space="preserve">
+    <value>您的时区：</value>
+  </data>
+  <data name="this.uxExpectedTimeLabel.Text" xml:space="preserve">
+    <value>预计时间：</value>
+  </data>
+  <data name="this.uxActualTimeLabel.Text" xml:space="preserve">
+    <value>您的实际时间：</value>
+  </data>
+  <data name="this.uxTimeZoneField.Text" xml:space="preserve">
+    <value>时区</value>
+  </data>
+  <data name="this.uxExpectedTimeField.Text" xml:space="preserve">
+    <value>服务器时间</value>
+  </data>
+  <data name="this.uxActualTimeField.Text" xml:space="preserve">
+    <value>系统时间</value>
+  </data>
+  <data name="this.uxCheckTimeOnStartUpCheckBox.Text" xml:space="preserve">
+    <value>EVEMon 启动时检查我的系统时钟</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>时间同步问题</value>
+  </data>
+</root>

--- a/src/EVEMon/Program.cs
+++ b/src/EVEMon/Program.cs
@@ -76,6 +76,7 @@ namespace EVEMon
             // Initialization
             EveMonClient.Initialize();
             Settings.Initialize();
+            LocalizationHelper.ApplyCulture(Settings.Language);
 
             // Did something requested an exit before we entered Run() ?
             if (s_exitRequested)

--- a/src/EVEMon/Properties/Resources.zh-CN.resx
+++ b/src/EVEMon/Properties/Resources.zh-CN.resx
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="ErrorBadReminder" xml:space="preserve">
+    <value>提醒间隔必须是严格的正整数。</value>
+  </data>
+  <data name="ErrorBuildingError" xml:space="preserve">
+    <value>检索错误数据时出错。哇，事情真的很混乱！</value>
+  </data>
+  <data name="ErrorClipboardFailure" xml:space="preserve">
+    <value>无法完成操作，因为剪贴板正被另一个进程使用。稍等片刻，然后重试。</value>
+  </data>
+  <data name="ErrorDownloadFailure" xml:space="preserve">
+    <value>文件无法正确下载，您想重试吗？</value>
+  </data>
+  <data name="ErrorFewScopes" xml:space="preserve">
+    <value>警告：此 ESI 密钥提供的数据不足以满足基本的 EVEMon 功能。</value>
+  </data>
+  <data name="ErrorInstallerNotFound" xml:space="preserve">
+    <value>找不到安装程序文件。 EVEMon 将继续而不更新。</value>
+  </data>
+  <data name="ErrorNoCalendar" xml:space="preserve">
+    <value>找不到该路径上的日历。</value>
+  </data>
+  <data name="ErrorNoDataFile" xml:space="preserve">
+    <value>无法创建数据文件报告</value>
+  </data>
+  <data name="ErrorNoScopes" xml:space="preserve">
+    <value>警告：此 ESI 密钥未授权任何范围，因此不会提供任何数据。</value>
+  </data>
+  <data name="ErrorNoToken" xml:space="preserve">
+    <value>无法获取ESI令牌。</value>
+  </data>
+  <data name="ErrorNoTraceFile" xml:space="preserve">
+    <value>无法加载跟踪文件以包含在报告中</value>
+  </data>
+  <data name="ErrorSetClientID" xml:space="preserve">
+    <value>添加 ESI 密钥之前，请在“设置”&gt;“网络”中设置 ESI 客户端 ID 和客户端密钥。</value>
+  </data>
+  <data name="ErrorSSOStartup" xml:space="preserve">
+    <value>无法启动 SSO 服务器。检查您的防火墙设置（使用端口 {0:D}）并确保在添加 ESI 密钥时只有一个 EVEMon 实例处于活动状态。</value>
+  </data>
+  <data name="ErrorTrustFailure" xml:space="preserve">
+    <value>无法与 CCP API 服务器建立可信连接。
+
+这可能是由于活跃的中间人攻击或过时的本地 SSL 证书造成的。
+
+确保系统已安装最新的所有安全补丁，然后重试。</value>
+  </data>
+  <data name="ErrorUnhandled" xml:space="preserve">
+    <value>发生错误，EVEMon 无法正常处理错误消息。
+
+遇到的异常是“{0}”。</value>
+  </data>
+  <data name="ErrorUnhandledBase" xml:space="preserve">
+    <value>
+最初遇到的异常是“{0}”。</value>
+  </data>
+  <data name="ErrorUnhandledEnd" xml:space="preserve">
+    <value>
+请在 EVEMon 论坛上报告此情况。</value>
+  </data>
+  <data name="MessageBlueprintSelect" xml:space="preserve">
+    <value>使用左侧的树选择要查看的蓝图。</value>
+  </data>
+  <data name="MessageCopiedDetails" xml:space="preserve">
+    <value>错误详细信息已复制到剪贴板。</value>
+  </data>
+  <data name="MessageCopiedPlan" xml:space="preserve">
+    <value>所选条目已复制到剪贴板。</value>
+  </data>
+  <data name="MessageJumpCloneSkills" xml:space="preserve">
+    <value>{0} 拥有 {1:D} 跳跃克隆技能（加上 1 用于植入活动身体）</value>
+  </data>
+  <data name="MessagePriorityConflict" xml:space="preserve">
+    <value>这将导致优先级冲突，要么是优先级较低的先决条件，要么是优先级较高的依赖技能。
+
+如果您希望执行此操作并调整其他技能，请选择“是”
+或“否”（如果您不想更改优先级）。</value>
+  </data>
+  <data name="PromptClearCache" xml:space="preserve">
+    <value>您确定要清除缓存吗？</value>
+  </data>
+  <data name="PromptDeletePlan" xml:space="preserve">
+    <value>您确定要删除该计划吗？</value>
+  </data>
+  <data name="PromptIgnoreUpdate" xml:space="preserve">
+    <value>您确定要忽略此更新吗？在发布新版本之前，不会再次提示您。</value>
+  </data>
+  <data name="PromptResetSettings" xml:space="preserve">
+    <value>您确定要重置设置吗？
+一切都将失去，包括计划。</value>
+  </data>
+  <data name="MessageGettingStarted" xml:space="preserve">
+    <value>要开始使用 EVEMon，请选择“文件”&gt;“添加字符...”菜单选项，输入您的 ESI API 信息并选择要监控的字符。</value>
+  </data>
+  <data name="ErrorClipboardImport" xml:space="preserve">
+    <value>剪贴板的内容不是有效的技能列表或包含无效的技能级别。</value>
+  </data>
+  <data name="MessageClipboardPlanned" xml:space="preserve">
+    <value>粘贴的技能和所有依赖项都已经经过培训或计划。</value>
+  </data>
+  <data name="MessageClipboardTrained" xml:space="preserve">
+    <value>粘贴的技能和所有依赖项都已训练完毕。</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/CloudStorageServiceControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/CloudStorageServiceControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/EmailNotificationsControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/EmailNotificationsControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/ExternalCalendarControl.Designer.cs
+++ b/src/EVEMon/SettingsUI/ExternalCalendarControl.Designer.cs
@@ -97,7 +97,7 @@
             gbReminder.Size = new System.Drawing.Size(497, 111);
             gbReminder.TabIndex = 13;
             gbReminder.TabStop = false;
-            gbReminder.Text = "Reminder Setting";
+            gbReminder.Text = resources.GetString("gbReminder.Text");
             // 
             // lblMinutes
             // 
@@ -107,7 +107,7 @@
             lblMinutes.Name = "lblMinutes";
             lblMinutes.Size = new System.Drawing.Size(50, 15);
             lblMinutes.TabIndex = 11;
-            lblMinutes.Text = "minutes";
+            lblMinutes.Text = resources.GetString("lblMinutes.Text");
             // 
             // cbSetReminder
             // 
@@ -117,7 +117,7 @@
             cbSetReminder.Name = "cbSetReminder";
             cbSetReminder.Size = new System.Drawing.Size(96, 19);
             cbSetReminder.TabIndex = 6;
-            cbSetReminder.Text = "Use reminder";
+            cbSetReminder.Text = resources.GetString("cbSetReminder.Text");
             cbSetReminder.UseVisualStyleBackColor = true;
             cbSetReminder.Click += OnMustEnableOrDisable;
             // 
@@ -129,7 +129,7 @@
             lblLateReminder.Name = "lblLateReminder";
             lblLateReminder.Size = new System.Drawing.Size(86, 15);
             lblLateReminder.TabIndex = 6;
-            lblLateReminder.Text = "Late Reminder:";
+            lblLateReminder.Text = resources.GetString("lblLateReminder.Text");
             // 
             // dtpLateReminder
             // 
@@ -150,7 +150,7 @@
             lblEarlyReminder.Name = "lblEarlyReminder";
             lblEarlyReminder.Size = new System.Drawing.Size(89, 15);
             lblEarlyReminder.TabIndex = 4;
-            lblEarlyReminder.Text = "Early Reminder:";
+            lblEarlyReminder.Text = resources.GetString("lblEarlyReminder.Text");
             // 
             // tbReminder
             // 
@@ -170,7 +170,7 @@
             cbUseAlterateReminder.Name = "cbUseAlterateReminder";
             cbUseAlterateReminder.Size = new System.Drawing.Size(145, 19);
             cbUseAlterateReminder.TabIndex = 8;
-            cbUseAlterateReminder.Text = "Use alternate reminder";
+            cbUseAlterateReminder.Text = resources.GetString("cbUseAlterateReminder.Text");
             cbUseAlterateReminder.UseVisualStyleBackColor = true;
             cbUseAlterateReminder.Click += OnMustEnableOrDisable;
             // 
@@ -193,7 +193,7 @@
             cbLastQueuedSkillOnly.Name = "cbLastQueuedSkillOnly";
             cbLastQueuedSkillOnly.Size = new System.Drawing.Size(144, 19);
             cbLastQueuedSkillOnly.TabIndex = 12;
-            cbLastQueuedSkillOnly.Text = "Last Queued Skill Only";
+            cbLastQueuedSkillOnly.Text = resources.GetString("cbLastQueuedSkillOnly.Text");
             cbLastQueuedSkillOnly.UseVisualStyleBackColor = true;
             // 
             // rbGoogle
@@ -205,7 +205,7 @@
             rbGoogle.Name = "rbGoogle";
             rbGoogle.Size = new System.Drawing.Size(63, 19);
             rbGoogle.TabIndex = 2;
-            rbGoogle.Text = "Google";
+            rbGoogle.Text = resources.GetString("rbGoogle.Text");
             rbGoogle.UseVisualStyleBackColor = true;
             rbGoogle.CheckedChanged += rbGoogle_CheckedChanged;
             // 
@@ -228,7 +228,7 @@
             gbGoogle.Size = new System.Drawing.Size(498, 158);
             gbGoogle.TabIndex = 3;
             gbGoogle.TabStop = false;
-            gbGoogle.Text = "Google Information";
+            gbGoogle.Text = resources.GetString("gbGoogle.Text");
             // 
             // calendarIDLinkLabel
             // 
@@ -240,7 +240,7 @@
             calendarIDLinkLabel.Size = new System.Drawing.Size(436, 21);
             calendarIDLinkLabel.TabIndex = 12;
             calendarIDLinkLabel.TabStop = true;
-            calendarIDLinkLabel.Text = "Tip: Leave Calendar ID blank to use default calendar. How to find a Calendar ID.";
+            calendarIDLinkLabel.Text = resources.GetString("calendarIDLinkLabel.Text");
             calendarIDLinkLabel.UseCompatibleTextRendering = true;
             calendarIDLinkLabel.LinkClicked += calendarIDLinkLabel_LinkClicked;
             // 
@@ -252,7 +252,7 @@
             apiResponseLabel.Name = "apiResponseLabel";
             apiResponseLabel.Size = new System.Drawing.Size(484, 28);
             apiResponseLabel.TabIndex = 11;
-            apiResponseLabel.Text = "APIResponse";
+            apiResponseLabel.Text = resources.GetString("apiResponseLabel.Text");
             apiResponseLabel.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // btnRevokeAuth
@@ -263,7 +263,7 @@
             btnRevokeAuth.Name = "btnRevokeAuth";
             btnRevokeAuth.Size = new System.Drawing.Size(88, 27);
             btnRevokeAuth.TabIndex = 9;
-            btnRevokeAuth.Text = "Reset";
+            btnRevokeAuth.Text = resources.GetString("btnRevokeAuth.Text");
             btnRevokeAuth.UseVisualStyleBackColor = true;
             btnRevokeAuth.Click += btnRevokeAuth_Click;
             // 
@@ -275,7 +275,7 @@
             btnRequestAuth.Name = "btnRequestAuth";
             btnRequestAuth.Size = new System.Drawing.Size(172, 27);
             btnRequestAuth.TabIndex = 8;
-            btnRequestAuth.Text = "Request Authentication";
+            btnRequestAuth.Text = resources.GetString("btnRequestAuth.Text");
             btnRequestAuth.UseVisualStyleBackColor = true;
             btnRequestAuth.Click += btnRequestAuth_Click;
             // 
@@ -297,7 +297,7 @@
             lblReminder.Name = "lblReminder";
             lblReminder.Size = new System.Drawing.Size(61, 15);
             lblReminder.TabIndex = 6;
-            lblReminder.Text = "Reminder:";
+            lblReminder.Text = resources.GetString("lblReminder.Text");
             // 
             // lblCalendarId
             // 
@@ -307,7 +307,7 @@
             lblCalendarId.Name = "lblCalendarId";
             lblCalendarId.Size = new System.Drawing.Size(71, 15);
             lblCalendarId.TabIndex = 5;
-            lblCalendarId.Text = "Calendar ID:";
+            lblCalendarId.Text = resources.GetString("lblCalendarId.Text");
             // 
             // tbGoogleCalendarName
             // 
@@ -317,7 +317,7 @@
             tbGoogleCalendarName.Name = "tbGoogleCalendarName";
             tbGoogleCalendarName.Size = new System.Drawing.Size(400, 23);
             tbGoogleCalendarName.TabIndex = 5;
-            tbGoogleCalendarName.Text = "primary";
+            tbGoogleCalendarName.Text = resources.GetString("tbGoogleCalendarName.Text");
             // 
             // throbber
             // 
@@ -346,7 +346,7 @@
             gbMSOutlook.Size = new System.Drawing.Size(498, 158);
             gbMSOutlook.TabIndex = 14;
             gbMSOutlook.TabStop = false;
-            gbMSOutlook.Text = "MS Outlook Information";
+            gbMSOutlook.Text = resources.GetString("gbMSOutlook.Text");
             // 
             // calendarPathExampleLabel
             // 
@@ -368,7 +368,7 @@
             rbCustomCalendar.Size = new System.Drawing.Size(139, 19);
             rbCustomCalendar.TabIndex = 3;
             rbCustomCalendar.TabStop = true;
-            rbCustomCalendar.Text = "Use Custom Calendar";
+            rbCustomCalendar.Text = resources.GetString("rbCustomCalendar.Text");
             rbCustomCalendar.UseVisualStyleBackColor = true;
             rbCustomCalendar.Click += OnMustEnableOrDisable;
             // 
@@ -382,7 +382,7 @@
             rbDefaultCalendar.Size = new System.Drawing.Size(135, 19);
             rbDefaultCalendar.TabIndex = 2;
             rbDefaultCalendar.TabStop = true;
-            rbDefaultCalendar.Text = "Use Default Calendar";
+            rbDefaultCalendar.Text = resources.GetString("rbDefaultCalendar.Text");
             rbDefaultCalendar.UseVisualStyleBackColor = true;
             rbDefaultCalendar.Click += OnMustEnableOrDisable;
             // 
@@ -404,7 +404,7 @@
             calendarPathLabel.Name = "calendarPathLabel";
             calendarPathLabel.Size = new System.Drawing.Size(84, 15);
             calendarPathLabel.TabIndex = 0;
-            calendarPathLabel.Text = "Calendar Path:";
+            calendarPathLabel.Text = resources.GetString("calendarPathLabel.Text");
             // 
             // ExternalCalendarControl
             // 

--- a/src/EVEMon/SettingsUI/ExternalCalendarControl.resx
+++ b/src/EVEMon/SettingsUI/ExternalCalendarControl.resx
@@ -123,4 +123,64 @@ in 'My Calendars' right click on the calendar in question and select 'Properties
 Combine the 'Location:' path with the calendar name, separated by a left backslash.
 e.g. {\\Location}\{Calendar name}</value>
   </data>
+  <data name="gbReminder.Text" xml:space="preserve">
+    <value>Reminder Setting</value>
+  </data>
+  <data name="lblMinutes.Text" xml:space="preserve">
+    <value>minutes</value>
+  </data>
+  <data name="cbSetReminder.Text" xml:space="preserve">
+    <value>Use reminder</value>
+  </data>
+  <data name="lblLateReminder.Text" xml:space="preserve">
+    <value>Late Reminder:</value>
+  </data>
+  <data name="lblEarlyReminder.Text" xml:space="preserve">
+    <value>Early Reminder:</value>
+  </data>
+  <data name="cbUseAlterateReminder.Text" xml:space="preserve">
+    <value>Use alternate reminder</value>
+  </data>
+  <data name="cbLastQueuedSkillOnly.Text" xml:space="preserve">
+    <value>Last Queued Skill Only</value>
+  </data>
+  <data name="rbGoogle.Text" xml:space="preserve">
+    <value>Google</value>
+  </data>
+  <data name="gbGoogle.Text" xml:space="preserve">
+    <value>Google Information</value>
+  </data>
+  <data name="calendarIDLinkLabel.Text" xml:space="preserve">
+    <value>Tip: Leave Calendar ID blank to use default calendar. How to find a Calendar ID.</value>
+  </data>
+  <data name="apiResponseLabel.Text" xml:space="preserve">
+    <value>APIResponse</value>
+  </data>
+  <data name="btnRevokeAuth.Text" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="btnRequestAuth.Text" xml:space="preserve">
+    <value>Request Authentication</value>
+  </data>
+  <data name="lblReminder.Text" xml:space="preserve">
+    <value>Reminder:</value>
+  </data>
+  <data name="lblCalendarId.Text" xml:space="preserve">
+    <value>Calendar ID:</value>
+  </data>
+  <data name="tbGoogleCalendarName.Text" xml:space="preserve">
+    <value>primary</value>
+  </data>
+  <data name="gbMSOutlook.Text" xml:space="preserve">
+    <value>MS Outlook Information</value>
+  </data>
+  <data name="rbCustomCalendar.Text" xml:space="preserve">
+    <value>Use Custom Calendar</value>
+  </data>
+  <data name="rbDefaultCalendar.Text" xml:space="preserve">
+    <value>Use Default Calendar</value>
+  </data>
+  <data name="calendarPathLabel.Text" xml:space="preserve">
+    <value>Calendar Path:</value>
+  </data>
 </root>

--- a/src/EVEMon/SettingsUI/ExternalCalendarControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/ExternalCalendarControl.zh-CN.resx
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="calendarPathExampleLabel.Text" xml:space="preserve">
+    <value>提示：要查找日历的路径，请打开 Outlook，切换到“日历”视图 (Ctrl+2)， 
+在“我的日历”中右键单击相关日历并选择“属性”。 
+将“位置：”路径与日历名称组合起来，并用左反斜杠分隔。
+例如{\\位置}\{日历名称}</value>
+  </data>
+  <data name="gbReminder.Text" xml:space="preserve">
+    <value>提醒设置</value>
+  </data>
+  <data name="lblMinutes.Text" xml:space="preserve">
+    <value>分钟</value>
+  </data>
+  <data name="cbSetReminder.Text" xml:space="preserve">
+    <value>使用提醒</value>
+  </data>
+  <data name="lblLateReminder.Text" xml:space="preserve">
+    <value>迟到提醒：</value>
+  </data>
+  <data name="lblEarlyReminder.Text" xml:space="preserve">
+    <value>早期提醒：</value>
+  </data>
+  <data name="cbUseAlterateReminder.Text" xml:space="preserve">
+    <value>使用备用提醒</value>
+  </data>
+  <data name="cbLastQueuedSkillOnly.Text" xml:space="preserve">
+    <value>仅最后排队的技能</value>
+  </data>
+  <data name="rbGoogle.Text" xml:space="preserve">
+    <value>谷歌</value>
+  </data>
+  <data name="gbGoogle.Text" xml:space="preserve">
+    <value>谷歌信息</value>
+  </data>
+  <data name="calendarIDLinkLabel.Text" xml:space="preserve">
+    <value>提示：将日历 ID 留空以使用默认日历。如何查找日历 ID。</value>
+  </data>
+  <data name="apiResponseLabel.Text" xml:space="preserve">
+    <value>API响应</value>
+  </data>
+  <data name="btnRevokeAuth.Text" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="btnRequestAuth.Text" xml:space="preserve">
+    <value>请求认证</value>
+  </data>
+  <data name="lblReminder.Text" xml:space="preserve">
+    <value>提醒：</value>
+  </data>
+  <data name="lblCalendarId.Text" xml:space="preserve">
+    <value>日历 ID：</value>
+  </data>
+  <data name="tbGoogleCalendarName.Text" xml:space="preserve">
+    <value>小学</value>
+  </data>
+  <data name="gbMSOutlook.Text" xml:space="preserve">
+    <value>微软展望信息</value>
+  </data>
+  <data name="rbCustomCalendar.Text" xml:space="preserve">
+    <value>使用自定义日历</value>
+  </data>
+  <data name="rbDefaultCalendar.Text" xml:space="preserve">
+    <value>使用默认日历</value>
+  </data>
+  <data name="calendarPathLabel.Text" xml:space="preserve">
+    <value>日历路径：</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/NotificationsControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/NotificationsControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/PortableEveClientsControl.Designer.cs
+++ b/src/EVEMon/SettingsUI/PortableEveClientsControl.Designer.cs
@@ -52,7 +52,7 @@
             this.BrowseButton.Name = "BrowseButton";
             this.BrowseButton.Size = new System.Drawing.Size(75, 23);
             this.BrowseButton.TabIndex = 1;
-            this.BrowseButton.Text = "Browse";
+            this.BrowseButton.Text = resources.GetString("this.BrowseButton.Text");
             this.BrowseButton.UseVisualStyleBackColor = true;
             this.BrowseButton.Click += new System.EventHandler(this.BrowseButton_Click);
             // 

--- a/src/EVEMon/SettingsUI/PortableEveClientsControl.resx
+++ b/src/EVEMon/SettingsUI/PortableEveClientsControl.resx
@@ -134,4 +134,7 @@
         qzUAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.BrowseButton.Text" xml:space="preserve">
+    <value>Browse</value>
+  </data>
 </root>

--- a/src/EVEMon/SettingsUI/PortableEveClientsControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/PortableEveClientsControl.zh-CN.resx
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.BrowseButton.Text" xml:space="preserve">
+    <value>浏览</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/ProxyAuthenticationWindow.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/ProxyAuthenticationWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/SettingsFileStorageControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/SettingsFileStorageControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.Designer.cs
@@ -34,21 +34,21 @@ namespace EVEMon.SettingsUI
         {
             components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsForm));
-            System.Windows.Forms.TreeNode treeNode16 = new System.Windows.Forms.TreeNode("Updates", 11, 11);
-            System.Windows.Forms.TreeNode treeNode17 = new System.Windows.Forms.TreeNode("Network", 7, 7);
-            System.Windows.Forms.TreeNode treeNode18 = new System.Windows.Forms.TreeNode("Portable EVE Clients", 15, 15);
-            System.Windows.Forms.TreeNode treeNode19 = new System.Windows.Forms.TreeNode("Market Price Providers", 16, 16);
-            System.Windows.Forms.TreeNode treeNode20 = new System.Windows.Forms.TreeNode("General", 10, 10, new System.Windows.Forms.TreeNode[] { treeNode16, treeNode17, treeNode18, treeNode19 });
-            System.Windows.Forms.TreeNode treeNode21 = new System.Windows.Forms.TreeNode("Main Window", 6, 6);
-            System.Windows.Forms.TreeNode treeNode22 = new System.Windows.Forms.TreeNode("Icons", 13, 13);
-            System.Windows.Forms.TreeNode treeNode23 = new System.Windows.Forms.TreeNode("Messages", 14, 14);
-            System.Windows.Forms.TreeNode treeNode24 = new System.Windows.Forms.TreeNode("Skill Planner", 8, 8, new System.Windows.Forms.TreeNode[] { treeNode22, treeNode23 });
-            System.Windows.Forms.TreeNode treeNode25 = new System.Windows.Forms.TreeNode("System Tray Icon", 2, 2);
-            System.Windows.Forms.TreeNode treeNode26 = new System.Windows.Forms.TreeNode("External Calendar", 5, 5);
-            System.Windows.Forms.TreeNode treeNode27 = new System.Windows.Forms.TreeNode("Scheduler", 1, 1, new System.Windows.Forms.TreeNode[] { treeNode26 });
-            System.Windows.Forms.TreeNode treeNode28 = new System.Windows.Forms.TreeNode("Skill Completion Mails", 12, 12);
-            System.Windows.Forms.TreeNode treeNode29 = new System.Windows.Forms.TreeNode("Notifications", 9, 9, new System.Windows.Forms.TreeNode[] { treeNode28 });
-            System.Windows.Forms.TreeNode treeNode30 = new System.Windows.Forms.TreeNode("Cloud Storage Service", 17, 17);
+            System.Windows.Forms.TreeNode treeNode16 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode16.Text"), 11, 11);
+            System.Windows.Forms.TreeNode treeNode17 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode17.Text"), 7, 7);
+            System.Windows.Forms.TreeNode treeNode18 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode18.Text"), 15, 15);
+            System.Windows.Forms.TreeNode treeNode19 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode19.Text"), 16, 16);
+            System.Windows.Forms.TreeNode treeNode20 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode20.Text"), 10, 10, new System.Windows.Forms.TreeNode[] { treeNode16, treeNode17, treeNode18, treeNode19 });
+            System.Windows.Forms.TreeNode treeNode21 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode21.Text"), 6, 6);
+            System.Windows.Forms.TreeNode treeNode22 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode22.Text"), 13, 13);
+            System.Windows.Forms.TreeNode treeNode23 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode23.Text"), 14, 14);
+            System.Windows.Forms.TreeNode treeNode24 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode24.Text"), 8, 8, new System.Windows.Forms.TreeNode[] { treeNode22, treeNode23 });
+            System.Windows.Forms.TreeNode treeNode25 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode25.Text"), 2, 2);
+            System.Windows.Forms.TreeNode treeNode26 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode26.Text"), 5, 5);
+            System.Windows.Forms.TreeNode treeNode27 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode27.Text"), 1, 1, new System.Windows.Forms.TreeNode[] { treeNode26 });
+            System.Windows.Forms.TreeNode treeNode28 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode28.Text"), 12, 12);
+            System.Windows.Forms.TreeNode treeNode29 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode29.Text"), 9, 9, new System.Windows.Forms.TreeNode[] { treeNode28 });
+            System.Windows.Forms.TreeNode treeNode30 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode30.Text"), 17, 17);
             systemTrayIconGroupBox = new System.Windows.Forms.GroupBox();
             rbSystemTrayOptionsNever = new System.Windows.Forms.RadioButton();
             rbSystemTrayOptionsAlways = new System.Windows.Forms.RadioButton();
@@ -75,6 +75,7 @@ namespace EVEMon.SettingsUI
             cbTitleToTime = new System.Windows.Forms.CheckBox();
             lblGeneralPage = new System.Windows.Forms.Label();
             lblEnvironment = new System.Windows.Forms.Label();
+            lblLanguage = new System.Windows.Forms.Label();
             lblSkillPlannerPage = new System.Windows.Forms.Label();
             lblNetworkPageProxy = new System.Windows.Forms.Label();
             lblProxyHostIPAddress = new System.Windows.Forms.Label();
@@ -110,6 +111,7 @@ namespace EVEMon.SettingsUI
             generalPage = new MultiPanelPage();
             btnEVEMonDataDir = new System.Windows.Forms.Button();
             cbWorksafeMode = new System.Windows.Forms.CheckBox();
+            languageComboBox = new System.Windows.Forms.ComboBox();
             compatibilityCombo = new System.Windows.Forms.ComboBox();
             runAtStartupComboBox = new System.Windows.Forms.CheckBox();
             mainWindowPage = new MultiPanelPage();
@@ -256,7 +258,7 @@ namespace EVEMon.SettingsUI
             systemTrayIconGroupBox.Size = new System.Drawing.Size(489, 115);
             systemTrayIconGroupBox.TabIndex = 9;
             systemTrayIconGroupBox.TabStop = false;
-            systemTrayIconGroupBox.Text = "Show System Tray Icon";
+            systemTrayIconGroupBox.Text = resources.GetString("systemTrayIconGroupBox.Text");
             // 
             // rbSystemTrayOptionsNever
             // 
@@ -269,7 +271,7 @@ namespace EVEMon.SettingsUI
             rbSystemTrayOptionsNever.TabIndex = 1;
             rbSystemTrayOptionsNever.TabStop = true;
             rbSystemTrayOptionsNever.Tag = "";
-            rbSystemTrayOptionsNever.Text = "Never";
+            rbSystemTrayOptionsNever.Text = resources.GetString("rbSystemTrayOptionsNever.Text");
             rbSystemTrayOptionsNever.UseVisualStyleBackColor = true;
             rbSystemTrayOptionsNever.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -284,7 +286,7 @@ namespace EVEMon.SettingsUI
             rbSystemTrayOptionsAlways.TabIndex = 3;
             rbSystemTrayOptionsAlways.TabStop = true;
             rbSystemTrayOptionsAlways.Tag = "";
-            rbSystemTrayOptionsAlways.Text = "Always";
+            rbSystemTrayOptionsAlways.Text = resources.GetString("rbSystemTrayOptionsAlways.Text");
             rbSystemTrayOptionsAlways.UseVisualStyleBackColor = true;
             // 
             // rbSystemTrayOptionsMinimized
@@ -298,7 +300,7 @@ namespace EVEMon.SettingsUI
             rbSystemTrayOptionsMinimized.TabIndex = 2;
             rbSystemTrayOptionsMinimized.TabStop = true;
             rbSystemTrayOptionsMinimized.Tag = "";
-            rbSystemTrayOptionsMinimized.Text = "When Minimized";
+            rbSystemTrayOptionsMinimized.Text = resources.GetString("rbSystemTrayOptionsMinimized.Text");
             rbSystemTrayOptionsMinimized.UseVisualStyleBackColor = true;
             // 
             // bottomPanel
@@ -322,7 +324,7 @@ namespace EVEMon.SettingsUI
             applyButton.Name = "applyButton";
             applyButton.Size = new System.Drawing.Size(88, 27);
             applyButton.TabIndex = 4;
-            applyButton.Text = "&Apply";
+            applyButton.Text = resources.GetString("applyButton.Text");
             applyButton.UseVisualStyleBackColor = true;
             applyButton.Click += applyButton_Click;
             // 
@@ -334,7 +336,7 @@ namespace EVEMon.SettingsUI
             okButton.Name = "okButton";
             okButton.Size = new System.Drawing.Size(88, 27);
             okButton.TabIndex = 3;
-            okButton.Text = "&OK";
+            okButton.Text = resources.GetString("okButton.Text");
             okButton.UseVisualStyleBackColor = true;
             okButton.Click += btnOk_Click;
             // 
@@ -347,7 +349,7 @@ namespace EVEMon.SettingsUI
             cancelButton.Name = "cancelButton";
             cancelButton.Size = new System.Drawing.Size(88, 27);
             cancelButton.TabIndex = 2;
-            cancelButton.Text = "&Cancel";
+            cancelButton.Text = resources.GetString("cancelButton.Text");
             cancelButton.UseVisualStyleBackColor = true;
             cancelButton.Click += btnCancel_Click;
             // 
@@ -370,7 +372,7 @@ namespace EVEMon.SettingsUI
             lblSize.Name = "lblSize";
             lblSize.Size = new System.Drawing.Size(27, 15);
             lblSize.TabIndex = 31;
-            lblSize.Text = "Size";
+            lblSize.Text = resources.GetString("lblSize.Text");
             // 
             // CharacterMonitorGroupBox
             // 
@@ -391,7 +393,7 @@ namespace EVEMon.SettingsUI
             CharacterMonitorGroupBox.Size = new System.Drawing.Size(497, 145);
             CharacterMonitorGroupBox.TabIndex = 7;
             CharacterMonitorGroupBox.TabStop = false;
-            CharacterMonitorGroupBox.Text = "Character Monitor";
+            CharacterMonitorGroupBox.Text = resources.GetString("CharacterMonitorGroupBox.Text");
             // 
             // nudSkillQueueWarningThresholdDays
             // 
@@ -411,7 +413,7 @@ namespace EVEMon.SettingsUI
             lblSkillQueueWarningThresholdDays.Name = "lblSkillQueueWarningThresholdDays";
             lblSkillQueueWarningThresholdDays.Size = new System.Drawing.Size(38, 15);
             lblSkillQueueWarningThresholdDays.TabIndex = 15;
-            lblSkillQueueWarningThresholdDays.Text = "Days :";
+            lblSkillQueueWarningThresholdDays.Text = resources.GetString("lblSkillQueueWarningThresholdDays.Text");
             // 
             // lblSkillQueuWarningThreshold
             // 
@@ -421,7 +423,7 @@ namespace EVEMon.SettingsUI
             lblSkillQueuWarningThreshold.Name = "lblSkillQueuWarningThreshold";
             lblSkillQueuWarningThreshold.Size = new System.Drawing.Size(169, 15);
             lblSkillQueuWarningThreshold.TabIndex = 14;
-            lblSkillQueuWarningThreshold.Text = "Skill Queue Warning Threshold";
+            lblSkillQueuWarningThreshold.Text = resources.GetString("lblSkillQueuWarningThreshold.Text");
             // 
             // cbColorQueuedSkills
             // 
@@ -431,8 +433,8 @@ namespace EVEMon.SettingsUI
             cbColorQueuedSkills.Name = "cbColorQueuedSkills";
             cbColorQueuedSkills.Size = new System.Drawing.Size(150, 19);
             cbColorQueuedSkills.TabIndex = 13;
-            cbColorQueuedSkills.Text = "Highlight Queued Skills";
-            ttToolTipCodes.SetToolTip(cbColorQueuedSkills, "When enabled, highlights all\r\nqueued skills in character's skill list");
+            cbColorQueuedSkills.Text = resources.GetString("cbColorQueuedSkills.Text");
+            ttToolTipCodes.SetToolTip(cbColorQueuedSkills, resources.GetString("cbColorQueuedSkills.ToolTip"));
             cbColorQueuedSkills.UseVisualStyleBackColor = true;
             // 
             // cbShowPrereqMetSkills
@@ -443,8 +445,8 @@ namespace EVEMon.SettingsUI
             cbShowPrereqMetSkills.Name = "cbShowPrereqMetSkills";
             cbShowPrereqMetSkills.Size = new System.Drawing.Size(173, 19);
             cbShowPrereqMetSkills.TabIndex = 12;
-            cbShowPrereqMetSkills.Text = "Show Also Prereq-Met Skills";
-            ttToolTipCodes.SetToolTip(cbShowPrereqMetSkills, "When enabled, shows all prerequisites\r\nmet skills in character's skill list");
+            cbShowPrereqMetSkills.Text = resources.GetString("cbShowPrereqMetSkills.Text");
+            ttToolTipCodes.SetToolTip(cbShowPrereqMetSkills, resources.GetString("cbShowPrereqMetSkills.ToolTip"));
             cbShowPrereqMetSkills.UseVisualStyleBackColor = true;
             // 
             // cbColorPartialSkills
@@ -455,8 +457,8 @@ namespace EVEMon.SettingsUI
             cbColorPartialSkills.Name = "cbColorPartialSkills";
             cbColorPartialSkills.Size = new System.Drawing.Size(191, 19);
             cbColorPartialSkills.TabIndex = 11;
-            cbColorPartialSkills.Text = "Highlight Partially Trained Skills";
-            ttToolTipCodes.SetToolTip(cbColorPartialSkills, "When enabled, highlights all partially\r\ntrained skills in character's skill list");
+            cbColorPartialSkills.Text = resources.GetString("cbColorPartialSkills.Text");
+            ttToolTipCodes.SetToolTip(cbColorPartialSkills, resources.GetString("cbColorPartialSkills.ToolTip"));
             cbColorPartialSkills.UseVisualStyleBackColor = true;
             // 
             // cbAlwaysShowSkillQueueTime
@@ -467,8 +469,8 @@ namespace EVEMon.SettingsUI
             cbAlwaysShowSkillQueueTime.Name = "cbAlwaysShowSkillQueueTime";
             cbAlwaysShowSkillQueueTime.Size = new System.Drawing.Size(235, 19);
             cbAlwaysShowSkillQueueTime.TabIndex = 2;
-            cbAlwaysShowSkillQueueTime.Text = "Always show time above the skill queue";
-            ttToolTipCodes.SetToolTip(cbAlwaysShowSkillQueueTime, "When enabled, always displays the total\r\nqueue time above the skill queue bar");
+            cbAlwaysShowSkillQueueTime.Text = resources.GetString("cbAlwaysShowSkillQueueTime.Text");
+            ttToolTipCodes.SetToolTip(cbAlwaysShowSkillQueueTime, resources.GetString("cbAlwaysShowSkillQueueTime.ToolTip"));
             cbAlwaysShowSkillQueueTime.UseVisualStyleBackColor = true;
             // 
             // cbShowNonPublicSkills
@@ -480,8 +482,8 @@ namespace EVEMon.SettingsUI
             cbShowNonPublicSkills.Name = "cbShowNonPublicSkills";
             cbShowNonPublicSkills.Size = new System.Drawing.Size(174, 19);
             cbShowNonPublicSkills.TabIndex = 1;
-            cbShowNonPublicSkills.Text = "Show Also Non-Public Skills";
-            ttToolTipCodes.SetToolTip(cbShowNonPublicSkills, "When enabled, shows all non-public skills in character's skill list");
+            cbShowNonPublicSkills.Text = resources.GetString("cbShowNonPublicSkills.Text");
+            ttToolTipCodes.SetToolTip(cbShowNonPublicSkills, resources.GetString("cbShowNonPublicSkills.ToolTip"));
             cbShowNonPublicSkills.UseVisualStyleBackColor = true;
             // 
             // cbShowAllPublicSkills
@@ -492,8 +494,8 @@ namespace EVEMon.SettingsUI
             cbShowAllPublicSkills.Name = "cbShowAllPublicSkills";
             cbShowAllPublicSkills.Size = new System.Drawing.Size(163, 19);
             cbShowAllPublicSkills.TabIndex = 0;
-            cbShowAllPublicSkills.Text = "Show Also All Public Skills";
-            ttToolTipCodes.SetToolTip(cbShowAllPublicSkills, "When enabled, shows all public skills in character's skill list");
+            cbShowAllPublicSkills.Text = resources.GetString("cbShowAllPublicSkills.Text");
+            ttToolTipCodes.SetToolTip(cbShowAllPublicSkills, resources.GetString("cbShowAllPublicSkills.ToolTip"));
             cbShowAllPublicSkills.UseVisualStyleBackColor = true;
             cbShowAllPublicSkills.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -510,7 +512,7 @@ namespace EVEMon.SettingsUI
             WindowTitleGroupBox.Size = new System.Drawing.Size(497, 111);
             WindowTitleGroupBox.TabIndex = 14;
             WindowTitleGroupBox.TabStop = false;
-            WindowTitleGroupBox.Text = "Window Title";
+            WindowTitleGroupBox.Text = resources.GetString("WindowTitleGroupBox.Text");
             // 
             // cbWindowsTitleList
             // 
@@ -532,8 +534,8 @@ namespace EVEMon.SettingsUI
             cbSkillInTitle.Name = "cbSkillInTitle";
             cbSkillInTitle.Size = new System.Drawing.Size(135, 19);
             cbSkillInTitle.TabIndex = 7;
-            cbSkillInTitle.Text = "Show skill in training";
-            ttToolTipCodes.SetToolTip(cbSkillInTitle, "When enabled, shows the character's skill\r\nin training according to choice below");
+            cbSkillInTitle.Text = resources.GetString("cbSkillInTitle.Text");
+            ttToolTipCodes.SetToolTip(cbSkillInTitle, resources.GetString("cbSkillInTitle.ToolTip"));
             cbSkillInTitle.UseVisualStyleBackColor = true;
             // 
             // cbTitleToTime
@@ -545,8 +547,8 @@ namespace EVEMon.SettingsUI
             cbTitleToTime.Name = "cbTitleToTime";
             cbTitleToTime.Size = new System.Drawing.Size(212, 19);
             cbTitleToTime.TabIndex = 6;
-            cbTitleToTime.Text = "Show character info in window title";
-            ttToolTipCodes.SetToolTip(cbTitleToTime, "When enabled, shows the character's info in window title");
+            cbTitleToTime.Text = resources.GetString("cbTitleToTime.Text");
+            ttToolTipCodes.SetToolTip(cbTitleToTime, resources.GetString("cbTitleToTime.ToolTip"));
             cbTitleToTime.UseVisualStyleBackColor = true;
             cbTitleToTime.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -569,7 +571,17 @@ namespace EVEMon.SettingsUI
             lblEnvironment.Name = "lblEnvironment";
             lblEnvironment.Size = new System.Drawing.Size(236, 15);
             lblEnvironment.TabIndex = 1;
-            lblEnvironment.Text = "Environment (requires restart to take effect)";
+            lblEnvironment.Text = resources.GetString("lblEnvironment.Text");
+            //
+            // lblLanguage
+            //
+            lblLanguage.AutoSize = true;
+            lblLanguage.Location = new System.Drawing.Point(4, 181);
+            lblLanguage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            lblLanguage.Name = "lblLanguage";
+            lblLanguage.Size = new System.Drawing.Size(146, 15);
+            lblLanguage.TabIndex = 22;
+            lblLanguage.Text = resources.GetString("lblLanguage.Text");
             // 
             // lblSkillPlannerPage
             // 
@@ -580,7 +592,7 @@ namespace EVEMon.SettingsUI
             lblSkillPlannerPage.Name = "lblSkillPlannerPage";
             lblSkillPlannerPage.Size = new System.Drawing.Size(495, 32);
             lblSkillPlannerPage.TabIndex = 19;
-            lblSkillPlannerPage.Text = "You can select whether to highlight any entry in the Skill Planner according to its status and more.";
+            lblSkillPlannerPage.Text = resources.GetString("lblSkillPlannerPage.Text");
             // 
             // lblNetworkPageProxy
             // 
@@ -591,7 +603,7 @@ namespace EVEMon.SettingsUI
             lblNetworkPageProxy.Name = "lblNetworkPageProxy";
             lblNetworkPageProxy.Size = new System.Drawing.Size(465, 37);
             lblNetworkPageProxy.TabIndex = 8;
-            lblNetworkPageProxy.Text = "By default, EVEMon will use the same Proxy settings as Internet Explorer (can be configured through the Control Panel).";
+            lblNetworkPageProxy.Text = resources.GetString("lblNetworkPageProxy.Text");
             // 
             // lblProxyHostIPAddress
             // 
@@ -601,7 +613,7 @@ namespace EVEMon.SettingsUI
             lblProxyHostIPAddress.Name = "lblProxyHostIPAddress";
             lblProxyHostIPAddress.Size = new System.Drawing.Size(212, 15);
             lblProxyHostIPAddress.TabIndex = 3;
-            lblProxyHostIPAddress.Text = "Host/IP Address";
+            lblProxyHostIPAddress.Text = resources.GetString("lblProxyHostIPAddress.Text");
             lblProxyHostIPAddress.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lblProxyPort
@@ -612,7 +624,7 @@ namespace EVEMon.SettingsUI
             lblProxyPort.Name = "lblProxyPort";
             lblProxyPort.Size = new System.Drawing.Size(65, 15);
             lblProxyPort.TabIndex = 4;
-            lblProxyPort.Text = "Port";
+            lblProxyPort.Text = resources.GetString("lblProxyPort.Text");
             lblProxyPort.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lblHTTP
@@ -623,7 +635,7 @@ namespace EVEMon.SettingsUI
             lblHTTP.Name = "lblHTTP";
             lblHTTP.Size = new System.Drawing.Size(38, 15);
             lblHTTP.TabIndex = 0;
-            lblHTTP.Text = "HTTP:";
+            lblHTTP.Text = resources.GetString("lblHTTP.Text");
             lblHTTP.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // lblEmailNotificationPage
@@ -636,7 +648,7 @@ namespace EVEMon.SettingsUI
             lblEmailNotificationPage.Name = "lblEmailNotificationPage";
             lblEmailNotificationPage.Size = new System.Drawing.Size(405, 15);
             lblEmailNotificationPage.TabIndex = 19;
-            lblEmailNotificationPage.Text = "EVEMon can send you an email whenever a skill level completes its training.";
+            lblEmailNotificationPage.Text = resources.GetString("lblEmailNotificationPage.Text");
             // 
             // lblNotificationsPage
             // 
@@ -647,7 +659,7 @@ namespace EVEMon.SettingsUI
             lblNotificationsPage.Name = "lblNotificationsPage";
             lblNotificationsPage.Size = new System.Drawing.Size(495, 50);
             lblNotificationsPage.TabIndex = 19;
-            lblNotificationsPage.Text = "You can choose what notifications will be shown in your system's tray notification area or in EVEMon's main window and when. You can also toggle the sound notification upon skill completion on or off.";
+            lblNotificationsPage.Text = resources.GetString("lblNotificationsPage.Text");
             // 
             // lblTrayIconPage
             // 
@@ -658,7 +670,7 @@ namespace EVEMon.SettingsUI
             lblTrayIconPage.Name = "lblTrayIconPage";
             lblTrayIconPage.Size = new System.Drawing.Size(495, 36);
             lblTrayIconPage.TabIndex = 18;
-            lblTrayIconPage.Text = "Here you can set the visible status of EVEMon's Tray Icon, configure the style of the Tray Icon's popup info and EVEMon's behaviour upon pressing the Close button.\r\n";
+            lblTrayIconPage.Text = resources.GetString("lblTrayIconPage.Text");
             // 
             // lblSchedulerUIPage
             // 
@@ -669,7 +681,7 @@ namespace EVEMon.SettingsUI
             lblSchedulerUIPage.Name = "lblSchedulerUIPage";
             lblSchedulerUIPage.Size = new System.Drawing.Size(492, 52);
             lblSchedulerUIPage.TabIndex = 6;
-            lblSchedulerUIPage.Text = "Select the colors used in the scheduler. Using the scheduler, EVEMon can warn you about skill that will complete at times you will be away from your computer.";
+            lblSchedulerUIPage.Text = resources.GetString("lblSchedulerUIPage.Text");
             // 
             // lblText
             // 
@@ -679,7 +691,7 @@ namespace EVEMon.SettingsUI
             lblText.Name = "lblText";
             lblText.Size = new System.Drawing.Size(31, 15);
             lblText.TabIndex = 5;
-            lblText.Text = "Text:";
+            lblText.Text = resources.GetString("lblText.Text");
             // 
             // lblBlockingEvents
             // 
@@ -689,7 +701,7 @@ namespace EVEMon.SettingsUI
             lblBlockingEvents.Name = "lblBlockingEvents";
             lblBlockingEvents.Size = new System.Drawing.Size(93, 15);
             lblBlockingEvents.TabIndex = 0;
-            lblBlockingEvents.Text = "Blocking Events:";
+            lblBlockingEvents.Text = resources.GetString("lblBlockingEvents.Text");
             // 
             // lblRecurringEvents
             // 
@@ -699,7 +711,7 @@ namespace EVEMon.SettingsUI
             lblRecurringEvents.Name = "lblRecurringEvents";
             lblRecurringEvents.Size = new System.Drawing.Size(98, 15);
             lblRecurringEvents.TabIndex = 1;
-            lblRecurringEvents.Text = "Recurring Events:";
+            lblRecurringEvents.Text = resources.GetString("lblRecurringEvents.Text");
             // 
             // lblSimpleEvents
             // 
@@ -709,7 +721,7 @@ namespace EVEMon.SettingsUI
             lblSimpleEvents.Name = "lblSimpleEvents";
             lblSimpleEvents.Size = new System.Drawing.Size(83, 15);
             lblSimpleEvents.TabIndex = 2;
-            lblSimpleEvents.Text = "Simple Events:";
+            lblSimpleEvents.Text = resources.GetString("lblSimpleEvents.Text");
             // 
             // lblExternalCalendarPage
             // 
@@ -731,7 +743,7 @@ namespace EVEMon.SettingsUI
             lblIconsPage.Name = "lblIconsPage";
             lblIconsPage.Size = new System.Drawing.Size(495, 37);
             lblIconsPage.TabIndex = 15;
-            lblIconsPage.Text = "You can customize the icons used in the skill planner; if you have a good idea for a set of icons instructions to create your own can be found on wiki.";
+            lblIconsPage.Text = resources.GetString("lblIconsPage.Text");
             // 
             // gbSkillBrowserIconSet
             // 
@@ -744,7 +756,7 @@ namespace EVEMon.SettingsUI
             gbSkillBrowserIconSet.Size = new System.Drawing.Size(262, 235);
             gbSkillBrowserIconSet.TabIndex = 14;
             gbSkillBrowserIconSet.TabStop = false;
-            gbSkillBrowserIconSet.Text = "Skill Browser Icon Set";
+            gbSkillBrowserIconSet.Text = resources.GetString("gbSkillBrowserIconSet.Text");
             // 
             // iconsSetTableLayoutPanel
             // 
@@ -793,7 +805,7 @@ namespace EVEMon.SettingsUI
             lblObsoletePlanEntries.Name = "lblObsoletePlanEntries";
             lblObsoletePlanEntries.Size = new System.Drawing.Size(495, 32);
             lblObsoletePlanEntries.TabIndex = 24;
-            lblObsoletePlanEntries.Text = "You can configure how EVEMon handles skills that appear to be completed and reset the appearing messages behavior.";
+            lblObsoletePlanEntries.Text = resources.GetString("lblObsoletePlanEntries.Text");
             // 
             // cbUseIncreasedContrastOnOverview
             // 
@@ -803,8 +815,8 @@ namespace EVEMon.SettingsUI
             cbUseIncreasedContrastOnOverview.Name = "cbUseIncreasedContrastOnOverview";
             cbUseIncreasedContrastOnOverview.Size = new System.Drawing.Size(146, 19);
             cbUseIncreasedContrastOnOverview.TabIndex = 34;
-            cbUseIncreasedContrastOnOverview.Text = "Use Increased Contrast";
-            ttToolTipCodes.SetToolTip(cbUseIncreasedContrastOnOverview, "When enabled, increases the contrast of the shown info");
+            cbUseIncreasedContrastOnOverview.Text = resources.GetString("cbUseIncreasedContrastOnOverview.Text");
+            ttToolTipCodes.SetToolTip(cbUseIncreasedContrastOnOverview, resources.GetString("cbUseIncreasedContrastOnOverview.ToolTip"));
             cbUseIncreasedContrastOnOverview.UseVisualStyleBackColor = true;
             // 
             // overviewGroupCharactersInTrainingCheckBox
@@ -815,8 +827,8 @@ namespace EVEMon.SettingsUI
             overviewGroupCharactersInTrainingCheckBox.Name = "overviewGroupCharactersInTrainingCheckBox";
             overviewGroupCharactersInTrainingCheckBox.Size = new System.Drawing.Size(176, 19);
             overviewGroupCharactersInTrainingCheckBox.TabIndex = 33;
-            overviewGroupCharactersInTrainingCheckBox.Text = "Group Characters In Training";
-            ttToolTipCodes.SetToolTip(overviewGroupCharactersInTrainingCheckBox, "When enabled, groups the character's\r\nthat are currently in training");
+            overviewGroupCharactersInTrainingCheckBox.Text = resources.GetString("overviewGroupCharactersInTrainingCheckBox.Text");
+            ttToolTipCodes.SetToolTip(overviewGroupCharactersInTrainingCheckBox, resources.GetString("overviewGroupCharactersInTrainingCheckBox.ToolTip"));
             overviewGroupCharactersInTrainingCheckBox.UseVisualStyleBackColor = true;
             // 
             // overviewShowSkillQueueTrainingTimeCheckBox
@@ -827,8 +839,8 @@ namespace EVEMon.SettingsUI
             overviewShowSkillQueueTrainingTimeCheckBox.Name = "overviewShowSkillQueueTrainingTimeCheckBox";
             overviewShowSkillQueueTrainingTimeCheckBox.Size = new System.Drawing.Size(191, 19);
             overviewShowSkillQueueTrainingTimeCheckBox.TabIndex = 32;
-            overviewShowSkillQueueTrainingTimeCheckBox.Text = "Show Skill Queue Training Time";
-            ttToolTipCodes.SetToolTip(overviewShowSkillQueueTrainingTimeCheckBox, "When enabled, shows the character's\r\nskill queue training time");
+            overviewShowSkillQueueTrainingTimeCheckBox.Text = resources.GetString("overviewShowSkillQueueTrainingTimeCheckBox.Text");
+            ttToolTipCodes.SetToolTip(overviewShowSkillQueueTrainingTimeCheckBox, resources.GetString("overviewShowSkillQueueTrainingTimeCheckBox.ToolTip"));
             overviewShowSkillQueueTrainingTimeCheckBox.UseVisualStyleBackColor = true;
             // 
             // overviewShowWalletCheckBox
@@ -839,8 +851,8 @@ namespace EVEMon.SettingsUI
             overviewShowWalletCheckBox.Name = "overviewShowWalletCheckBox";
             overviewShowWalletCheckBox.Size = new System.Drawing.Size(135, 19);
             overviewShowWalletCheckBox.TabIndex = 30;
-            overviewShowWalletCheckBox.Text = "Show Wallet Balance";
-            ttToolTipCodes.SetToolTip(overviewShowWalletCheckBox, "When enabled, shows the character's wallet balance");
+            overviewShowWalletCheckBox.Text = resources.GetString("overviewShowWalletCheckBox.Text");
+            ttToolTipCodes.SetToolTip(overviewShowWalletCheckBox, resources.GetString("overviewShowWalletCheckBox.ToolTip"));
             overviewShowWalletCheckBox.UseVisualStyleBackColor = true;
             // 
             // overviewShowPortraitCheckBox
@@ -851,8 +863,8 @@ namespace EVEMon.SettingsUI
             overviewShowPortraitCheckBox.Name = "overviewShowPortraitCheckBox";
             overviewShowPortraitCheckBox.Size = new System.Drawing.Size(151, 19);
             overviewShowPortraitCheckBox.TabIndex = 26;
-            overviewShowPortraitCheckBox.Text = "Show Character Portrait";
-            ttToolTipCodes.SetToolTip(overviewShowPortraitCheckBox, "When enabled, shows the character's portrait\r\nas a thumbnail alongside the character's name");
+            overviewShowPortraitCheckBox.Text = resources.GetString("overviewShowPortraitCheckBox.Text");
+            ttToolTipCodes.SetToolTip(overviewShowPortraitCheckBox, resources.GetString("overviewShowPortraitCheckBox.ToolTip"));
             overviewShowPortraitCheckBox.UseVisualStyleBackColor = true;
             // 
             // cbShowOverViewTab
@@ -863,8 +875,8 @@ namespace EVEMon.SettingsUI
             cbShowOverViewTab.Name = "cbShowOverViewTab";
             cbShowOverViewTab.Size = new System.Drawing.Size(137, 19);
             cbShowOverViewTab.TabIndex = 0;
-            cbShowOverViewTab.Text = "Show \"Overview\" tab";
-            ttToolTipCodes.SetToolTip(cbShowOverViewTab, "When enabled, shows the Overview tab");
+            cbShowOverViewTab.Text = resources.GetString("cbShowOverViewTab.Text");
+            ttToolTipCodes.SetToolTip(cbShowOverViewTab, resources.GetString("cbShowOverViewTab.ToolTip"));
             cbShowOverViewTab.UseVisualStyleBackColor = true;
             cbShowOverViewTab.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -885,77 +897,77 @@ namespace EVEMon.SettingsUI
             treeNode16.Name = "UpdatesNode";
             treeNode16.SelectedImageIndex = 11;
             treeNode16.Tag = "updatesPage";
-            treeNode16.Text = "Updates";
+            treeNode16.Text = resources.GetString("treeNode16.Text");
             treeNode17.ImageIndex = 7;
             treeNode17.Name = "networkNode";
             treeNode17.SelectedImageIndex = 7;
             treeNode17.Tag = "networkPage";
-            treeNode17.Text = "Network";
+            treeNode17.Text = resources.GetString("treeNode17.Text");
             treeNode18.ImageIndex = 15;
             treeNode18.Name = "PortableEveClientsNode";
             treeNode18.SelectedImageIndex = 15;
             treeNode18.Tag = "portableEveClientsPage";
-            treeNode18.Text = "Portable EVE Clients";
+            treeNode18.Text = resources.GetString("treeNode18.Text");
             treeNode19.ImageIndex = 16;
             treeNode19.Name = "MarketPriceProvidersNode";
             treeNode19.SelectedImageIndex = 16;
             treeNode19.Tag = "marketPriceProvidersPage";
-            treeNode19.Text = "Market Price Providers";
+            treeNode19.Text = resources.GetString("treeNode19.Text");
             treeNode20.ImageIndex = 10;
             treeNode20.Name = "generalNode";
             treeNode20.SelectedImageIndex = 10;
             treeNode20.Tag = "generalPage";
-            treeNode20.Text = "General";
+            treeNode20.Text = resources.GetString("treeNode20.Text");
             treeNode21.ImageIndex = 6;
             treeNode21.Name = "Node3";
             treeNode21.SelectedImageIndex = 6;
             treeNode21.Tag = "mainWindowPage";
-            treeNode21.Text = "Main Window";
+            treeNode21.Text = resources.GetString("treeNode21.Text");
             treeNode22.ImageIndex = 13;
             treeNode22.Name = "IconsNode";
             treeNode22.SelectedImageIndex = 13;
             treeNode22.Tag = "iconsPage";
-            treeNode22.Text = "Icons";
+            treeNode22.Text = resources.GetString("treeNode22.Text");
             treeNode23.ImageIndex = 14;
             treeNode23.Name = "MassagesNode";
             treeNode23.SelectedImageIndex = 14;
             treeNode23.Tag = "messagesPage";
-            treeNode23.Text = "Messages";
+            treeNode23.Text = resources.GetString("treeNode23.Text");
             treeNode24.ImageIndex = 8;
             treeNode24.Name = "Node4";
             treeNode24.SelectedImageIndex = 8;
             treeNode24.Tag = "skillPlannerPage";
-            treeNode24.Text = "Skill Planner";
+            treeNode24.Text = resources.GetString("treeNode24.Text");
             treeNode25.ImageIndex = 2;
             treeNode25.Name = "trayIconNode";
             treeNode25.SelectedImageIndex = 2;
             treeNode25.Tag = "trayIconPage";
-            treeNode25.Text = "System Tray Icon";
+            treeNode25.Text = resources.GetString("treeNode25.Text");
             treeNode26.ImageIndex = 5;
             treeNode26.Name = "Node11";
             treeNode26.SelectedImageIndex = 5;
             treeNode26.Tag = "externalCalendarPage";
-            treeNode26.Text = "External Calendar";
+            treeNode26.Text = resources.GetString("treeNode26.Text");
             treeNode27.ImageIndex = 1;
             treeNode27.Name = "Node10";
             treeNode27.SelectedImageIndex = 1;
             treeNode27.Tag = "schedulerUIPage";
-            treeNode27.Text = "Scheduler";
+            treeNode27.Text = resources.GetString("treeNode27.Text");
             treeNode28.ImageIndex = 12;
             treeNode28.Name = "Node7";
             treeNode28.SelectedImageIndex = 12;
             treeNode28.Tag = "emailNotificationsPage";
-            treeNode28.Text = "Skill Completion Mails";
+            treeNode28.Text = resources.GetString("treeNode28.Text");
             treeNode29.ImageIndex = 9;
             treeNode29.Name = "Node2";
             treeNode29.SelectedImageIndex = 9;
             treeNode29.Tag = "notificationsPage";
-            treeNode29.Text = "Notifications";
+            treeNode29.Text = resources.GetString("treeNode29.Text");
             treeNode30.ImageIndex = 17;
             treeNode30.Name = "CloudStorageServiceNode";
             treeNode30.SelectedImageIndex = 17;
             treeNode30.Tag = "cloudStorageServicePage";
-            treeNode30.Text = "Cloud Storage Service";
+            treeNode30.Text = resources.GetString("treeNode30.Text");
             treeView.Nodes.AddRange(new System.Windows.Forms.TreeNode[] { treeNode20, treeNode21, treeNode24, treeNode25, treeNode27, treeNode29, treeNode30 });
             treeView.SelectedImageIndex = 0;
             treeView.ShowLines = false;
@@ -1033,6 +1045,8 @@ namespace EVEMon.SettingsUI
             generalPage.Controls.Add(btnEVEMonDataDir);
             generalPage.Controls.Add(lblGeneralPage);
             generalPage.Controls.Add(cbWorksafeMode);
+            generalPage.Controls.Add(languageComboBox);
+            generalPage.Controls.Add(lblLanguage);
             generalPage.Controls.Add(compatibilityCombo);
             generalPage.Controls.Add(lblEnvironment);
             generalPage.Controls.Add(runAtStartupComboBox);
@@ -1042,7 +1056,7 @@ namespace EVEMon.SettingsUI
             generalPage.Name = "generalPage";
             generalPage.Size = new System.Drawing.Size(507, 491);
             generalPage.TabIndex = 0;
-            generalPage.Text = "generalPage";
+            generalPage.Text = resources.GetString("generalPage.Text");
             // 
             // btnEVEMonDataDir
             // 
@@ -1053,28 +1067,38 @@ namespace EVEMon.SettingsUI
             btnEVEMonDataDir.Name = "btnEVEMonDataDir";
             btnEVEMonDataDir.Size = new System.Drawing.Size(162, 29);
             btnEVEMonDataDir.TabIndex = 21;
-            btnEVEMonDataDir.Text = "EVEMon Data Directory";
+            btnEVEMonDataDir.Text = resources.GetString("btnEVEMonDataDir.Text");
             btnEVEMonDataDir.UseVisualStyleBackColor = true;
             btnEVEMonDataDir.Click += btnEVEMonDataDir_Click;
             // 
             // cbWorksafeMode
             // 
             cbWorksafeMode.AutoSize = true;
-            cbWorksafeMode.Location = new System.Drawing.Point(4, 151);
+            cbWorksafeMode.Location = new System.Drawing.Point(4, 132);
             cbWorksafeMode.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             cbWorksafeMode.Name = "cbWorksafeMode";
             cbWorksafeMode.Size = new System.Drawing.Size(296, 19);
             cbWorksafeMode.TabIndex = 6;
-            cbWorksafeMode.Text = "Run in \"safe for work\" mode (no portraits or colors)";
+            cbWorksafeMode.Text = resources.GetString("cbWorksafeMode.Text");
             cbWorksafeMode.UseVisualStyleBackColor = true;
             cbWorksafeMode.CheckedChanged += OnMustEnableOrDisable;
+            //
+            // languageComboBox
+            //
+            languageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            languageComboBox.FormattingEnabled = true;
+            languageComboBox.Location = new System.Drawing.Point(270, 177);
+            languageComboBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            languageComboBox.Name = "languageComboBox";
+            languageComboBox.Size = new System.Drawing.Size(140, 23);
+            languageComboBox.TabIndex = 23;
             // 
             // compatibilityCombo
             // 
             compatibilityCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             compatibilityCombo.FormattingEnabled = true;
             compatibilityCombo.Items.AddRange(new object[] { "Windows", "Wine" });
-            compatibilityCombo.Location = new System.Drawing.Point(270, 205);
+            compatibilityCombo.Location = new System.Drawing.Point(270, 216);
             compatibilityCombo.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             compatibilityCombo.Name = "compatibilityCombo";
             compatibilityCombo.Size = new System.Drawing.Size(140, 23);
@@ -1088,7 +1112,7 @@ namespace EVEMon.SettingsUI
             runAtStartupComboBox.Name = "runAtStartupComboBox";
             runAtStartupComboBox.Size = new System.Drawing.Size(148, 19);
             runAtStartupComboBox.TabIndex = 5;
-            runAtStartupComboBox.Text = "Run EVEMon at Startup";
+            runAtStartupComboBox.Text = resources.GetString("runAtStartupComboBox.Text");
             runAtStartupComboBox.UseVisualStyleBackColor = true;
             // 
             // mainWindowPage
@@ -1103,7 +1127,7 @@ namespace EVEMon.SettingsUI
             mainWindowPage.Name = "mainWindowPage";
             mainWindowPage.Size = new System.Drawing.Size(507, 492);
             mainWindowPage.TabIndex = 1;
-            mainWindowPage.Text = "mainWindowPage";
+            mainWindowPage.Text = resources.GetString("mainWindowPage.Text");
             // 
             // OverviewGroupBox
             // 
@@ -1117,7 +1141,7 @@ namespace EVEMon.SettingsUI
             OverviewGroupBox.Size = new System.Drawing.Size(499, 147);
             OverviewGroupBox.TabIndex = 15;
             OverviewGroupBox.TabStop = false;
-            OverviewGroupBox.Text = "Overview";
+            OverviewGroupBox.Text = resources.GetString("OverviewGroupBox.Text");
             // 
             // overviewPanel
             // 
@@ -1156,7 +1180,7 @@ namespace EVEMon.SettingsUI
             cbShowSkillpointsOnOverview.Name = "cbShowSkillpointsOnOverview";
             cbShowSkillpointsOnOverview.Size = new System.Drawing.Size(115, 19);
             cbShowSkillpointsOnOverview.TabIndex = 35;
-            cbShowSkillpointsOnOverview.Text = "Show Skill Points";
+            cbShowSkillpointsOnOverview.Text = resources.GetString("cbShowSkillpointsOnOverview.Text");
             cbShowSkillpointsOnOverview.UseVisualStyleBackColor = true;
             // 
             // overviewPortraitSizeComboBox
@@ -1185,7 +1209,7 @@ namespace EVEMon.SettingsUI
             skillPlannerPage.Name = "skillPlannerPage";
             skillPlannerPage.Size = new System.Drawing.Size(507, 492);
             skillPlannerPage.TabIndex = 3;
-            skillPlannerPage.Text = "skillPlannerPage";
+            skillPlannerPage.Text = resources.GetString("skillPlannerPage.Text");
             skillPlannerPage.Visible = false;
             // 
             // cbAdvanceEntryAdd
@@ -1196,7 +1220,7 @@ namespace EVEMon.SettingsUI
             cbAdvanceEntryAdd.Name = "cbAdvanceEntryAdd";
             cbAdvanceEntryAdd.Size = new System.Drawing.Size(229, 19);
             cbAdvanceEntryAdd.TabIndex = 21;
-            cbAdvanceEntryAdd.Text = "Set Priority When Adding Skills To Plan";
+            cbAdvanceEntryAdd.Text = resources.GetString("cbAdvanceEntryAdd.Text");
             cbAdvanceEntryAdd.UseVisualStyleBackColor = true;
             // 
             // cbSummaryOnMultiSelectOnly
@@ -1207,7 +1231,7 @@ namespace EVEMon.SettingsUI
             cbSummaryOnMultiSelectOnly.Name = "cbSummaryOnMultiSelectOnly";
             cbSummaryOnMultiSelectOnly.Size = new System.Drawing.Size(259, 19);
             cbSummaryOnMultiSelectOnly.TabIndex = 20;
-            cbSummaryOnMultiSelectOnly.Text = "Show Plan Summary Only On \"Multi-Select\"";
+            cbSummaryOnMultiSelectOnly.Text = resources.GetString("cbSummaryOnMultiSelectOnly.Text");
             cbSummaryOnMultiSelectOnly.UseVisualStyleBackColor = true;
             // 
             // cbHighlightQueuedSiklls
@@ -1218,7 +1242,7 @@ namespace EVEMon.SettingsUI
             cbHighlightQueuedSiklls.Name = "cbHighlightQueuedSiklls";
             cbHighlightQueuedSiklls.Size = new System.Drawing.Size(150, 19);
             cbHighlightQueuedSiklls.TabIndex = 14;
-            cbHighlightQueuedSiklls.Text = "Highlight Queued Skills";
+            cbHighlightQueuedSiklls.Text = resources.GetString("cbHighlightQueuedSiklls.Text");
             cbHighlightQueuedSiklls.UseVisualStyleBackColor = true;
             // 
             // cbHighlightPartialSkills
@@ -1229,7 +1253,7 @@ namespace EVEMon.SettingsUI
             cbHighlightPartialSkills.Name = "cbHighlightPartialSkills";
             cbHighlightPartialSkills.Size = new System.Drawing.Size(191, 19);
             cbHighlightPartialSkills.TabIndex = 10;
-            cbHighlightPartialSkills.Text = "Highlight Partially Trained Skills";
+            cbHighlightPartialSkills.Text = resources.GetString("cbHighlightPartialSkills.Text");
             cbHighlightPartialSkills.UseVisualStyleBackColor = true;
             // 
             // cbHighlightConflicts
@@ -1240,7 +1264,7 @@ namespace EVEMon.SettingsUI
             cbHighlightConflicts.Name = "cbHighlightConflicts";
             cbHighlightConflicts.Size = new System.Drawing.Size(177, 19);
             cbHighlightConflicts.TabIndex = 9;
-            cbHighlightConflicts.Text = "Highlight Schedule Conflicts";
+            cbHighlightConflicts.Text = resources.GetString("cbHighlightConflicts.Text");
             cbHighlightConflicts.UseVisualStyleBackColor = true;
             // 
             // cbHighlightPrerequisites
@@ -1251,7 +1275,7 @@ namespace EVEMon.SettingsUI
             cbHighlightPrerequisites.Name = "cbHighlightPrerequisites";
             cbHighlightPrerequisites.Size = new System.Drawing.Size(146, 19);
             cbHighlightPrerequisites.TabIndex = 8;
-            cbHighlightPrerequisites.Text = "Highlight Prerequisites";
+            cbHighlightPrerequisites.Text = resources.GetString("cbHighlightPrerequisites.Text");
             cbHighlightPrerequisites.UseVisualStyleBackColor = true;
             // 
             // cbHighlightPlannedSkills
@@ -1262,7 +1286,7 @@ namespace EVEMon.SettingsUI
             cbHighlightPlannedSkills.Name = "cbHighlightPlannedSkills";
             cbHighlightPlannedSkills.Size = new System.Drawing.Size(151, 19);
             cbHighlightPlannedSkills.TabIndex = 0;
-            cbHighlightPlannedSkills.Text = "Highlight Planned Skills";
+            cbHighlightPlannedSkills.Text = resources.GetString("cbHighlightPlannedSkills.Text");
             cbHighlightPlannedSkills.UseVisualStyleBackColor = true;
             // 
             // networkPage
@@ -1275,7 +1299,7 @@ namespace EVEMon.SettingsUI
             networkPage.Name = "networkPage";
             networkPage.Size = new System.Drawing.Size(507, 492);
             networkPage.TabIndex = 4;
-            networkPage.Text = "networkPage";
+            networkPage.Text = resources.GetString("networkPage.Text");
             networkPage.Visible = false;
             // 
             // esiSettingsGroupBox
@@ -1292,7 +1316,7 @@ namespace EVEMon.SettingsUI
             esiSettingsGroupBox.Size = new System.Drawing.Size(477, 102);
             esiSettingsGroupBox.TabIndex = 1;
             esiSettingsGroupBox.TabStop = false;
-            esiSettingsGroupBox.Text = "ESI Client Settings";
+            esiSettingsGroupBox.Text = resources.GetString("esiSettingsGroupBox.Text");
             // 
             // lblClientSecret
             // 
@@ -1302,7 +1326,7 @@ namespace EVEMon.SettingsUI
             lblClientSecret.Name = "lblClientSecret";
             lblClientSecret.Size = new System.Drawing.Size(73, 15);
             lblClientSecret.TabIndex = 2;
-            lblClientSecret.Text = "Client Secret";
+            lblClientSecret.Text = resources.GetString("lblClientSecret.Text");
             // 
             // lblClientID
             // 
@@ -1312,7 +1336,7 @@ namespace EVEMon.SettingsUI
             lblClientID.Name = "lblClientID";
             lblClientID.Size = new System.Drawing.Size(52, 15);
             lblClientID.TabIndex = 2;
-            lblClientID.Text = "Client ID";
+            lblClientID.Text = resources.GetString("lblClientID.Text");
             // 
             // esiSettingsLabel
             // 
@@ -1324,7 +1348,7 @@ namespace EVEMon.SettingsUI
             esiSettingsLabel.Size = new System.Drawing.Size(395, 21);
             esiSettingsLabel.TabIndex = 1;
             esiSettingsLabel.TabStop = true;
-            esiSettingsLabel.Text = "Create ESI client application: https://peterhaneve.github.io/evemon-esi\r\n";
+            esiSettingsLabel.Text = resources.GetString("esiSettingsLabel.Text");
             esiSettingsLabel.UseCompatibleTextRendering = true;
             esiSettingsLabel.LinkClicked += esiSettingsLabel_LinkClicked;
             // 
@@ -1357,7 +1381,7 @@ namespace EVEMon.SettingsUI
             ProxyServerGroupBox.Size = new System.Drawing.Size(477, 181);
             ProxyServerGroupBox.TabIndex = 0;
             ProxyServerGroupBox.TabStop = false;
-            ProxyServerGroupBox.Text = "Proxy Server Settings";
+            ProxyServerGroupBox.Text = resources.GetString("ProxyServerGroupBox.Text");
             // 
             // customProxyCheckBox
             // 
@@ -1367,7 +1391,7 @@ namespace EVEMon.SettingsUI
             customProxyCheckBox.Name = "customProxyCheckBox";
             customProxyCheckBox.Size = new System.Drawing.Size(130, 19);
             customProxyCheckBox.TabIndex = 9;
-            customProxyCheckBox.Text = "Use a custom proxy";
+            customProxyCheckBox.Text = resources.GetString("customProxyCheckBox.Text");
             customProxyCheckBox.UseVisualStyleBackColor = true;
             customProxyCheckBox.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -1406,7 +1430,7 @@ namespace EVEMon.SettingsUI
             proxyAuthenticationButton.Name = "proxyAuthenticationButton";
             proxyAuthenticationButton.Size = new System.Drawing.Size(113, 27);
             proxyAuthenticationButton.TabIndex = 5;
-            proxyAuthenticationButton.Text = "Authentication...";
+            proxyAuthenticationButton.Text = resources.GetString("proxyAuthenticationButton.Text");
             proxyAuthenticationButton.UseVisualStyleBackColor = true;
             proxyAuthenticationButton.Click += proxyAuthenticationButton_Click;
             // 
@@ -1430,7 +1454,7 @@ namespace EVEMon.SettingsUI
             emailNotificationsPage.Name = "emailNotificationsPage";
             emailNotificationsPage.Size = new System.Drawing.Size(507, 492);
             emailNotificationsPage.TabIndex = 6;
-            emailNotificationsPage.Text = "emailNotificationsPage";
+            emailNotificationsPage.Text = resources.GetString("emailNotificationsPage.Text");
             emailNotificationsPage.Visible = false;
             // 
             // mailNotificationCheckBox
@@ -1441,7 +1465,7 @@ namespace EVEMon.SettingsUI
             mailNotificationCheckBox.Name = "mailNotificationCheckBox";
             mailNotificationCheckBox.Size = new System.Drawing.Size(241, 19);
             mailNotificationCheckBox.TabIndex = 0;
-            mailNotificationCheckBox.Text = "Send email when skill training completes";
+            mailNotificationCheckBox.Text = resources.GetString("mailNotificationCheckBox.Text");
             mailNotificationCheckBox.UseVisualStyleBackColor = true;
             mailNotificationCheckBox.CheckedChanged += OnMustEnableOrDisable;
             // 
@@ -1465,7 +1489,7 @@ namespace EVEMon.SettingsUI
             notificationsPage.Name = "notificationsPage";
             notificationsPage.Size = new System.Drawing.Size(507, 492);
             notificationsPage.TabIndex = 7;
-            notificationsPage.Text = "notificationsPage";
+            notificationsPage.Text = resources.GetString("notificationsPage.Text");
             notificationsPage.Visible = false;
             // 
             // cbPlaySoundOnSkillComplete
@@ -1476,7 +1500,7 @@ namespace EVEMon.SettingsUI
             cbPlaySoundOnSkillComplete.Name = "cbPlaySoundOnSkillComplete";
             cbPlaySoundOnSkillComplete.Size = new System.Drawing.Size(241, 19);
             cbPlaySoundOnSkillComplete.TabIndex = 3;
-            cbPlaySoundOnSkillComplete.Text = "Play sound when skill training completes";
+            cbPlaySoundOnSkillComplete.Text = resources.GetString("cbPlaySoundOnSkillComplete.Text");
             cbPlaySoundOnSkillComplete.UseVisualStyleBackColor = true;
             // 
             // notificationsControl
@@ -1503,7 +1527,7 @@ namespace EVEMon.SettingsUI
             trayIconPage.Name = "trayIconPage";
             trayIconPage.Size = new System.Drawing.Size(507, 492);
             trayIconPage.TabIndex = 8;
-            trayIconPage.Text = "trayIconPage";
+            trayIconPage.Text = resources.GetString("trayIconPage.Text");
             trayIconPage.Visible = false;
             // 
             // mainWindowBehaviourGroupBox
@@ -1518,7 +1542,7 @@ namespace EVEMon.SettingsUI
             mainWindowBehaviourGroupBox.Size = new System.Drawing.Size(489, 105);
             mainWindowBehaviourGroupBox.TabIndex = 17;
             mainWindowBehaviourGroupBox.TabStop = false;
-            mainWindowBehaviourGroupBox.Text = "Main Window Close Behaviour";
+            mainWindowBehaviourGroupBox.Text = resources.GetString("mainWindowBehaviourGroupBox.Text");
             // 
             // rbMinToTaskBar
             // 
@@ -1529,7 +1553,7 @@ namespace EVEMon.SettingsUI
             rbMinToTaskBar.Size = new System.Drawing.Size(149, 19);
             rbMinToTaskBar.TabIndex = 2;
             rbMinToTaskBar.TabStop = true;
-            rbMinToTaskBar.Text = "Minimize to the taskbar";
+            rbMinToTaskBar.Text = resources.GetString("rbMinToTaskBar.Text");
             rbMinToTaskBar.UseVisualStyleBackColor = true;
             // 
             // rbMinToTray
@@ -1541,7 +1565,7 @@ namespace EVEMon.SettingsUI
             rbMinToTray.Size = new System.Drawing.Size(171, 19);
             rbMinToTray.TabIndex = 1;
             rbMinToTray.TabStop = true;
-            rbMinToTray.Text = "Minimize to the system tray";
+            rbMinToTray.Text = resources.GetString("rbMinToTray.Text");
             rbMinToTray.UseVisualStyleBackColor = true;
             // 
             // rbExitEVEMon
@@ -1553,7 +1577,7 @@ namespace EVEMon.SettingsUI
             rbExitEVEMon.Size = new System.Drawing.Size(91, 19);
             rbExitEVEMon.TabIndex = 0;
             rbExitEVEMon.TabStop = true;
-            rbExitEVEMon.Text = "Exit EVEMon";
+            rbExitEVEMon.Text = resources.GetString("rbExitEVEMon.Text");
             rbExitEVEMon.UseVisualStyleBackColor = true;
             // 
             // trayIconPopupGroupBox
@@ -1571,7 +1595,7 @@ namespace EVEMon.SettingsUI
             trayIconPopupGroupBox.Size = new System.Drawing.Size(489, 120);
             trayIconPopupGroupBox.TabIndex = 10;
             trayIconPopupGroupBox.TabStop = false;
-            trayIconPopupGroupBox.Text = "Icon Popup Style";
+            trayIconPopupGroupBox.Text = resources.GetString("trayIconPopupGroupBox.Text");
             // 
             // trayPopupDisabledRadio
             // 
@@ -1582,7 +1606,7 @@ namespace EVEMon.SettingsUI
             trayPopupDisabledRadio.Size = new System.Drawing.Size(70, 19);
             trayPopupDisabledRadio.TabIndex = 5;
             trayPopupDisabledRadio.TabStop = true;
-            trayPopupDisabledRadio.Text = "Disabled";
+            trayPopupDisabledRadio.Text = resources.GetString("trayPopupDisabledRadio.Text");
             trayPopupDisabledRadio.UseVisualStyleBackColor = true;
             // 
             // trayPopupButton
@@ -1592,7 +1616,7 @@ namespace EVEMon.SettingsUI
             trayPopupButton.Name = "trayPopupButton";
             trayPopupButton.Size = new System.Drawing.Size(88, 27);
             trayPopupButton.TabIndex = 4;
-            trayPopupButton.Text = "Configure";
+            trayPopupButton.Text = resources.GetString("trayPopupButton.Text");
             trayPopupButton.UseVisualStyleBackColor = true;
             trayPopupButton.Click += trayPopupButton_Click;
             // 
@@ -1605,7 +1629,7 @@ namespace EVEMon.SettingsUI
             trayPopupRadio.Size = new System.Drawing.Size(60, 19);
             trayPopupRadio.TabIndex = 3;
             trayPopupRadio.TabStop = true;
-            trayPopupRadio.Text = "Popup";
+            trayPopupRadio.Text = resources.GetString("trayPopupRadio.Text");
             trayPopupRadio.UseVisualStyleBackColor = true;
             // 
             // trayTooltipRadio
@@ -1617,7 +1641,7 @@ namespace EVEMon.SettingsUI
             trayTooltipRadio.Size = new System.Drawing.Size(61, 19);
             trayTooltipRadio.TabIndex = 0;
             trayTooltipRadio.TabStop = true;
-            trayTooltipRadio.Text = "Tooltip";
+            trayTooltipRadio.Text = resources.GetString("trayTooltipRadio.Text");
             trayTooltipRadio.UseVisualStyleBackColor = true;
             // 
             // trayTooltipButton
@@ -1627,7 +1651,7 @@ namespace EVEMon.SettingsUI
             trayTooltipButton.Name = "trayTooltipButton";
             trayTooltipButton.Size = new System.Drawing.Size(88, 27);
             trayTooltipButton.TabIndex = 2;
-            trayTooltipButton.Text = "Configure";
+            trayTooltipButton.Text = resources.GetString("trayTooltipButton.Text");
             trayTooltipButton.UseVisualStyleBackColor = true;
             trayTooltipButton.Click += trayTooltipButton_Click;
             // 
@@ -1643,7 +1667,7 @@ namespace EVEMon.SettingsUI
             updatesPage.Name = "updatesPage";
             updatesPage.Size = new System.Drawing.Size(507, 492);
             updatesPage.TabIndex = 9;
-            updatesPage.Text = "updatesPage";
+            updatesPage.Text = resources.GetString("updatesPage.Text");
             updatesPage.Visible = false;
             // 
             // updateSettingsControl
@@ -1666,7 +1690,7 @@ namespace EVEMon.SettingsUI
             lblUpdatesPage.Name = "lblUpdatesPage";
             lblUpdatesPage.Size = new System.Drawing.Size(500, 39);
             lblUpdatesPage.TabIndex = 9;
-            lblUpdatesPage.Text = "The following settings help reducing the network load, especially for high-latency connections and clients with many characters.";
+            lblUpdatesPage.Text = resources.GetString("lblUpdatesPage.Text");
             // 
             // cbCheckTime
             // 
@@ -1676,7 +1700,7 @@ namespace EVEMon.SettingsUI
             cbCheckTime.Name = "cbCheckTime";
             cbCheckTime.Size = new System.Drawing.Size(157, 19);
             cbCheckTime.TabIndex = 0;
-            cbCheckTime.Text = "Check system clock sync";
+            cbCheckTime.Text = resources.GetString("cbCheckTime.Text");
             cbCheckTime.UseVisualStyleBackColor = true;
             // 
             // cbCheckForUpdates
@@ -1687,7 +1711,7 @@ namespace EVEMon.SettingsUI
             cbCheckForUpdates.Name = "cbCheckForUpdates";
             cbCheckForUpdates.Size = new System.Drawing.Size(169, 19);
             cbCheckForUpdates.TabIndex = 0;
-            cbCheckForUpdates.Text = "Check for EVEMon updates";
+            cbCheckForUpdates.Text = resources.GetString("cbCheckForUpdates.Text");
             cbCheckForUpdates.UseVisualStyleBackColor = true;
             // 
             // schedulerUIPage
@@ -1709,7 +1733,7 @@ namespace EVEMon.SettingsUI
             schedulerUIPage.Name = "schedulerUIPage";
             schedulerUIPage.Size = new System.Drawing.Size(507, 492);
             schedulerUIPage.TabIndex = 10;
-            schedulerUIPage.Text = "schedulerUIPage";
+            schedulerUIPage.Text = resources.GetString("schedulerUIPage.Text");
             schedulerUIPage.Visible = false;
             // 
             // panelColorText
@@ -1795,7 +1819,7 @@ namespace EVEMon.SettingsUI
             externalCalendarPage.Name = "externalCalendarPage";
             externalCalendarPage.Size = new System.Drawing.Size(507, 491);
             externalCalendarPage.TabIndex = 11;
-            externalCalendarPage.Text = "externalCalendarPage";
+            externalCalendarPage.Text = resources.GetString("externalCalendarPage.Text");
             externalCalendarPage.Visible = false;
             // 
             // externalCalendarControl
@@ -1817,7 +1841,7 @@ namespace EVEMon.SettingsUI
             externalCalendarCheckbox.Name = "externalCalendarCheckbox";
             externalCalendarCheckbox.Size = new System.Drawing.Size(140, 19);
             externalCalendarCheckbox.TabIndex = 0;
-            externalCalendarCheckbox.Text = "Use External Calendar";
+            externalCalendarCheckbox.Text = resources.GetString("externalCalendarCheckbox.Text");
             externalCalendarCheckbox.UseVisualStyleBackColor = true;
             externalCalendarCheckbox.Click += OnMustEnableOrDisable;
             // 
@@ -1831,7 +1855,7 @@ namespace EVEMon.SettingsUI
             iconsPage.Name = "iconsPage";
             iconsPage.Size = new System.Drawing.Size(507, 492);
             iconsPage.TabIndex = 16;
-            iconsPage.Text = "iconsPage";
+            iconsPage.Text = resources.GetString("iconsPage.Text");
             // 
             // messagesPage
             // 
@@ -1844,7 +1868,7 @@ namespace EVEMon.SettingsUI
             messagesPage.Name = "messagesPage";
             messagesPage.Size = new System.Drawing.Size(507, 492);
             messagesPage.TabIndex = 17;
-            messagesPage.Text = "messagesPage";
+            messagesPage.Text = resources.GetString("messagesPage.Text");
             // 
             // gbMessageBox
             // 
@@ -1857,7 +1881,7 @@ namespace EVEMon.SettingsUI
             gbMessageBox.Size = new System.Drawing.Size(495, 67);
             gbMessageBox.TabIndex = 25;
             gbMessageBox.TabStop = false;
-            gbMessageBox.Text = "Pop-up Messages";
+            gbMessageBox.Text = resources.GetString("gbMessageBox.Text");
             // 
             // lblPrioritesConflict
             // 
@@ -1867,7 +1891,7 @@ namespace EVEMon.SettingsUI
             lblPrioritesConflict.Name = "lblPrioritesConflict";
             lblPrioritesConflict.Size = new System.Drawing.Size(98, 15);
             lblPrioritesConflict.TabIndex = 1;
-            lblPrioritesConflict.Text = "Priorities Conflict";
+            lblPrioritesConflict.Text = resources.GetString("lblPrioritesConflict.Text");
             // 
             // btnPrioritiesReset
             // 
@@ -1876,7 +1900,7 @@ namespace EVEMon.SettingsUI
             btnPrioritiesReset.Name = "btnPrioritiesReset";
             btnPrioritiesReset.Size = new System.Drawing.Size(88, 27);
             btnPrioritiesReset.TabIndex = 0;
-            btnPrioritiesReset.Text = "Reset";
+            btnPrioritiesReset.Text = resources.GetString("btnPrioritiesReset.Text");
             btnPrioritiesReset.UseVisualStyleBackColor = true;
             btnPrioritiesReset.Click += btnPrioritiesReset_Click;
             // 
@@ -1895,7 +1919,7 @@ namespace EVEMon.SettingsUI
             ObsoleteEntryRemovalGroupBox.Size = new System.Drawing.Size(496, 216);
             ObsoleteEntryRemovalGroupBox.TabIndex = 23;
             ObsoleteEntryRemovalGroupBox.TabStop = false;
-            ObsoleteEntryRemovalGroupBox.Text = "Obsolete Plan Entry Removal";
+            ObsoleteEntryRemovalGroupBox.Text = resources.GetString("ObsoleteEntryRemovalGroupBox.Text");
             // 
             // RemoveAllLabel
             // 
@@ -1904,7 +1928,7 @@ namespace EVEMon.SettingsUI
             RemoveAllLabel.Name = "RemoveAllLabel";
             RemoveAllLabel.Size = new System.Drawing.Size(460, 31);
             RemoveAllLabel.TabIndex = 5;
-            RemoveAllLabel.Text = "If EVEMon believes a skill level has been completed, whether it has been confirmed by the API or not it will be removed when the plan is opened.";
+            RemoveAllLabel.Text = resources.GetString("RemoveAllLabel.Text");
             // 
             // AlwaysAskLabel
             // 
@@ -1913,7 +1937,7 @@ namespace EVEMon.SettingsUI
             AlwaysAskLabel.Name = "AlwaysAskLabel";
             AlwaysAskLabel.Size = new System.Drawing.Size(460, 31);
             AlwaysAskLabel.TabIndex = 4;
-            AlwaysAskLabel.Text = "Always display the \"Obsolete Entries\" link at the bottom of the skill planner before removing entries.";
+            AlwaysAskLabel.Text = resources.GetString("AlwaysAskLabel.Text");
             // 
             // RemoveConfirmedLabel
             // 
@@ -1922,7 +1946,7 @@ namespace EVEMon.SettingsUI
             RemoveConfirmedLabel.Name = "RemoveConfirmedLabel";
             RemoveConfirmedLabel.Size = new System.Drawing.Size(460, 31);
             RemoveConfirmedLabel.TabIndex = 3;
-            RemoveConfirmedLabel.Text = "Once the API has confirmed a skill level has completed it is removed the next time a plan is opened. This is the default behaviour.";
+            RemoveConfirmedLabel.Text = resources.GetString("RemoveConfirmedLabel.Text");
             // 
             // alwaysAskRadioButton
             // 
@@ -1933,7 +1957,7 @@ namespace EVEMon.SettingsUI
             alwaysAskRadioButton.Size = new System.Drawing.Size(82, 19);
             alwaysAskRadioButton.TabIndex = 2;
             alwaysAskRadioButton.TabStop = true;
-            alwaysAskRadioButton.Text = "Always ask";
+            alwaysAskRadioButton.Text = resources.GetString("alwaysAskRadioButton.Text");
             alwaysAskRadioButton.UseVisualStyleBackColor = true;
             // 
             // removeAllRadioButton
@@ -1945,7 +1969,7 @@ namespace EVEMon.SettingsUI
             removeAllRadioButton.Size = new System.Drawing.Size(229, 19);
             removeAllRadioButton.TabIndex = 1;
             removeAllRadioButton.TabStop = true;
-            removeAllRadioButton.Text = "Remove entry once training completes";
+            removeAllRadioButton.Text = resources.GetString("removeAllRadioButton.Text");
             removeAllRadioButton.UseVisualStyleBackColor = true;
             // 
             // removeConfirmedRadioButton
@@ -1957,7 +1981,7 @@ namespace EVEMon.SettingsUI
             removeConfirmedRadioButton.Size = new System.Drawing.Size(248, 19);
             removeConfirmedRadioButton.TabIndex = 0;
             removeConfirmedRadioButton.TabStop = true;
-            removeConfirmedRadioButton.Text = "Remove confirmed entry (Recommended)";
+            removeConfirmedRadioButton.Text = resources.GetString("removeConfirmedRadioButton.Text");
             removeConfirmedRadioButton.UseVisualStyleBackColor = true;
             // 
             // portableEveClientsPage
@@ -1970,7 +1994,7 @@ namespace EVEMon.SettingsUI
             portableEveClientsPage.Name = "portableEveClientsPage";
             portableEveClientsPage.Size = new System.Drawing.Size(507, 492);
             portableEveClientsPage.TabIndex = 20;
-            portableEveClientsPage.Text = "portableEveClientsPage";
+            portableEveClientsPage.Text = resources.GetString("portableEveClientsPage.Text");
             // 
             // lblPECIDescription
             // 
@@ -1993,7 +2017,7 @@ namespace EVEMon.SettingsUI
             PECIGroupBox.Size = new System.Drawing.Size(491, 327);
             PECIGroupBox.TabIndex = 0;
             PECIGroupBox.TabStop = false;
-            PECIGroupBox.Text = "Portable EVE Client Installations";
+            PECIGroupBox.Text = resources.GetString("PECIGroupBox.Text");
             // 
             // portableEveClientsControl
             // 
@@ -2015,7 +2039,7 @@ namespace EVEMon.SettingsUI
             marketPriceProvidersPage.Name = "marketPriceProvidersPage";
             marketPriceProvidersPage.Size = new System.Drawing.Size(507, 492);
             marketPriceProvidersPage.TabIndex = 21;
-            marketPriceProvidersPage.Text = "marketPriceProvidersPage";
+            marketPriceProvidersPage.Text = resources.GetString("marketPriceProvidersPage.Text");
             // 
             // gbMarketPriceProviders
             // 
@@ -2028,7 +2052,7 @@ namespace EVEMon.SettingsUI
             gbMarketPriceProviders.Size = new System.Drawing.Size(250, 77);
             gbMarketPriceProviders.TabIndex = 22;
             gbMarketPriceProviders.TabStop = false;
-            gbMarketPriceProviders.Text = "Market Price Provider";
+            gbMarketPriceProviders.Text = resources.GetString("gbMarketPriceProviders.Text");
             // 
             // cbProvidersList
             // 
@@ -2048,7 +2072,7 @@ namespace EVEMon.SettingsUI
             SelectedProviderLabel.Name = "SelectedProviderLabel";
             SelectedProviderLabel.Size = new System.Drawing.Size(54, 15);
             SelectedProviderLabel.TabIndex = 0;
-            SelectedProviderLabel.Text = "Provider:";
+            SelectedProviderLabel.Text = resources.GetString("SelectedProviderLabel.Text");
             // 
             // marketPriceProviderPageLabel
             // 
@@ -2060,7 +2084,7 @@ namespace EVEMon.SettingsUI
             marketPriceProviderPageLabel.Name = "marketPriceProviderPageLabel";
             marketPriceProviderPageLabel.Size = new System.Drawing.Size(327, 15);
             marketPriceProviderPageLabel.TabIndex = 21;
-            marketPriceProviderPageLabel.Text = "Request prices for all EVE items from a market price provider.";
+            marketPriceProviderPageLabel.Text = resources.GetString("marketPriceProviderPageLabel.Text");
             // 
             // cloudStorageServicePage
             // 
@@ -2074,7 +2098,7 @@ namespace EVEMon.SettingsUI
             cloudStorageServicePage.Name = "cloudStorageServicePage";
             cloudStorageServicePage.Size = new System.Drawing.Size(507, 492);
             cloudStorageServicePage.TabIndex = 22;
-            cloudStorageServicePage.Text = "cloudStorageServicePage";
+            cloudStorageServicePage.Text = resources.GetString("cloudStorageServicePage.Text");
             // 
             // providerAuthenticationGroupBox
             // 
@@ -2086,7 +2110,7 @@ namespace EVEMon.SettingsUI
             providerAuthenticationGroupBox.Size = new System.Drawing.Size(491, 148);
             providerAuthenticationGroupBox.TabIndex = 24;
             providerAuthenticationGroupBox.TabStop = false;
-            providerAuthenticationGroupBox.Text = "Cloud Storage Provider Authentication";
+            providerAuthenticationGroupBox.Text = resources.GetString("providerAuthenticationGroupBox.Text");
             // 
             // cloudStorageServiceControl
             // 
@@ -2110,7 +2134,7 @@ namespace EVEMon.SettingsUI
             cloudStorageGroupBox.Size = new System.Drawing.Size(271, 77);
             cloudStorageGroupBox.TabIndex = 23;
             cloudStorageGroupBox.TabStop = false;
-            cloudStorageGroupBox.Text = "Cloud Storage Provider";
+            cloudStorageGroupBox.Text = resources.GetString("cloudStorageGroupBox.Text");
             // 
             // cloudStorageProviderLogoPictureBox
             // 
@@ -2141,7 +2165,7 @@ namespace EVEMon.SettingsUI
             lblSelectedProvider.Name = "lblSelectedProvider";
             lblSelectedProvider.Size = new System.Drawing.Size(54, 15);
             lblSelectedProvider.TabIndex = 0;
-            lblSelectedProvider.Text = "Provider:";
+            lblSelectedProvider.Text = resources.GetString("lblSelectedProvider.Text");
             // 
             // linkLabel1
             // 
@@ -2164,7 +2188,7 @@ namespace EVEMon.SettingsUI
             settingsFileStorageGroupBox.Size = new System.Drawing.Size(492, 147);
             settingsFileStorageGroupBox.TabIndex = 4;
             settingsFileStorageGroupBox.TabStop = false;
-            settingsFileStorageGroupBox.Text = "Settings File Storage";
+            settingsFileStorageGroupBox.Text = resources.GetString("settingsFileStorageGroupBox.Text");
             // 
             // settingsFileStorageControl
             // 
@@ -2300,6 +2324,7 @@ namespace EVEMon.SettingsUI
         private System.Windows.Forms.CheckBox cbCheckTime;
         private System.Windows.Forms.CheckBox cbShowOverViewTab;
         private System.Windows.Forms.ComboBox compatibilityCombo;
+        private System.Windows.Forms.ComboBox languageComboBox;
         private EVEMon.SettingsUI.NotificationsControl notificationsControl;
         private System.Windows.Forms.TreeView treeView;
         private MultiPanel multiPanel;
@@ -2366,6 +2391,7 @@ namespace EVEMon.SettingsUI
         private System.Windows.Forms.GroupBox WindowTitleGroupBox;
         private System.Windows.Forms.Label lblGeneralPage;
         private System.Windows.Forms.Label lblEnvironment;
+        private System.Windows.Forms.Label lblLanguage;
         private System.Windows.Forms.Label lblSkillPlannerPage;
         private System.Windows.Forms.Label lblNetworkPageProxy;
         private System.Windows.Forms.Label lblProxyHostIPAddress;

--- a/src/EVEMon/SettingsUI/SettingsForm.cs
+++ b/src/EVEMon/SettingsUI/SettingsForm.cs
@@ -144,6 +144,7 @@ namespace EVEMon.SettingsUI
             }
 
             // Misc settings
+            InitializeLanguageDropDown();
             cbWorksafeMode.Checked = m_settings.UI.SafeForWork;
             compatibilityCombo.SelectedIndex = (int)m_settings.Compatibility;
 
@@ -256,9 +257,13 @@ namespace EVEMon.SettingsUI
         {
             // Return settings
             ApplyToSettings();
+            bool languageChanged = LanguageChanged;
 
             if (SettingsChanged)
                 await Settings.ImportAsync(m_settings, true);
+
+            if (languageChanged)
+                ShowLanguageRestartRequiredMessage();
 
             Close();
         }
@@ -272,12 +277,16 @@ namespace EVEMon.SettingsUI
         private async void applyButton_Click(object sender, EventArgs e)
         {
             ApplyToSettings();
+            bool languageChanged = LanguageChanged;
 
             if (!SettingsChanged)
                 return;
 
             // Import the new settings
             await Settings.ImportAsync(m_settings, true);
+
+            if (languageChanged)
+                ShowLanguageRestartRequiredMessage();
 
             // Refresh the old settings
             m_oldSettings = Settings.Export();
@@ -287,6 +296,14 @@ namespace EVEMon.SettingsUI
 
 
         #region Core methods
+
+        /// <summary>
+        /// Gets a value indicating whether the selected language changed.
+        /// </summary>
+        private bool LanguageChanged => !string.Equals(
+            LocalizationHelper.NormalizeCultureName(m_settings.Language),
+            LocalizationHelper.NormalizeCultureName(m_oldSettings.Language),
+            StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
         /// Sets the tray icon settings.
@@ -430,6 +447,8 @@ namespace EVEMon.SettingsUI
             int extraIndex = extraInfoComboBox.SelectedIndex;
 
             // General - Compatibility
+            m_settings.Language = (languageComboBox.SelectedItem as SupportedLanguage)?.CultureName ??
+                LocalizationHelper.DefaultCultureName;
             m_settings.Compatibility = (CompatibilityMode)Math.Max(0, compatibilityCombo.SelectedIndex);
             m_settings.UI.SafeForWork = cbWorksafeMode.Checked;
 
@@ -591,6 +610,36 @@ namespace EVEMon.SettingsUI
 
             if (cbProvidersList.SelectedIndex == -1 && cbProvidersList.Items.Count > 0)
                 cbProvidersList.SelectedIndex = 0;
+        }
+
+        /// <summary>
+        /// Populates the combobox for supported UI languages.
+        /// </summary>
+        private void InitializeLanguageDropDown()
+        {
+            languageComboBox.Items.Clear();
+            languageComboBox.Items.AddRange(LocalizationHelper.SupportedLanguages.Cast<object>().ToArray());
+
+            string selectedCultureName = LocalizationHelper.NormalizeCultureName(m_settings.Language);
+            SupportedLanguage selectedLanguage = LocalizationHelper.SupportedLanguages.First(language =>
+                string.Equals(language.CultureName, selectedCultureName, StringComparison.OrdinalIgnoreCase));
+
+            languageComboBox.SelectedItem = selectedLanguage;
+        }
+
+        /// <summary>
+        /// Shows the restart required message for language changes.
+        /// </summary>
+        private void ShowLanguageRestartRequiredMessage()
+        {
+            string message = string.Equals(
+                LocalizationHelper.NormalizeCultureName(m_settings.Language),
+                LocalizationHelper.ChineseCultureName,
+                StringComparison.OrdinalIgnoreCase)
+                ? "语言更改将在重启 EVEMon 后生效。"
+                : "The language change will take effect after restarting EVEMon.";
+
+            MessageBox.Show(message, "EVEMon", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 
         /// <summary>

--- a/src/EVEMon/SettingsUI/SettingsForm.resx
+++ b/src/EVEMon/SettingsUI/SettingsForm.resx
@@ -467,4 +467,437 @@ Hint: If the control below is disabled although you are running EVE clients in p
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>70</value>
   </metadata>
+  <data name="systemTrayIconGroupBox.Text" xml:space="preserve">
+    <value>Show System Tray Icon</value>
+  </data>
+  <data name="rbSystemTrayOptionsNever.Text" xml:space="preserve">
+    <value>Never</value>
+  </data>
+  <data name="rbSystemTrayOptionsAlways.Text" xml:space="preserve">
+    <value>Always</value>
+  </data>
+  <data name="rbSystemTrayOptionsMinimized.Text" xml:space="preserve">
+    <value>When Minimized</value>
+  </data>
+  <data name="applyButton.Text" xml:space="preserve">
+    <value>&amp;Apply</value>
+  </data>
+  <data name="okButton.Text" xml:space="preserve">
+    <value>&amp;OK</value>
+  </data>
+  <data name="cancelButton.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="lblSize.Text" xml:space="preserve">
+    <value>Size</value>
+  </data>
+  <data name="CharacterMonitorGroupBox.Text" xml:space="preserve">
+    <value>Character Monitor</value>
+  </data>
+  <data name="lblSkillQueueWarningThresholdDays.Text" xml:space="preserve">
+    <value>Days :</value>
+  </data>
+  <data name="lblSkillQueuWarningThreshold.Text" xml:space="preserve">
+    <value>Skill Queue Warning Threshold</value>
+  </data>
+  <data name="cbColorQueuedSkills.Text" xml:space="preserve">
+    <value>Highlight Queued Skills</value>
+  </data>
+  <data name="cbShowPrereqMetSkills.Text" xml:space="preserve">
+    <value>Show Also Prereq-Met Skills</value>
+  </data>
+  <data name="cbColorPartialSkills.Text" xml:space="preserve">
+    <value>Highlight Partially Trained Skills</value>
+  </data>
+  <data name="cbAlwaysShowSkillQueueTime.Text" xml:space="preserve">
+    <value>Always show time above the skill queue</value>
+  </data>
+  <data name="cbShowNonPublicSkills.Text" xml:space="preserve">
+    <value>Show Also Non-Public Skills</value>
+  </data>
+  <data name="cbShowAllPublicSkills.Text" xml:space="preserve">
+    <value>Show Also All Public Skills</value>
+  </data>
+  <data name="WindowTitleGroupBox.Text" xml:space="preserve">
+    <value>Window Title</value>
+  </data>
+  <data name="cbSkillInTitle.Text" xml:space="preserve">
+    <value>Show skill in training</value>
+  </data>
+  <data name="cbTitleToTime.Text" xml:space="preserve">
+    <value>Show character info in window title</value>
+  </data>
+  <data name="lblEnvironment.Text" xml:space="preserve">
+    <value>Environment (requires restart to take effect)</value>
+  </data>
+  <data name="lblLanguage.Text" xml:space="preserve">
+    <value>Language (requires restart)</value>
+  </data>
+  <data name="lblSkillPlannerPage.Text" xml:space="preserve">
+    <value>You can select whether to highlight any entry in the Skill Planner according to its status and more.</value>
+  </data>
+  <data name="lblNetworkPageProxy.Text" xml:space="preserve">
+    <value>By default, EVEMon will use the same Proxy settings as Internet Explorer (can be configured through the Control Panel).</value>
+  </data>
+  <data name="lblProxyHostIPAddress.Text" xml:space="preserve">
+    <value>Host/IP Address</value>
+  </data>
+  <data name="lblProxyPort.Text" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="lblHTTP.Text" xml:space="preserve">
+    <value>HTTP:</value>
+  </data>
+  <data name="lblEmailNotificationPage.Text" xml:space="preserve">
+    <value>EVEMon can send you an email whenever a skill level completes its training.</value>
+  </data>
+  <data name="lblNotificationsPage.Text" xml:space="preserve">
+    <value>You can choose what notifications will be shown in your system's tray notification area or in EVEMon's main window and when. You can also toggle the sound notification upon skill completion on or off.</value>
+  </data>
+  <data name="lblTrayIconPage.Text" xml:space="preserve">
+    <value>Here you can set the visible status of EVEMon's Tray Icon, configure the style of the Tray Icon's popup info and EVEMon's behaviour upon pressing the Close button.
+</value>
+  </data>
+  <data name="lblSchedulerUIPage.Text" xml:space="preserve">
+    <value>Select the colors used in the scheduler. Using the scheduler, EVEMon can warn you about skill that will complete at times you will be away from your computer.</value>
+  </data>
+  <data name="lblText.Text" xml:space="preserve">
+    <value>Text:</value>
+  </data>
+  <data name="lblBlockingEvents.Text" xml:space="preserve">
+    <value>Blocking Events:</value>
+  </data>
+  <data name="lblRecurringEvents.Text" xml:space="preserve">
+    <value>Recurring Events:</value>
+  </data>
+  <data name="lblSimpleEvents.Text" xml:space="preserve">
+    <value>Simple Events:</value>
+  </data>
+  <data name="lblIconsPage.Text" xml:space="preserve">
+    <value>You can customize the icons used in the skill planner; if you have a good idea for a set of icons instructions to create your own can be found on wiki.</value>
+  </data>
+  <data name="gbSkillBrowserIconSet.Text" xml:space="preserve">
+    <value>Skill Browser Icon Set</value>
+  </data>
+  <data name="lblObsoletePlanEntries.Text" xml:space="preserve">
+    <value>You can configure how EVEMon handles skills that appear to be completed and reset the appearing messages behavior.</value>
+  </data>
+  <data name="cbUseIncreasedContrastOnOverview.Text" xml:space="preserve">
+    <value>Use Increased Contrast</value>
+  </data>
+  <data name="overviewGroupCharactersInTrainingCheckBox.Text" xml:space="preserve">
+    <value>Group Characters In Training</value>
+  </data>
+  <data name="overviewShowSkillQueueTrainingTimeCheckBox.Text" xml:space="preserve">
+    <value>Show Skill Queue Training Time</value>
+  </data>
+  <data name="overviewShowWalletCheckBox.Text" xml:space="preserve">
+    <value>Show Wallet Balance</value>
+  </data>
+  <data name="overviewShowPortraitCheckBox.Text" xml:space="preserve">
+    <value>Show Character Portrait</value>
+  </data>
+  <data name="cbShowOverViewTab.Text" xml:space="preserve">
+    <value>Show "Overview" tab</value>
+  </data>
+  <data name="treeNode16.Text" xml:space="preserve">
+    <value>Updates</value>
+  </data>
+  <data name="treeNode17.Text" xml:space="preserve">
+    <value>Network</value>
+  </data>
+  <data name="treeNode18.Text" xml:space="preserve">
+    <value>Portable EVE Clients</value>
+  </data>
+  <data name="treeNode19.Text" xml:space="preserve">
+    <value>Market Price Providers</value>
+  </data>
+  <data name="treeNode20.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="treeNode21.Text" xml:space="preserve">
+    <value>Main Window</value>
+  </data>
+  <data name="treeNode22.Text" xml:space="preserve">
+    <value>Icons</value>
+  </data>
+  <data name="treeNode23.Text" xml:space="preserve">
+    <value>Messages</value>
+  </data>
+  <data name="treeNode24.Text" xml:space="preserve">
+    <value>Skill Planner</value>
+  </data>
+  <data name="treeNode25.Text" xml:space="preserve">
+    <value>System Tray Icon</value>
+  </data>
+  <data name="treeNode26.Text" xml:space="preserve">
+    <value>External Calendar</value>
+  </data>
+  <data name="treeNode27.Text" xml:space="preserve">
+    <value>Scheduler</value>
+  </data>
+  <data name="treeNode28.Text" xml:space="preserve">
+    <value>Skill Completion Mails</value>
+  </data>
+  <data name="treeNode29.Text" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="treeNode30.Text" xml:space="preserve">
+    <value>Cloud Storage Service</value>
+  </data>
+  <data name="generalPage.Text" xml:space="preserve">
+    <value>generalPage</value>
+  </data>
+  <data name="btnEVEMonDataDir.Text" xml:space="preserve">
+    <value>EVEMon Data Directory</value>
+  </data>
+  <data name="cbWorksafeMode.Text" xml:space="preserve">
+    <value>Run in "safe for work" mode (no portraits or colors)</value>
+  </data>
+  <data name="runAtStartupComboBox.Text" xml:space="preserve">
+    <value>Run EVEMon at Startup</value>
+  </data>
+  <data name="mainWindowPage.Text" xml:space="preserve">
+    <value>mainWindowPage</value>
+  </data>
+  <data name="OverviewGroupBox.Text" xml:space="preserve">
+    <value>Overview</value>
+  </data>
+  <data name="cbShowSkillpointsOnOverview.Text" xml:space="preserve">
+    <value>Show Skill Points</value>
+  </data>
+  <data name="skillPlannerPage.Text" xml:space="preserve">
+    <value>skillPlannerPage</value>
+  </data>
+  <data name="cbAdvanceEntryAdd.Text" xml:space="preserve">
+    <value>Set Priority When Adding Skills To Plan</value>
+  </data>
+  <data name="cbSummaryOnMultiSelectOnly.Text" xml:space="preserve">
+    <value>Show Plan Summary Only On "Multi-Select"</value>
+  </data>
+  <data name="cbHighlightQueuedSiklls.Text" xml:space="preserve">
+    <value>Highlight Queued Skills</value>
+  </data>
+  <data name="cbHighlightPartialSkills.Text" xml:space="preserve">
+    <value>Highlight Partially Trained Skills</value>
+  </data>
+  <data name="cbHighlightConflicts.Text" xml:space="preserve">
+    <value>Highlight Schedule Conflicts</value>
+  </data>
+  <data name="cbHighlightPrerequisites.Text" xml:space="preserve">
+    <value>Highlight Prerequisites</value>
+  </data>
+  <data name="cbHighlightPlannedSkills.Text" xml:space="preserve">
+    <value>Highlight Planned Skills</value>
+  </data>
+  <data name="networkPage.Text" xml:space="preserve">
+    <value>networkPage</value>
+  </data>
+  <data name="esiSettingsGroupBox.Text" xml:space="preserve">
+    <value>ESI Client Settings</value>
+  </data>
+  <data name="lblClientSecret.Text" xml:space="preserve">
+    <value>Client Secret</value>
+  </data>
+  <data name="lblClientID.Text" xml:space="preserve">
+    <value>Client ID</value>
+  </data>
+  <data name="esiSettingsLabel.Text" xml:space="preserve">
+    <value>Create ESI client application: https://peterhaneve.github.io/evemon-esi
+</value>
+  </data>
+  <data name="ProxyServerGroupBox.Text" xml:space="preserve">
+    <value>Proxy Server Settings</value>
+  </data>
+  <data name="customProxyCheckBox.Text" xml:space="preserve">
+    <value>Use a custom proxy</value>
+  </data>
+  <data name="proxyAuthenticationButton.Text" xml:space="preserve">
+    <value>Authentication...</value>
+  </data>
+  <data name="emailNotificationsPage.Text" xml:space="preserve">
+    <value>emailNotificationsPage</value>
+  </data>
+  <data name="mailNotificationCheckBox.Text" xml:space="preserve">
+    <value>Send email when skill training completes</value>
+  </data>
+  <data name="notificationsPage.Text" xml:space="preserve">
+    <value>notificationsPage</value>
+  </data>
+  <data name="cbPlaySoundOnSkillComplete.Text" xml:space="preserve">
+    <value>Play sound when skill training completes</value>
+  </data>
+  <data name="trayIconPage.Text" xml:space="preserve">
+    <value>trayIconPage</value>
+  </data>
+  <data name="mainWindowBehaviourGroupBox.Text" xml:space="preserve">
+    <value>Main Window Close Behaviour</value>
+  </data>
+  <data name="rbMinToTaskBar.Text" xml:space="preserve">
+    <value>Minimize to the taskbar</value>
+  </data>
+  <data name="rbMinToTray.Text" xml:space="preserve">
+    <value>Minimize to the system tray</value>
+  </data>
+  <data name="rbExitEVEMon.Text" xml:space="preserve">
+    <value>Exit EVEMon</value>
+  </data>
+  <data name="trayIconPopupGroupBox.Text" xml:space="preserve">
+    <value>Icon Popup Style</value>
+  </data>
+  <data name="trayPopupDisabledRadio.Text" xml:space="preserve">
+    <value>Disabled</value>
+  </data>
+  <data name="trayPopupButton.Text" xml:space="preserve">
+    <value>Configure</value>
+  </data>
+  <data name="trayPopupRadio.Text" xml:space="preserve">
+    <value>Popup</value>
+  </data>
+  <data name="trayTooltipRadio.Text" xml:space="preserve">
+    <value>Tooltip</value>
+  </data>
+  <data name="trayTooltipButton.Text" xml:space="preserve">
+    <value>Configure</value>
+  </data>
+  <data name="updatesPage.Text" xml:space="preserve">
+    <value>updatesPage</value>
+  </data>
+  <data name="lblUpdatesPage.Text" xml:space="preserve">
+    <value>The following settings help reducing the network load, especially for high-latency connections and clients with many characters.</value>
+  </data>
+  <data name="cbCheckTime.Text" xml:space="preserve">
+    <value>Check system clock sync</value>
+  </data>
+  <data name="cbCheckForUpdates.Text" xml:space="preserve">
+    <value>Check for EVEMon updates</value>
+  </data>
+  <data name="schedulerUIPage.Text" xml:space="preserve">
+    <value>schedulerUIPage</value>
+  </data>
+  <data name="externalCalendarPage.Text" xml:space="preserve">
+    <value>externalCalendarPage</value>
+  </data>
+  <data name="externalCalendarCheckbox.Text" xml:space="preserve">
+    <value>Use External Calendar</value>
+  </data>
+  <data name="iconsPage.Text" xml:space="preserve">
+    <value>iconsPage</value>
+  </data>
+  <data name="messagesPage.Text" xml:space="preserve">
+    <value>messagesPage</value>
+  </data>
+  <data name="gbMessageBox.Text" xml:space="preserve">
+    <value>Pop-up Messages</value>
+  </data>
+  <data name="lblPrioritesConflict.Text" xml:space="preserve">
+    <value>Priorities Conflict</value>
+  </data>
+  <data name="btnPrioritiesReset.Text" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="ObsoleteEntryRemovalGroupBox.Text" xml:space="preserve">
+    <value>Obsolete Plan Entry Removal</value>
+  </data>
+  <data name="RemoveAllLabel.Text" xml:space="preserve">
+    <value>If EVEMon believes a skill level has been completed, whether it has been confirmed by the API or not it will be removed when the plan is opened.</value>
+  </data>
+  <data name="AlwaysAskLabel.Text" xml:space="preserve">
+    <value>Always display the "Obsolete Entries" link at the bottom of the skill planner before removing entries.</value>
+  </data>
+  <data name="RemoveConfirmedLabel.Text" xml:space="preserve">
+    <value>Once the API has confirmed a skill level has completed it is removed the next time a plan is opened. This is the default behaviour.</value>
+  </data>
+  <data name="alwaysAskRadioButton.Text" xml:space="preserve">
+    <value>Always ask</value>
+  </data>
+  <data name="removeAllRadioButton.Text" xml:space="preserve">
+    <value>Remove entry once training completes</value>
+  </data>
+  <data name="removeConfirmedRadioButton.Text" xml:space="preserve">
+    <value>Remove confirmed entry (Recommended)</value>
+  </data>
+  <data name="portableEveClientsPage.Text" xml:space="preserve">
+    <value>portableEveClientsPage</value>
+  </data>
+  <data name="PECIGroupBox.Text" xml:space="preserve">
+    <value>Portable EVE Client Installations</value>
+  </data>
+  <data name="marketPriceProvidersPage.Text" xml:space="preserve">
+    <value>marketPriceProvidersPage</value>
+  </data>
+  <data name="gbMarketPriceProviders.Text" xml:space="preserve">
+    <value>Market Price Provider</value>
+  </data>
+  <data name="SelectedProviderLabel.Text" xml:space="preserve">
+    <value>Provider:</value>
+  </data>
+  <data name="marketPriceProviderPageLabel.Text" xml:space="preserve">
+    <value>Request prices for all EVE items from a market price provider.</value>
+  </data>
+  <data name="cloudStorageServicePage.Text" xml:space="preserve">
+    <value>cloudStorageServicePage</value>
+  </data>
+  <data name="providerAuthenticationGroupBox.Text" xml:space="preserve">
+    <value>Cloud Storage Provider Authentication</value>
+  </data>
+  <data name="cloudStorageGroupBox.Text" xml:space="preserve">
+    <value>Cloud Storage Provider</value>
+  </data>
+  <data name="lblSelectedProvider.Text" xml:space="preserve">
+    <value>Provider:</value>
+  </data>
+  <data name="settingsFileStorageGroupBox.Text" xml:space="preserve">
+    <value>Settings File Storage</value>
+  </data>
+  <data name="cbColorQueuedSkills.ToolTip" xml:space="preserve">
+    <value>When enabled, highlights all
+queued skills in character's skill list</value>
+  </data>
+  <data name="cbShowPrereqMetSkills.ToolTip" xml:space="preserve">
+    <value>When enabled, shows all prerequisites
+met skills in character's skill list</value>
+  </data>
+  <data name="cbColorPartialSkills.ToolTip" xml:space="preserve">
+    <value>When enabled, highlights all partially
+trained skills in character's skill list</value>
+  </data>
+  <data name="cbAlwaysShowSkillQueueTime.ToolTip" xml:space="preserve">
+    <value>When enabled, always displays the total
+queue time above the skill queue bar</value>
+  </data>
+  <data name="cbShowNonPublicSkills.ToolTip" xml:space="preserve">
+    <value>When enabled, shows all non-public skills in character's skill list</value>
+  </data>
+  <data name="cbShowAllPublicSkills.ToolTip" xml:space="preserve">
+    <value>When enabled, shows all public skills in character's skill list</value>
+  </data>
+  <data name="cbSkillInTitle.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character's skill
+in training according to choice below</value>
+  </data>
+  <data name="cbTitleToTime.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character's info in window title</value>
+  </data>
+  <data name="cbUseIncreasedContrastOnOverview.ToolTip" xml:space="preserve">
+    <value>When enabled, increases the contrast of the shown info</value>
+  </data>
+  <data name="overviewGroupCharactersInTrainingCheckBox.ToolTip" xml:space="preserve">
+    <value>When enabled, groups the character's
+that are currently in training</value>
+  </data>
+  <data name="overviewShowSkillQueueTrainingTimeCheckBox.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character's
+skill queue training time</value>
+  </data>
+  <data name="overviewShowWalletCheckBox.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character's wallet balance</value>
+  </data>
+  <data name="overviewShowPortraitCheckBox.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character's portrait
+as a thumbnail alongside the character's name</value>
+  </data>
+  <data name="cbShowOverViewTab.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the Overview tab</value>
+  </data>
 </root>

--- a/src/EVEMon/SettingsUI/SettingsForm.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/SettingsForm.zh-CN.resx
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="lblMainWindowPage.Text" xml:space="preserve">
+    <value>您可以配置窗口标题中是否显示任何信息以及显示顺序。选择将在角色监视器技能列表中显示的技能及其突出显示的状态。显示或不显示概览选项卡并选择要显示的信息。
+</value>
+  </data>
+  <data name="lblGeneralPage.Text" xml:space="preserve">
+    <value>选择 EVEMon 是否在每次启动系统时启动。您可以选择禁用 EVEMon 的图形并选择它将运行的环境。您也可以通过单击相关按钮打开 EVEMon 的 Data 文件夹。</value>
+  </data>
+  <data name="lblExternalCalendarPage.Text" xml:space="preserve">
+    <value>EVEMon 可以将您当前的训练队列导出到 Microsoft Outlook 或 Google。这使您可以将日历与智能手机、黑莓手机等同步，以便您随身携带提醒。提前和延迟提醒允许您设置您在 EVE 附近无法更新队列的时间，并且提醒将设置为在这些时间触发，而不是标准提醒间隔。
+</value>
+  </data>
+  <data name="lblPECIDescription.Text" xml:space="preserve">
+    <value>如果 EVE 客户端在便携模式下运行 (/LUA:OFF)，您可以设置它们的路径。通过提供路径，EVEMon可以访问缓存文件夹并扫描人物肖像和市场数据。
+
+提示：如果您在便携模式下运行 EVE 客户端，但下面的控件被禁用，则意味着 EVEMon 已在默认位置 (%LOCALAPPDATA%\CCP\EVE) 检测到一个或多个“宁静”文件夹。手动删除这些并重新启动 EVEMon。</value>
+  </data>
+  <data name="linkLabel1.Text" xml:space="preserve">
+    <value>EVEMon 提供将您的设置文件在线存储在云存储提供商处并在不同计算机之间使用的功能。为了能够使用这些服务，您需要拥有所选提供商的帐户。</value>
+  </data>
+  <data name="systemTrayIconGroupBox.Text" xml:space="preserve">
+    <value>显示系统托盘图标</value>
+  </data>
+  <data name="rbSystemTrayOptionsNever.Text" xml:space="preserve">
+    <value>从来没有</value>
+  </data>
+  <data name="rbSystemTrayOptionsAlways.Text" xml:space="preserve">
+    <value>总是</value>
+  </data>
+  <data name="rbSystemTrayOptionsMinimized.Text" xml:space="preserve">
+    <value>最小化时</value>
+  </data>
+  <data name="applyButton.Text" xml:space="preserve">
+    <value>应用(&amp;A)</value>
+  </data>
+  <data name="okButton.Text" xml:space="preserve">
+    <value>确定</value>
+  </data>
+  <data name="cancelButton.Text" xml:space="preserve">
+    <value>取消(&amp;C)</value>
+  </data>
+  <data name="lblSize.Text" xml:space="preserve">
+    <value>尺寸</value>
+  </data>
+  <data name="CharacterMonitorGroupBox.Text" xml:space="preserve">
+    <value>角色监视器</value>
+  </data>
+  <data name="lblSkillQueueWarningThresholdDays.Text" xml:space="preserve">
+    <value>天数：</value>
+  </data>
+  <data name="lblSkillQueuWarningThreshold.Text" xml:space="preserve">
+    <value>技能队列警告阈值</value>
+  </data>
+  <data name="cbColorQueuedSkills.Text" xml:space="preserve">
+    <value>突出显示排队技能</value>
+  </data>
+  <data name="cbShowPrereqMetSkills.Text" xml:space="preserve">
+    <value>另请显示先决条件满足的技能</value>
+  </data>
+  <data name="cbColorPartialSkills.Text" xml:space="preserve">
+    <value>突出显示部分训练过的技能</value>
+  </data>
+  <data name="cbAlwaysShowSkillQueueTime.Text" xml:space="preserve">
+    <value>始终在技能队列上方显示时间</value>
+  </data>
+  <data name="cbShowNonPublicSkills.Text" xml:space="preserve">
+    <value>还展示非公共技能</value>
+  </data>
+  <data name="cbShowAllPublicSkills.Text" xml:space="preserve">
+    <value>还显示所有公共技能</value>
+  </data>
+  <data name="WindowTitleGroupBox.Text" xml:space="preserve">
+    <value>窗口标题</value>
+  </data>
+  <data name="cbSkillInTitle.Text" xml:space="preserve">
+    <value>在训练中展现技巧</value>
+  </data>
+  <data name="cbTitleToTime.Text" xml:space="preserve">
+    <value>在窗口标题中显示字符信息</value>
+  </data>
+  <data name="lblEnvironment.Text" xml:space="preserve">
+    <value>环境（需要重启生效）</value>
+  </data>
+  <data name="lblLanguage.Text" xml:space="preserve">
+    <value>语言（需要重新启动）</value>
+  </data>
+  <data name="lblSkillPlannerPage.Text" xml:space="preserve">
+    <value>您可以根据状态等选择是否突出显示技能规划器中的任何条目。</value>
+  </data>
+  <data name="lblNetworkPageProxy.Text" xml:space="preserve">
+    <value>默认情况下，EVEMon 将使用与 Internet Explorer 相同的代理设置（可以通过控制面板进行配置）。</value>
+  </data>
+  <data name="lblProxyHostIPAddress.Text" xml:space="preserve">
+    <value>主机/IP 地址</value>
+  </data>
+  <data name="lblProxyPort.Text" xml:space="preserve">
+    <value>港口</value>
+  </data>
+  <data name="lblHTTP.Text" xml:space="preserve">
+    <value>HTTP:</value>
+  </data>
+  <data name="lblEmailNotificationPage.Text" xml:space="preserve">
+    <value>每当技能级别完成培训时，EVEMon 都会向您发送电子邮件。</value>
+  </data>
+  <data name="lblNotificationsPage.Text" xml:space="preserve">
+    <value>您可以选择在系统托盘通知区域或 EVEMon 主窗口中显示哪些通知以及何时显示。您还可以打开或关闭技能完成时的声音通知。</value>
+  </data>
+  <data name="lblTrayIconPage.Text" xml:space="preserve">
+    <value>在这里您可以设置 EVEMon 托盘图标的可见状态、配置托盘图标弹出信息的样式以及按关闭按钮时 EVEMon 的行为。
+</value>
+  </data>
+  <data name="lblSchedulerUIPage.Text" xml:space="preserve">
+    <value>选择调度程序中使用的颜色。使用调度程序，EVEMon 可以警告您在您离开计算机时需要完成的技能。</value>
+  </data>
+  <data name="lblText.Text" xml:space="preserve">
+    <value>文字：</value>
+  </data>
+  <data name="lblBlockingEvents.Text" xml:space="preserve">
+    <value>阻止事件：</value>
+  </data>
+  <data name="lblRecurringEvents.Text" xml:space="preserve">
+    <value>重复事件：</value>
+  </data>
+  <data name="lblSimpleEvents.Text" xml:space="preserve">
+    <value>简单事件：</value>
+  </data>
+  <data name="lblIconsPage.Text" xml:space="preserve">
+    <value>您可以自定义技能规划器中使用的图标；如果您对一组图标有好主意，可以在 wiki 上找到创建自己的图标的说明。</value>
+  </data>
+  <data name="gbSkillBrowserIconSet.Text" xml:space="preserve">
+    <value>技能浏览器图标集</value>
+  </data>
+  <data name="lblObsoletePlanEntries.Text" xml:space="preserve">
+    <value>您可以配置 EVEMon 如何处理似乎已完成的技能并重置显示的消息行为。</value>
+  </data>
+  <data name="cbUseIncreasedContrastOnOverview.Text" xml:space="preserve">
+    <value>使用增强对比度</value>
+  </data>
+  <data name="overviewGroupCharactersInTrainingCheckBox.Text" xml:space="preserve">
+    <value>训练中的群体角色</value>
+  </data>
+  <data name="overviewShowSkillQueueTrainingTimeCheckBox.Text" xml:space="preserve">
+    <value>显示技能队列训练时间</value>
+  </data>
+  <data name="overviewShowWalletCheckBox.Text" xml:space="preserve">
+    <value>显示钱包余额</value>
+  </data>
+  <data name="overviewShowPortraitCheckBox.Text" xml:space="preserve">
+    <value>显示人物肖像</value>
+  </data>
+  <data name="cbShowOverViewTab.Text" xml:space="preserve">
+    <value>显示“概览”选项卡</value>
+  </data>
+  <data name="treeNode16.Text" xml:space="preserve">
+    <value>更新</value>
+  </data>
+  <data name="treeNode17.Text" xml:space="preserve">
+    <value>网络</value>
+  </data>
+  <data name="treeNode18.Text" xml:space="preserve">
+    <value>便携式 EVE 客户端</value>
+  </data>
+  <data name="treeNode19.Text" xml:space="preserve">
+    <value>市场价格提供者</value>
+  </data>
+  <data name="treeNode20.Text" xml:space="preserve">
+    <value>一般</value>
+  </data>
+  <data name="treeNode21.Text" xml:space="preserve">
+    <value>主窗口</value>
+  </data>
+  <data name="treeNode22.Text" xml:space="preserve">
+    <value>图标</value>
+  </data>
+  <data name="treeNode23.Text" xml:space="preserve">
+    <value>留言</value>
+  </data>
+  <data name="treeNode24.Text" xml:space="preserve">
+    <value>技能规划师</value>
+  </data>
+  <data name="treeNode25.Text" xml:space="preserve">
+    <value>系统托盘图标</value>
+  </data>
+  <data name="treeNode26.Text" xml:space="preserve">
+    <value>外部日历</value>
+  </data>
+  <data name="treeNode27.Text" xml:space="preserve">
+    <value>调度程序</value>
+  </data>
+  <data name="treeNode28.Text" xml:space="preserve">
+    <value>技能完成邮件</value>
+  </data>
+  <data name="treeNode29.Text" xml:space="preserve">
+    <value>通知</value>
+  </data>
+  <data name="treeNode30.Text" xml:space="preserve">
+    <value>云存储服务</value>
+  </data>
+  <data name="generalPage.Text" xml:space="preserve">
+    <value>通用页面</value>
+  </data>
+  <data name="btnEVEMonDataDir.Text" xml:space="preserve">
+    <value>EVEMon数据目录</value>
+  </data>
+  <data name="cbWorksafeMode.Text" xml:space="preserve">
+    <value>在“安全工作”模式下运行（无肖像或颜色）</value>
+  </data>
+  <data name="runAtStartupComboBox.Text" xml:space="preserve">
+    <value>在启动时运行 EVEMon</value>
+  </data>
+  <data name="mainWindowPage.Text" xml:space="preserve">
+    <value>主窗口页面</value>
+  </data>
+  <data name="OverviewGroupBox.Text" xml:space="preserve">
+    <value>概述</value>
+  </data>
+  <data name="cbShowSkillpointsOnOverview.Text" xml:space="preserve">
+    <value>显示技能点</value>
+  </data>
+  <data name="skillPlannerPage.Text" xml:space="preserve">
+    <value>技能规划页面</value>
+  </data>
+  <data name="cbAdvanceEntryAdd.Text" xml:space="preserve">
+    <value>在计划中添加技能时设置优先级</value>
+  </data>
+  <data name="cbSummaryOnMultiSelectOnly.Text" xml:space="preserve">
+    <value>仅在“多选”上显示计划摘要</value>
+  </data>
+  <data name="cbHighlightQueuedSiklls.Text" xml:space="preserve">
+    <value>突出显示排队技能</value>
+  </data>
+  <data name="cbHighlightPartialSkills.Text" xml:space="preserve">
+    <value>突出显示部分训练过的技能</value>
+  </data>
+  <data name="cbHighlightConflicts.Text" xml:space="preserve">
+    <value>突出显示日程冲突</value>
+  </data>
+  <data name="cbHighlightPrerequisites.Text" xml:space="preserve">
+    <value>突出显示先决条件</value>
+  </data>
+  <data name="cbHighlightPlannedSkills.Text" xml:space="preserve">
+    <value>突出计划技能</value>
+  </data>
+  <data name="networkPage.Text" xml:space="preserve">
+    <value>网络页面</value>
+  </data>
+  <data name="esiSettingsGroupBox.Text" xml:space="preserve">
+    <value>ESI 客户端设置</value>
+  </data>
+  <data name="lblClientSecret.Text" xml:space="preserve">
+    <value>客户秘密</value>
+  </data>
+  <data name="lblClientID.Text" xml:space="preserve">
+    <value>客户ID</value>
+  </data>
+  <data name="esiSettingsLabel.Text" xml:space="preserve">
+    <value>创建 ESI 客户端应用程序：https://peterhaneve.github.io/EVEMon-ESI
+</value>
+  </data>
+  <data name="ProxyServerGroupBox.Text" xml:space="preserve">
+    <value>代理服务器设置</value>
+  </data>
+  <data name="customProxyCheckBox.Text" xml:space="preserve">
+    <value>使用自定义代理</value>
+  </data>
+  <data name="proxyAuthenticationButton.Text" xml:space="preserve">
+    <value>认证...</value>
+  </data>
+  <data name="emailNotificationsPage.Text" xml:space="preserve">
+    <value>电子邮件通知页面</value>
+  </data>
+  <data name="mailNotificationCheckBox.Text" xml:space="preserve">
+    <value>技能培训完成后发送电子邮件</value>
+  </data>
+  <data name="notificationsPage.Text" xml:space="preserve">
+    <value>通知页面</value>
+  </data>
+  <data name="cbPlaySoundOnSkillComplete.Text" xml:space="preserve">
+    <value>技能训练完成时播放声音</value>
+  </data>
+  <data name="trayIconPage.Text" xml:space="preserve">
+    <value>托盘图标页</value>
+  </data>
+  <data name="mainWindowBehaviourGroupBox.Text" xml:space="preserve">
+    <value>主窗口关闭行为</value>
+  </data>
+  <data name="rbMinToTaskBar.Text" xml:space="preserve">
+    <value>最小化到任务栏</value>
+  </data>
+  <data name="rbMinToTray.Text" xml:space="preserve">
+    <value>最小化到系统托盘</value>
+  </data>
+  <data name="rbExitEVEMon.Text" xml:space="preserve">
+    <value>退出 EVEMon</value>
+  </data>
+  <data name="trayIconPopupGroupBox.Text" xml:space="preserve">
+    <value>图标弹出样式</value>
+  </data>
+  <data name="trayPopupDisabledRadio.Text" xml:space="preserve">
+    <value>残疾人</value>
+  </data>
+  <data name="trayPopupButton.Text" xml:space="preserve">
+    <value>配置</value>
+  </data>
+  <data name="trayPopupRadio.Text" xml:space="preserve">
+    <value>弹出窗口</value>
+  </data>
+  <data name="trayTooltipRadio.Text" xml:space="preserve">
+    <value>工具提示</value>
+  </data>
+  <data name="trayTooltipButton.Text" xml:space="preserve">
+    <value>配置</value>
+  </data>
+  <data name="updatesPage.Text" xml:space="preserve">
+    <value>更新页面</value>
+  </data>
+  <data name="lblUpdatesPage.Text" xml:space="preserve">
+    <value>以下设置有助于减少网络负载，特别是对于高延迟连接和具有多个字符的客户端。</value>
+  </data>
+  <data name="cbCheckTime.Text" xml:space="preserve">
+    <value>检查系统时钟同步</value>
+  </data>
+  <data name="cbCheckForUpdates.Text" xml:space="preserve">
+    <value>检查 EVEMon 更新</value>
+  </data>
+  <data name="schedulerUIPage.Text" xml:space="preserve">
+    <value>调度程序UI页面</value>
+  </data>
+  <data name="externalCalendarPage.Text" xml:space="preserve">
+    <value>外部日历页</value>
+  </data>
+  <data name="externalCalendarCheckbox.Text" xml:space="preserve">
+    <value>使用外部日历</value>
+  </data>
+  <data name="iconsPage.Text" xml:space="preserve">
+    <value>图标页面</value>
+  </data>
+  <data name="messagesPage.Text" xml:space="preserve">
+    <value>消息页面</value>
+  </data>
+  <data name="gbMessageBox.Text" xml:space="preserve">
+    <value>弹出消息</value>
+  </data>
+  <data name="lblPrioritesConflict.Text" xml:space="preserve">
+    <value>优先顺序冲突</value>
+  </data>
+  <data name="btnPrioritiesReset.Text" xml:space="preserve">
+    <value>重置</value>
+  </data>
+  <data name="ObsoleteEntryRemovalGroupBox.Text" xml:space="preserve">
+    <value>删除过时的计划条目</value>
+  </data>
+  <data name="RemoveAllLabel.Text" xml:space="preserve">
+    <value>如果EVEMon认为某个技能等级已经完成，无论是否已被API确认，都会在计划开放时将其删除。</value>
+  </data>
+  <data name="AlwaysAskLabel.Text" xml:space="preserve">
+    <value>在删除条目之前，请始终在技能规划器底部显示“过时条目”链接。</value>
+  </data>
+  <data name="RemoveConfirmedLabel.Text" xml:space="preserve">
+    <value>一旦 API 确认技能级别已完成，它将在下次打开计划时删除。这是默认行为。</value>
+  </data>
+  <data name="alwaysAskRadioButton.Text" xml:space="preserve">
+    <value>总是问</value>
+  </data>
+  <data name="removeAllRadioButton.Text" xml:space="preserve">
+    <value>训练完成后删除条目</value>
+  </data>
+  <data name="removeConfirmedRadioButton.Text" xml:space="preserve">
+    <value>删除已确认的条目（推荐）</value>
+  </data>
+  <data name="portableEveClientsPage.Text" xml:space="preserve">
+    <value>便携式EVE客户页面</value>
+  </data>
+  <data name="PECIGroupBox.Text" xml:space="preserve">
+    <value>便携式 EVE 客户端安装</value>
+  </data>
+  <data name="marketPriceProvidersPage.Text" xml:space="preserve">
+    <value>市场价格提供商页面</value>
+  </data>
+  <data name="gbMarketPriceProviders.Text" xml:space="preserve">
+    <value>市场价格提供者</value>
+  </data>
+  <data name="SelectedProviderLabel.Text" xml:space="preserve">
+    <value>提供商：</value>
+  </data>
+  <data name="marketPriceProviderPageLabel.Text" xml:space="preserve">
+    <value>向市场价格提供商索取所有 EVE 物品的价格。</value>
+  </data>
+  <data name="cloudStorageServicePage.Text" xml:space="preserve">
+    <value>云存储服务页面</value>
+  </data>
+  <data name="providerAuthenticationGroupBox.Text" xml:space="preserve">
+    <value>云存储提供商身份验证</value>
+  </data>
+  <data name="cloudStorageGroupBox.Text" xml:space="preserve">
+    <value>云存储提供商</value>
+  </data>
+  <data name="lblSelectedProvider.Text" xml:space="preserve">
+    <value>提供商：</value>
+  </data>
+  <data name="settingsFileStorageGroupBox.Text" xml:space="preserve">
+    <value>设置文件存储</value>
+  </data>
+  <data name="cbColorQueuedSkills.ToolTip" xml:space="preserve">
+    <value>启用后，突出显示所有
+角色技能列表中的排队技能</value>
+  </data>
+  <data name="cbShowPrereqMetSkills.ToolTip" xml:space="preserve">
+    <value>启用后，显示所有先决条件
+遇到角色技能列表中的技能</value>
+  </data>
+  <data name="cbColorPartialSkills.ToolTip" xml:space="preserve">
+    <value>启用后，部分突出显示所有内容
+角色技能列表中训练过的技能</value>
+  </data>
+  <data name="cbAlwaysShowSkillQueueTime.ToolTip" xml:space="preserve">
+    <value>启用后，始终显示总计
+技能队列栏上方的队列时间</value>
+  </data>
+  <data name="cbShowNonPublicSkills.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色技能列表中的所有非公开技能</value>
+  </data>
+  <data name="cbShowAllPublicSkills.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色技能列表中的所有公共技能</value>
+  </data>
+  <data name="cbSkillInTitle.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的技能
+根据以下选择进行训练</value>
+  </data>
+  <data name="cbTitleToTime.ToolTip" xml:space="preserve">
+    <value>启用后，在窗口标题中显示角色信息</value>
+  </data>
+  <data name="cbUseIncreasedContrastOnOverview.ToolTip" xml:space="preserve">
+    <value>启用后，增加显示信息的对比度</value>
+  </data>
+  <data name="overviewGroupCharactersInTrainingCheckBox.ToolTip" xml:space="preserve">
+    <value>启用后，将对角色进行分组
+目前正在接受训练的</value>
+  </data>
+  <data name="overviewShowSkillQueueTrainingTimeCheckBox.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的
+技能队列训练时间</value>
+  </data>
+  <data name="overviewShowWalletCheckBox.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的钱包余额</value>
+  </data>
+  <data name="overviewShowPortraitCheckBox.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的肖像
+作为角色名字旁边的缩略图</value>
+  </data>
+  <data name="cbShowOverViewTab.ToolTip" xml:space="preserve">
+    <value>启用后，显示概述选项卡</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/TrayBaseWindow.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/TrayBaseWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/TrayPopUpConfigForm.Designer.cs
+++ b/src/EVEMon/SettingsUI/TrayPopUpConfigForm.Designer.cs
@@ -91,7 +91,7 @@ namespace EVEMon.SettingsUI
             this.btnUseDefaults.Name = "btnUseDefaults";
             this.btnUseDefaults.Size = new System.Drawing.Size(81, 23);
             this.btnUseDefaults.TabIndex = 2;
-            this.btnUseDefaults.Text = "Use Defaults";
+            this.btnUseDefaults.Text = resources.GetString("this.btnUseDefaults.Text");
             this.btnUseDefaults.UseVisualStyleBackColor = true;
             this.btnUseDefaults.Click += new System.EventHandler(this.btnUseDefaults_Click);
             // 
@@ -102,7 +102,7 @@ namespace EVEMon.SettingsUI
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 1;
-            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Text = resources.GetString("this.btnCancel.Text");
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
@@ -113,7 +113,7 @@ namespace EVEMon.SettingsUI
             this.btnOK.Name = "btnOK";
             this.btnOK.Size = new System.Drawing.Size(75, 23);
             this.btnOK.TabIndex = 0;
-            this.btnOK.Text = "OK";
+            this.btnOK.Text = resources.GetString("this.btnOK.Text");
             this.btnOK.UseVisualStyleBackColor = true;
             this.btnOK.Click += new System.EventHandler(this.btnOK_Click);
             // 
@@ -136,7 +136,7 @@ namespace EVEMon.SettingsUI
             this.tpGeneral.Padding = new System.Windows.Forms.Padding(3);
             this.tpGeneral.Size = new System.Drawing.Size(374, 394);
             this.tpGeneral.TabIndex = 0;
-            this.tpGeneral.Text = "General";
+            this.tpGeneral.Text = resources.GetString("this.tpGeneral.Text");
             this.tpGeneral.UseVisualStyleBackColor = true;
             // 
             // flowLayoutPanel3
@@ -162,7 +162,7 @@ namespace EVEMon.SettingsUI
             this.groupBox1.Size = new System.Drawing.Size(362, 96);
             this.groupBox1.TabIndex = 0;
             this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Layout";
+            this.groupBox1.Text = resources.GetString("this.groupBox1.Text");
             // 
             // cbIndentGroupedAccounts
             // 
@@ -171,7 +171,7 @@ namespace EVEMon.SettingsUI
             this.cbIndentGroupedAccounts.Name = "cbIndentGroupedAccounts";
             this.cbIndentGroupedAccounts.Size = new System.Drawing.Size(148, 17);
             this.cbIndentGroupedAccounts.TabIndex = 19;
-            this.cbIndentGroupedAccounts.Text = "Indent Grouped Accounts";
+            this.cbIndentGroupedAccounts.Text = resources.GetString("this.cbIndentGroupedAccounts.Text");
             this.ttHelp.SetToolTip(this.cbIndentGroupedAccounts, "When enabled, characters will be indented\r\nunder the first character in each acco" +
                     "unt group");
             this.cbIndentGroupedAccounts.UseVisualStyleBackColor = true;
@@ -194,7 +194,7 @@ namespace EVEMon.SettingsUI
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(111, 13);
             this.label1.TabIndex = 17;
-            this.label1.Text = "Group Characters by:";
+            this.label1.Text = resources.GetString("this.label1.Text");
             this.label1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // cbHideNotTraining
@@ -204,8 +204,8 @@ namespace EVEMon.SettingsUI
             this.cbHideNotTraining.Name = "cbHideNotTraining";
             this.cbHideNotTraining.Size = new System.Drawing.Size(157, 17);
             this.cbHideNotTraining.TabIndex = 12;
-            this.cbHideNotTraining.Text = "Hide Characters not training";
-            this.ttHelp.SetToolTip(this.cbHideNotTraining, "When enabled, only characters currently\r\ntraining a skill will be displayed");
+            this.cbHideNotTraining.Text = resources.GetString("this.cbHideNotTraining.Text");
+            this.ttHelp.SetToolTip(this.cbHideNotTraining, resources.GetString("this.cbHideNotTraining.ToolTip"));
             this.cbHideNotTraining.UseVisualStyleBackColor = true;
             this.cbHideNotTraining.CheckedChanged += new System.EventHandler(this.cbHideNotTraining_CheckedChanged);
             // 
@@ -220,7 +220,7 @@ namespace EVEMon.SettingsUI
             this.groupBox4.Size = new System.Drawing.Size(362, 79);
             this.groupBox4.TabIndex = 17;
             this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Display Order";
+            this.groupBox4.Text = resources.GetString("this.groupBox4.Text");
             // 
             // cbDisplayOrder2
             // 
@@ -230,7 +230,7 @@ namespace EVEMon.SettingsUI
             this.cbDisplayOrder2.Name = "cbDisplayOrder2";
             this.cbDisplayOrder2.Size = new System.Drawing.Size(221, 21);
             this.cbDisplayOrder2.TabIndex = 22;
-            this.ttHelp.SetToolTip(this.cbDisplayOrder2, "Controls the display order of characters, dependent on grouping.");
+            this.ttHelp.SetToolTip(this.cbDisplayOrder2, resources.GetString("this.cbDisplayOrder2.ToolTip"));
             // 
             // lblDisplayOrder1
             // 
@@ -239,7 +239,7 @@ namespace EVEMon.SettingsUI
             this.lblDisplayOrder1.Name = "lblDisplayOrder1";
             this.lblDisplayOrder1.Size = new System.Drawing.Size(114, 13);
             this.lblDisplayOrder1.TabIndex = 19;
-            this.lblDisplayOrder1.Text = "Characters in training:";
+            this.lblDisplayOrder1.Text = resources.GetString("this.lblDisplayOrder1.Text");
             this.lblDisplayOrder1.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // lblDisplayOrder2
@@ -249,7 +249,7 @@ namespace EVEMon.SettingsUI
             this.lblDisplayOrder2.Name = "lblDisplayOrder2";
             this.lblDisplayOrder2.Size = new System.Drawing.Size(122, 13);
             this.lblDisplayOrder2.TabIndex = 21;
-            this.lblDisplayOrder2.Text = "Characters not training:";
+            this.lblDisplayOrder2.Text = resources.GetString("this.lblDisplayOrder2.Text");
             this.lblDisplayOrder2.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // cbDisplayOrder1
@@ -265,7 +265,7 @@ namespace EVEMon.SettingsUI
             this.cbDisplayOrder1.Name = "cbDisplayOrder1";
             this.cbDisplayOrder1.Size = new System.Drawing.Size(221, 21);
             this.cbDisplayOrder1.TabIndex = 20;
-            this.ttHelp.SetToolTip(this.cbDisplayOrder1, "Controls the display order of characters, dependent on grouping.");
+            this.ttHelp.SetToolTip(this.cbDisplayOrder1, resources.GetString("this.cbDisplayOrder1.ToolTip"));
             // 
             // groupBox2
             // 
@@ -283,7 +283,7 @@ namespace EVEMon.SettingsUI
             this.groupBox2.Size = new System.Drawing.Size(362, 121);
             this.groupBox2.TabIndex = 15;
             this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Character Details";
+            this.groupBox2.Text = resources.GetString("this.groupBox2.Text");
             // 
             // cbShowSkillQueueTrainingTime
             // 
@@ -292,8 +292,8 @@ namespace EVEMon.SettingsUI
             this.cbShowSkillQueueTrainingTime.Name = "cbShowSkillQueueTrainingTime";
             this.cbShowSkillQueueTrainingTime.Size = new System.Drawing.Size(173, 17);
             this.cbShowSkillQueueTrainingTime.TabIndex = 35;
-            this.cbShowSkillQueueTrainingTime.Text = "Show Skill Queue Training Time";
-            this.ttHelp.SetToolTip(this.cbShowSkillQueueTrainingTime, "When enabled, shows the character\'s\r\nskill queue training time");
+            this.cbShowSkillQueueTrainingTime.Text = resources.GetString("this.cbShowSkillQueueTrainingTime.Text");
+            this.ttHelp.SetToolTip(this.cbShowSkillQueueTrainingTime, resources.GetString("this.cbShowSkillQueueTrainingTime.ToolTip"));
             this.cbShowSkillQueueTrainingTime.UseVisualStyleBackColor = true;
             // 
             // cbHighLightConflicts
@@ -303,7 +303,7 @@ namespace EVEMon.SettingsUI
             this.cbHighLightConflicts.Name = "cbHighLightConflicts";
             this.cbHighLightConflicts.Size = new System.Drawing.Size(157, 17);
             this.cbHighLightConflicts.TabIndex = 34;
-            this.cbHighLightConflicts.Text = "Highlight Schedule Conflicts";
+            this.cbHighLightConflicts.Text = resources.GetString("this.cbHighLightConflicts.Text");
             this.ttHelp.SetToolTip(this.cbHighLightConflicts, "When enabled, skills with a completion time\r\nconflicting with a blocked scheduler" +
                     " entry\r\nwill be highlighted in red.");
             this.cbHighLightConflicts.UseVisualStyleBackColor = true;
@@ -315,8 +315,8 @@ namespace EVEMon.SettingsUI
             this.cbShowSkill.Name = "cbShowSkill";
             this.cbShowSkill.Size = new System.Drawing.Size(124, 17);
             this.cbShowSkill.TabIndex = 31;
-            this.cbShowSkill.Text = "Show Skill in Training";
-            this.ttHelp.SetToolTip(this.cbShowSkill, "When enabled, shows the currently\r\ntraining skill name and level");
+            this.cbShowSkill.Text = resources.GetString("this.cbShowSkill.Text");
+            this.ttHelp.SetToolTip(this.cbShowSkill, resources.GetString("this.cbShowSkill.ToolTip"));
             this.cbShowSkill.UseVisualStyleBackColor = true;
             // 
             // cbShowCompletionTime
@@ -326,7 +326,7 @@ namespace EVEMon.SettingsUI
             this.cbShowCompletionTime.Name = "cbShowCompletionTime";
             this.cbShowCompletionTime.Size = new System.Drawing.Size(133, 17);
             this.cbShowCompletionTime.TabIndex = 33;
-            this.cbShowCompletionTime.Text = "Show Completion Time";
+            this.cbShowCompletionTime.Text = resources.GetString("this.cbShowCompletionTime.Text");
             this.ttHelp.SetToolTip(this.cbShowCompletionTime, "When enabled, shows the estimated completion\r\ndate and time of the  currently tra" +
                     "ining skill");
             this.cbShowCompletionTime.UseVisualStyleBackColor = true;
@@ -338,8 +338,8 @@ namespace EVEMon.SettingsUI
             this.cbShowTimeToCompletion.Name = "cbShowTimeToCompletion";
             this.cbShowTimeToCompletion.Size = new System.Drawing.Size(146, 17);
             this.cbShowTimeToCompletion.TabIndex = 32;
-            this.cbShowTimeToCompletion.Text = "Show Time to Completion";
-            this.ttHelp.SetToolTip(this.cbShowTimeToCompletion, "When enabled, shows the time remaining\r\n until training is completed");
+            this.cbShowTimeToCompletion.Text = resources.GetString("this.cbShowTimeToCompletion.Text");
+            this.ttHelp.SetToolTip(this.cbShowTimeToCompletion, resources.GetString("this.cbShowTimeToCompletion.ToolTip"));
             this.cbShowTimeToCompletion.UseVisualStyleBackColor = true;
             // 
             // cbPortraitSize
@@ -350,7 +350,7 @@ namespace EVEMon.SettingsUI
             this.cbPortraitSize.Name = "cbPortraitSize";
             this.cbPortraitSize.Size = new System.Drawing.Size(69, 21);
             this.cbPortraitSize.TabIndex = 28;
-            this.ttHelp.SetToolTip(this.cbPortraitSize, "Selects the image size, in pixels, to be used\r\nfor the character portrait");
+            this.ttHelp.SetToolTip(this.cbPortraitSize, resources.GetString("this.cbPortraitSize.ToolTip"));
             // 
             // cbShowWallet
             // 
@@ -359,8 +359,8 @@ namespace EVEMon.SettingsUI
             this.cbShowWallet.Name = "cbShowWallet";
             this.cbShowWallet.Size = new System.Drawing.Size(125, 17);
             this.cbShowWallet.TabIndex = 30;
-            this.cbShowWallet.Text = "Show Wallet Balance";
-            this.ttHelp.SetToolTip(this.cbShowWallet, "When enabled, shows the character\'s wallet balance");
+            this.cbShowWallet.Text = resources.GetString("this.cbShowWallet.Text");
+            this.ttHelp.SetToolTip(this.cbShowWallet, resources.GetString("this.cbShowWallet.ToolTip"));
             this.cbShowWallet.UseVisualStyleBackColor = true;
             // 
             // label3
@@ -370,7 +370,7 @@ namespace EVEMon.SettingsUI
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(30, 13);
             this.label3.TabIndex = 27;
-            this.label3.Text = "Size:";
+            this.label3.Text = resources.GetString("this.label3.Text");
             // 
             // cbShowPortrait
             // 
@@ -379,7 +379,7 @@ namespace EVEMon.SettingsUI
             this.cbShowPortrait.Name = "cbShowPortrait";
             this.cbShowPortrait.Size = new System.Drawing.Size(142, 17);
             this.cbShowPortrait.TabIndex = 26;
-            this.cbShowPortrait.Text = "Show Character Portrait";
+            this.cbShowPortrait.Text = resources.GetString("this.cbShowPortrait.Text");
             this.ttHelp.SetToolTip(this.cbShowPortrait, "When enabled, shows the character\'s portrait\r\nas a thumbnail alongside the charac" +
                     "ter\'s name");
             this.cbShowPortrait.UseVisualStyleBackColor = true;
@@ -396,7 +396,7 @@ namespace EVEMon.SettingsUI
             this.groupBox3.Size = new System.Drawing.Size(362, 64);
             this.groupBox3.TabIndex = 16;
             this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Miscellaneous";
+            this.groupBox3.Text = resources.GetString("this.groupBox3.Text");
             // 
             // cbUseIncreasedContrast
             // 
@@ -405,8 +405,8 @@ namespace EVEMon.SettingsUI
             this.cbUseIncreasedContrast.Name = "cbUseIncreasedContrast";
             this.cbUseIncreasedContrast.Size = new System.Drawing.Size(137, 17);
             this.cbUseIncreasedContrast.TabIndex = 21;
-            this.cbUseIncreasedContrast.Text = "Use Increased Contrast";
-            this.ttHelp.SetToolTip(this.cbUseIncreasedContrast, "When enabled, increases the contrast of the shown info");
+            this.cbUseIncreasedContrast.Text = resources.GetString("this.cbUseIncreasedContrast.Text");
+            this.ttHelp.SetToolTip(this.cbUseIncreasedContrast, resources.GetString("this.cbUseIncreasedContrast.ToolTip"));
             this.cbUseIncreasedContrast.UseVisualStyleBackColor = true;
             // 
             // cbShowEveTime
@@ -416,8 +416,8 @@ namespace EVEMon.SettingsUI
             this.cbShowEveTime.Name = "cbShowEveTime";
             this.cbShowEveTime.Size = new System.Drawing.Size(103, 17);
             this.cbShowEveTime.TabIndex = 20;
-            this.cbShowEveTime.Text = "Show EVE Time";
-            this.ttHelp.SetToolTip(this.cbShowEveTime, "When enabled, displays the current EVE time");
+            this.cbShowEveTime.Text = resources.GetString("this.cbShowEveTime.Text");
+            this.ttHelp.SetToolTip(this.cbShowEveTime, resources.GetString("this.cbShowEveTime.ToolTip"));
             this.cbShowEveTime.UseVisualStyleBackColor = true;
             // 
             // cbShowWarning
@@ -427,7 +427,7 @@ namespace EVEMon.SettingsUI
             this.cbShowWarning.Name = "cbShowWarning";
             this.cbShowWarning.Size = new System.Drawing.Size(193, 17);
             this.cbShowWarning.TabIndex = 19;
-            this.cbShowWarning.Text = "Show non-training account warning";
+            this.cbShowWarning.Text = resources.GetString("this.cbShowWarning.Text");
             this.ttHelp.SetToolTip(this.cbShowWarning, "When enabled, shows a warning message when\r\nno characters on an account are train" +
                     "ing a skill,\r\nif the provided API key is of 'Account' type.");
             this.cbShowWarning.UseVisualStyleBackColor = true;
@@ -439,8 +439,8 @@ namespace EVEMon.SettingsUI
             this.cbShowServerStatus.Name = "cbShowServerStatus";
             this.cbShowServerStatus.Size = new System.Drawing.Size(120, 17);
             this.cbShowServerStatus.TabIndex = 14;
-            this.cbShowServerStatus.Text = "Show Server Status";
-            this.ttHelp.SetToolTip(this.cbShowServerStatus, "When enabled, displays the current\r\nTranquility server status");
+            this.cbShowServerStatus.Text = resources.GetString("this.cbShowServerStatus.Text");
+            this.ttHelp.SetToolTip(this.cbShowServerStatus, resources.GetString("this.cbShowServerStatus.ToolTip"));
             this.cbShowServerStatus.UseVisualStyleBackColor = true;
             // 
             // flowLayoutPanel1
@@ -464,7 +464,7 @@ namespace EVEMon.SettingsUI
             this.MinimizeBox = false;
             this.Name = "TrayPopupConfigForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Tray Icon Popup Configuration";
+            this.Text = resources.GetString("this.Text");
             this.panel1.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
             this.tpGeneral.ResumeLayout(false);

--- a/src/EVEMon/SettingsUI/TrayPopUpConfigForm.resx
+++ b/src/EVEMon/SettingsUI/TrayPopUpConfigForm.resx
@@ -127,4 +127,121 @@ Training / Not Training - characters in training are shown above characters not 
 Not Training / Training - characters in training are shown below characters not training
 Account - characters on the same API key are shown together</value>
   </data>
+  <data name="this.btnUseDefaults.Text" xml:space="preserve">
+    <value>Use Defaults</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="this.btnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="this.tpGeneral.Text" xml:space="preserve">
+    <value>General</value>
+  </data>
+  <data name="this.groupBox1.Text" xml:space="preserve">
+    <value>Layout</value>
+  </data>
+  <data name="this.cbIndentGroupedAccounts.Text" xml:space="preserve">
+    <value>Indent Grouped Accounts</value>
+  </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>Group Characters by:</value>
+  </data>
+  <data name="this.cbHideNotTraining.Text" xml:space="preserve">
+    <value>Hide Characters not training</value>
+  </data>
+  <data name="this.groupBox4.Text" xml:space="preserve">
+    <value>Display Order</value>
+  </data>
+  <data name="this.lblDisplayOrder1.Text" xml:space="preserve">
+    <value>Characters in training:</value>
+  </data>
+  <data name="this.lblDisplayOrder2.Text" xml:space="preserve">
+    <value>Characters not training:</value>
+  </data>
+  <data name="this.groupBox2.Text" xml:space="preserve">
+    <value>Character Details</value>
+  </data>
+  <data name="this.cbShowSkillQueueTrainingTime.Text" xml:space="preserve">
+    <value>Show Skill Queue Training Time</value>
+  </data>
+  <data name="this.cbHighLightConflicts.Text" xml:space="preserve">
+    <value>Highlight Schedule Conflicts</value>
+  </data>
+  <data name="this.cbShowSkill.Text" xml:space="preserve">
+    <value>Show Skill in Training</value>
+  </data>
+  <data name="this.cbShowCompletionTime.Text" xml:space="preserve">
+    <value>Show Completion Time</value>
+  </data>
+  <data name="this.cbShowTimeToCompletion.Text" xml:space="preserve">
+    <value>Show Time to Completion</value>
+  </data>
+  <data name="this.cbShowWallet.Text" xml:space="preserve">
+    <value>Show Wallet Balance</value>
+  </data>
+  <data name="this.label3.Text" xml:space="preserve">
+    <value>Size:</value>
+  </data>
+  <data name="this.cbShowPortrait.Text" xml:space="preserve">
+    <value>Show Character Portrait</value>
+  </data>
+  <data name="this.groupBox3.Text" xml:space="preserve">
+    <value>Miscellaneous</value>
+  </data>
+  <data name="this.cbUseIncreasedContrast.Text" xml:space="preserve">
+    <value>Use Increased Contrast</value>
+  </data>
+  <data name="this.cbShowEveTime.Text" xml:space="preserve">
+    <value>Show EVE Time</value>
+  </data>
+  <data name="this.cbShowWarning.Text" xml:space="preserve">
+    <value>Show non-training account warning</value>
+  </data>
+  <data name="this.cbShowServerStatus.Text" xml:space="preserve">
+    <value>Show Server Status</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Tray Icon Popup Configuration</value>
+  </data>
+  <data name="this.cbHideNotTraining.ToolTip" xml:space="preserve">
+    <value>When enabled, only characters currently
+training a skill will be displayed</value>
+  </data>
+  <data name="this.cbDisplayOrder2.ToolTip" xml:space="preserve">
+    <value>Controls the display order of characters, dependent on grouping.</value>
+  </data>
+  <data name="this.cbDisplayOrder1.ToolTip" xml:space="preserve">
+    <value>Controls the display order of characters, dependent on grouping.</value>
+  </data>
+  <data name="this.cbShowSkillQueueTrainingTime.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character\'s
+skill queue training time</value>
+  </data>
+  <data name="this.cbShowSkill.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the currently
+training skill name and level</value>
+  </data>
+  <data name="this.cbShowTimeToCompletion.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the time remaining
+ until training is completed</value>
+  </data>
+  <data name="this.cbPortraitSize.ToolTip" xml:space="preserve">
+    <value>Selects the image size, in pixels, to be used
+for the character portrait</value>
+  </data>
+  <data name="this.cbShowWallet.ToolTip" xml:space="preserve">
+    <value>When enabled, shows the character\'s wallet balance</value>
+  </data>
+  <data name="this.cbUseIncreasedContrast.ToolTip" xml:space="preserve">
+    <value>When enabled, increases the contrast of the shown info</value>
+  </data>
+  <data name="this.cbShowEveTime.ToolTip" xml:space="preserve">
+    <value>When enabled, displays the current EVE time</value>
+  </data>
+  <data name="this.cbShowServerStatus.ToolTip" xml:space="preserve">
+    <value>When enabled, displays the current
+Tranquility server status</value>
+  </data>
 </root>

--- a/src/EVEMon/SettingsUI/TrayPopUpConfigForm.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/TrayPopUpConfigForm.zh-CN.resx
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="cbGroupBy.ToolTip" xml:space="preserve">
+    <value>控制弹出窗口中字符的分组方式：
+无 - 字符不分组
+训练/未训练 - 训练中的角色显示在未训练的角色上方
+未训练/训练 - 训练中的角色显示在未训练的角色下方
+帐户 - 同一 API 密钥上的字符一起显示</value>
+  </data>
+  <data name="this.btnUseDefaults.Text" xml:space="preserve">
+    <value>使用默认值</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="this.btnOK.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="this.tpGeneral.Text" xml:space="preserve">
+    <value>一般</value>
+  </data>
+  <data name="this.groupBox1.Text" xml:space="preserve">
+    <value>布局</value>
+  </data>
+  <data name="this.cbIndentGroupedAccounts.Text" xml:space="preserve">
+    <value>缩进分组帐户</value>
+  </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>对角色进行分组的依据：</value>
+  </data>
+  <data name="this.cbHideNotTraining.Text" xml:space="preserve">
+    <value>隐藏未训练的角色</value>
+  </data>
+  <data name="this.groupBox4.Text" xml:space="preserve">
+    <value>显示顺序</value>
+  </data>
+  <data name="this.lblDisplayOrder1.Text" xml:space="preserve">
+    <value>训练中的角色：</value>
+  </data>
+  <data name="this.lblDisplayOrder2.Text" xml:space="preserve">
+    <value>未训练的角色：</value>
+  </data>
+  <data name="this.groupBox2.Text" xml:space="preserve">
+    <value>角色详情</value>
+  </data>
+  <data name="this.cbShowSkillQueueTrainingTime.Text" xml:space="preserve">
+    <value>显示技能队列训练时间</value>
+  </data>
+  <data name="this.cbHighLightConflicts.Text" xml:space="preserve">
+    <value>突出显示日程冲突</value>
+  </data>
+  <data name="this.cbShowSkill.Text" xml:space="preserve">
+    <value>在训练中展现技巧</value>
+  </data>
+  <data name="this.cbShowCompletionTime.Text" xml:space="preserve">
+    <value>显示完成时间</value>
+  </data>
+  <data name="this.cbShowTimeToCompletion.Text" xml:space="preserve">
+    <value>显示完成时间</value>
+  </data>
+  <data name="this.cbShowWallet.Text" xml:space="preserve">
+    <value>显示钱包余额</value>
+  </data>
+  <data name="this.label3.Text" xml:space="preserve">
+    <value>尺寸：</value>
+  </data>
+  <data name="this.cbShowPortrait.Text" xml:space="preserve">
+    <value>显示人物肖像</value>
+  </data>
+  <data name="this.groupBox3.Text" xml:space="preserve">
+    <value>杂项</value>
+  </data>
+  <data name="this.cbUseIncreasedContrast.Text" xml:space="preserve">
+    <value>使用增强对比度</value>
+  </data>
+  <data name="this.cbShowEveTime.Text" xml:space="preserve">
+    <value>显示 EVE 时间</value>
+  </data>
+  <data name="this.cbShowWarning.Text" xml:space="preserve">
+    <value>显示非训练帐户警告</value>
+  </data>
+  <data name="this.cbShowServerStatus.Text" xml:space="preserve">
+    <value>显示服务器状态</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>托盘图标弹出配置</value>
+  </data>
+  <data name="this.cbHideNotTraining.ToolTip" xml:space="preserve">
+    <value>启用后，当前仅显示字符
+训练技能将会显示</value>
+  </data>
+  <data name="this.cbDisplayOrder2.ToolTip" xml:space="preserve">
+    <value>控制字符的显示顺序，具体取决于分组。</value>
+  </data>
+  <data name="this.cbDisplayOrder1.ToolTip" xml:space="preserve">
+    <value>控制字符的显示顺序，具体取决于分组。</value>
+  </data>
+  <data name="this.cbShowSkillQueueTrainingTime.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的
+技能队列训练时间</value>
+  </data>
+  <data name="this.cbShowSkill.ToolTip" xml:space="preserve">
+    <value>启用后，显示当前
+训练技能名称及等级</value>
+  </data>
+  <data name="this.cbShowTimeToCompletion.ToolTip" xml:space="preserve">
+    <value>启用后，显示剩余时间
+ 直到训练完成</value>
+  </data>
+  <data name="this.cbPortraitSize.ToolTip" xml:space="preserve">
+    <value>选择要使用的图像大小（以像素为单位）
+对于人物肖像</value>
+  </data>
+  <data name="this.cbShowWallet.ToolTip" xml:space="preserve">
+    <value>启用后，显示角色的钱包余额</value>
+  </data>
+  <data name="this.cbUseIncreasedContrast.ToolTip" xml:space="preserve">
+    <value>启用后，增加显示信息的对比度</value>
+  </data>
+  <data name="this.cbShowEveTime.ToolTip" xml:space="preserve">
+    <value>启用后，显示当前 EVE 时间</value>
+  </data>
+  <data name="this.cbShowServerStatus.ToolTip" xml:space="preserve">
+    <value>启用后，显示当前
+宁静服务器状态</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/TrayTooltipConfigForm.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/TrayTooltipConfigForm.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SettingsUI/UpdateSettingsControl.zh-CN.resx
+++ b/src/EVEMon/SettingsUI/UpdateSettingsControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerControl.Designer.cs
@@ -107,7 +107,7 @@ namespace EVEMon.SkillPlanner
             this.lblImplants.Name = "lblImplants";
             this.lblImplants.Size = new System.Drawing.Size(65, 16);
             this.lblImplants.TabIndex = 60;
-            this.lblImplants.Text = "Implants";
+            this.lblImplants.Text = resources.GetString("this.lblImplants.Text");
             this.lblImplants.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // pictureBox5
@@ -222,7 +222,7 @@ namespace EVEMon.SkillPlanner
             this.lblMemory.Name = "lblMemory";
             this.lblMemory.Size = new System.Drawing.Size(44, 13);
             this.lblMemory.TabIndex = 47;
-            this.lblMemory.Text = "Memory";
+            this.lblMemory.Text = resources.GetString("this.lblMemory.Text");
             // 
             // lblWillpower
             // 
@@ -231,7 +231,7 @@ namespace EVEMon.SkillPlanner
             this.lblWillpower.Name = "lblWillpower";
             this.lblWillpower.Size = new System.Drawing.Size(53, 13);
             this.lblWillpower.TabIndex = 45;
-            this.lblWillpower.Text = "Willpower";
+            this.lblWillpower.Text = resources.GetString("this.lblWillpower.Text");
             // 
             // lblCharisma
             // 
@@ -240,7 +240,7 @@ namespace EVEMon.SkillPlanner
             this.lblCharisma.Name = "lblCharisma";
             this.lblCharisma.Size = new System.Drawing.Size(50, 13);
             this.lblCharisma.TabIndex = 43;
-            this.lblCharisma.Text = "Charisma";
+            this.lblCharisma.Text = resources.GetString("this.lblCharisma.Text");
             // 
             // lblPerception
             // 
@@ -249,7 +249,7 @@ namespace EVEMon.SkillPlanner
             this.lblPerception.Name = "lblPerception";
             this.lblPerception.Size = new System.Drawing.Size(58, 13);
             this.lblPerception.TabIndex = 41;
-            this.lblPerception.Text = "Perception";
+            this.lblPerception.Text = resources.GetString("this.lblPerception.Text");
             // 
             // lblIntelligence
             // 
@@ -258,7 +258,7 @@ namespace EVEMon.SkillPlanner
             this.lblIntelligence.Name = "lblIntelligence";
             this.lblIntelligence.Size = new System.Drawing.Size(61, 13);
             this.lblIntelligence.TabIndex = 39;
-            this.lblIntelligence.Text = "Intelligence";
+            this.lblIntelligence.Text = resources.GetString("this.lblIntelligence.Text");
             // 
             // lblBase
             // 
@@ -266,7 +266,7 @@ namespace EVEMon.SkillPlanner
             this.lblBase.Name = "lblBase";
             this.lblBase.Size = new System.Drawing.Size(108, 16);
             this.lblBase.TabIndex = 59;
-            this.lblBase.Text = "Remappable";
+            this.lblBase.Text = resources.GetString("this.lblBase.Text");
             this.lblBase.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lbMEM
@@ -276,7 +276,7 @@ namespace EVEMon.SkillPlanner
             this.lbMEM.Name = "lbMEM";
             this.lbMEM.Size = new System.Drawing.Size(57, 13);
             this.lbMEM.TabIndex = 48;
-            this.lbMEM.Text = "Points : 20";
+            this.lbMEM.Text = resources.GetString("this.lbMEM.Text");
             // 
             // lbWIL
             // 
@@ -285,7 +285,7 @@ namespace EVEMon.SkillPlanner
             this.lbWIL.Name = "lbWIL";
             this.lbWIL.Size = new System.Drawing.Size(57, 13);
             this.lbWIL.TabIndex = 46;
-            this.lbWIL.Text = "Points : 20";
+            this.lbWIL.Text = resources.GetString("this.lbWIL.Text");
             // 
             // lbCHA
             // 
@@ -294,7 +294,7 @@ namespace EVEMon.SkillPlanner
             this.lbCHA.Name = "lbCHA";
             this.lbCHA.Size = new System.Drawing.Size(57, 13);
             this.lbCHA.TabIndex = 44;
-            this.lbCHA.Text = "Points : 20";
+            this.lbCHA.Text = resources.GetString("this.lbCHA.Text");
             // 
             // lbPER
             // 
@@ -303,7 +303,7 @@ namespace EVEMon.SkillPlanner
             this.lbPER.Name = "lbPER";
             this.lbPER.Size = new System.Drawing.Size(57, 13);
             this.lbPER.TabIndex = 42;
-            this.lbPER.Text = "Points : 20";
+            this.lbPER.Text = resources.GetString("this.lbPER.Text");
             // 
             // lbINT
             // 
@@ -312,7 +312,7 @@ namespace EVEMon.SkillPlanner
             this.lbINT.Name = "lbINT";
             this.lbINT.Size = new System.Drawing.Size(113, 13);
             this.lbINT.TabIndex = 40;
-            this.lbINT.Text = "20 (new : 18 ; old : 17)";
+            this.lbINT.Text = resources.GetString("this.lbINT.Text");
             // 
             // tblayoutComparePanel
             // 
@@ -343,7 +343,7 @@ namespace EVEMon.SkillPlanner
             this.lbGain.Name = "lbGain";
             this.lbGain.Size = new System.Drawing.Size(156, 13);
             this.lbGain.TabIndex = 17;
-            this.lbGain.Text = "Your skills are already optimized";
+            this.lbGain.Text = resources.GetString("this.lbGain.Text");
             // 
             // lbOptimizedTimeInfo
             // 
@@ -353,7 +353,7 @@ namespace EVEMon.SkillPlanner
             this.lbOptimizedTimeInfo.Name = "lbOptimizedTimeInfo";
             this.lbOptimizedTimeInfo.Size = new System.Drawing.Size(110, 13);
             this.lbOptimizedTimeInfo.TabIndex = 16;
-            this.lbOptimizedTimeInfo.Text = "With these attributes :";
+            this.lbOptimizedTimeInfo.Text = resources.GetString("this.lbOptimizedTimeInfo.Text");
             // 
             // lbCurrentTime
             // 
@@ -363,7 +363,7 @@ namespace EVEMon.SkillPlanner
             this.lbCurrentTime.Name = "lbCurrentTime";
             this.lbCurrentTime.Size = new System.Drawing.Size(50, 13);
             this.lbCurrentTime.TabIndex = 19;
-            this.lbCurrentTime.Text = "0h 0m 0s";
+            this.lbCurrentTime.Text = resources.GetString("this.lbCurrentTime.Text");
             // 
             // lbOptimizedTime
             // 
@@ -383,7 +383,7 @@ namespace EVEMon.SkillPlanner
             this.lbCurrentTimeInfo.Name = "lbCurrentTimeInfo";
             this.lbCurrentTimeInfo.Size = new System.Drawing.Size(69, 13);
             this.lbCurrentTimeInfo.TabIndex = 15;
-            this.lbCurrentTimeInfo.Text = "Current time :";
+            this.lbCurrentTimeInfo.Text = resources.GetString("this.lbCurrentTimeInfo.Text");
             // 
             // lbWarning
             // 
@@ -397,7 +397,7 @@ namespace EVEMon.SkillPlanner
             this.lbWarning.Name = "lbWarning";
             this.lbWarning.Size = new System.Drawing.Size(159, 26);
             this.lbWarning.TabIndex = 74;
-            this.lbWarning.Text = "Training will be complete before   the end of 12 month period.";
+            this.lbWarning.Text = resources.GetString("this.lbWarning.Text");
             this.lbWarning.Visible = false;
             // 
             // buttonCurrent
@@ -406,7 +406,7 @@ namespace EVEMon.SkillPlanner
             this.buttonCurrent.Name = "buttonCurrent";
             this.buttonCurrent.Size = new System.Drawing.Size(117, 23);
             this.buttonCurrent.TabIndex = 75;
-            this.buttonCurrent.Text = "Reset to current";
+            this.buttonCurrent.Text = resources.GetString("this.buttonCurrent.Text");
             this.buttonCurrent.UseVisualStyleBackColor = true;
             this.buttonCurrent.Click += new System.EventHandler(this.buttonCurrent_Click);
             // 
@@ -417,7 +417,7 @@ namespace EVEMon.SkillPlanner
             this.lblUnassignedAttributePoints.Name = "lblUnassignedAttributePoints";
             this.lblUnassignedAttributePoints.Size = new System.Drawing.Size(140, 13);
             this.lblUnassignedAttributePoints.TabIndex = 77;
-            this.lblUnassignedAttributePoints.Text = "Unassigned Attribute Points:";
+            this.lblUnassignedAttributePoints.Text = resources.GetString("this.lblUnassignedAttributePoints.Text");
             // 
             // buttonOptimize
             // 
@@ -425,7 +425,7 @@ namespace EVEMon.SkillPlanner
             this.buttonOptimize.Name = "buttonOptimize";
             this.buttonOptimize.Size = new System.Drawing.Size(117, 23);
             this.buttonOptimize.TabIndex = 79;
-            this.buttonOptimize.Text = "Optimized";
+            this.buttonOptimize.Text = resources.GetString("this.buttonOptimize.Text");
             this.buttonOptimize.UseVisualStyleBackColor = true;
             this.buttonOptimize.Click += new System.EventHandler(this.buttonOptimize_Click);
             // 
@@ -441,7 +441,7 @@ namespace EVEMon.SkillPlanner
             this.lblNotice.Name = "lblNotice";
             this.lblNotice.Size = new System.Drawing.Size(294, 13);
             this.lblNotice.TabIndex = 112;
-            this.lblNotice.Text = "Notice! This is not the active \"Implant Set\" of your character.";
+            this.lblNotice.Text = resources.GetString("this.lblNotice.Text");
             this.lblNotice.Visible = false;
             // 
             // labelDescription
@@ -454,7 +454,7 @@ namespace EVEMon.SkillPlanner
             this.labelDescription.Padding = new System.Windows.Forms.Padding(8);
             this.labelDescription.Size = new System.Drawing.Size(98, 29);
             this.labelDescription.TabIndex = 113;
-            this.labelDescription.Text = "labelDescription";
+            this.labelDescription.Text = resources.GetString("this.labelDescription.Text");
             // 
             // abMEMInc
             // 
@@ -708,7 +708,7 @@ namespace EVEMon.SkillPlanner
             this.lblBooster.Name = "lblBooster";
             this.lblBooster.Size = new System.Drawing.Size(103, 16);
             this.lblBooster.TabIndex = 119;
-            this.lblBooster.Text = "Active Booster: +99";
+            this.lblBooster.Text = resources.GetString("this.lblBooster.Text");
             this.lblBooster.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // AttributesOptimizerControl

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerControl.resx
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerControl.resx
@@ -470,4 +470,73 @@
         fzblsiKhnEkYfCITbDg+VGbxF8mwYf8FXNyO9VVdS+0AAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.lblImplants.Text" xml:space="preserve">
+    <value>Implants</value>
+  </data>
+  <data name="this.lblMemory.Text" xml:space="preserve">
+    <value>Memory</value>
+  </data>
+  <data name="this.lblWillpower.Text" xml:space="preserve">
+    <value>Willpower</value>
+  </data>
+  <data name="this.lblCharisma.Text" xml:space="preserve">
+    <value>Charisma</value>
+  </data>
+  <data name="this.lblPerception.Text" xml:space="preserve">
+    <value>Perception</value>
+  </data>
+  <data name="this.lblIntelligence.Text" xml:space="preserve">
+    <value>Intelligence</value>
+  </data>
+  <data name="this.lblBase.Text" xml:space="preserve">
+    <value>Remappable</value>
+  </data>
+  <data name="this.lbMEM.Text" xml:space="preserve">
+    <value>Points : 20</value>
+  </data>
+  <data name="this.lbWIL.Text" xml:space="preserve">
+    <value>Points : 20</value>
+  </data>
+  <data name="this.lbCHA.Text" xml:space="preserve">
+    <value>Points : 20</value>
+  </data>
+  <data name="this.lbPER.Text" xml:space="preserve">
+    <value>Points : 20</value>
+  </data>
+  <data name="this.lbINT.Text" xml:space="preserve">
+    <value>20 (new : 18 ; old : 17)</value>
+  </data>
+  <data name="this.lbGain.Text" xml:space="preserve">
+    <value>Your skills are already optimized</value>
+  </data>
+  <data name="this.lbOptimizedTimeInfo.Text" xml:space="preserve">
+    <value>With these attributes :</value>
+  </data>
+  <data name="this.lbCurrentTime.Text" xml:space="preserve">
+    <value>0h 0m 0s</value>
+  </data>
+  <data name="this.lbCurrentTimeInfo.Text" xml:space="preserve">
+    <value>Current time :</value>
+  </data>
+  <data name="this.lbWarning.Text" xml:space="preserve">
+    <value>Training will be complete before   the end of 12 month period.</value>
+  </data>
+  <data name="this.buttonCurrent.Text" xml:space="preserve">
+    <value>Reset to current</value>
+  </data>
+  <data name="this.lblUnassignedAttributePoints.Text" xml:space="preserve">
+    <value>Unassigned Attribute Points:</value>
+  </data>
+  <data name="this.buttonOptimize.Text" xml:space="preserve">
+    <value>Optimized</value>
+  </data>
+  <data name="this.lblNotice.Text" xml:space="preserve">
+    <value>Notice! This is not the active "Implant Set" of your character.</value>
+  </data>
+  <data name="this.labelDescription.Text" xml:space="preserve">
+    <value>labelDescription</value>
+  </data>
+  <data name="this.lblBooster.Text" xml:space="preserve">
+    <value>Active Booster: +99</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerControl.zh-CN.resx
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.lblImplants.Text" xml:space="preserve">
+    <value>植入物</value>
+  </data>
+  <data name="this.lblMemory.Text" xml:space="preserve">
+    <value>内存</value>
+  </data>
+  <data name="this.lblWillpower.Text" xml:space="preserve">
+    <value>意志力</value>
+  </data>
+  <data name="this.lblCharisma.Text" xml:space="preserve">
+    <value>魅力</value>
+  </data>
+  <data name="this.lblPerception.Text" xml:space="preserve">
+    <value>感知</value>
+  </data>
+  <data name="this.lblIntelligence.Text" xml:space="preserve">
+    <value>情报</value>
+  </data>
+  <data name="this.lblBase.Text" xml:space="preserve">
+    <value>可重新映射</value>
+  </data>
+  <data name="this.lbMEM.Text" xml:space="preserve">
+    <value>积分：20</value>
+  </data>
+  <data name="this.lbWIL.Text" xml:space="preserve">
+    <value>积分：20</value>
+  </data>
+  <data name="this.lbCHA.Text" xml:space="preserve">
+    <value>积分：20</value>
+  </data>
+  <data name="this.lbPER.Text" xml:space="preserve">
+    <value>积分：20</value>
+  </data>
+  <data name="this.lbINT.Text" xml:space="preserve">
+    <value>20（新：18；旧：17）</value>
+  </data>
+  <data name="this.lbGain.Text" xml:space="preserve">
+    <value>你的技能已经优化</value>
+  </data>
+  <data name="this.lbOptimizedTimeInfo.Text" xml:space="preserve">
+    <value>具有这些属性：</value>
+  </data>
+  <data name="this.lbCurrentTime.Text" xml:space="preserve">
+    <value>0小时0分0秒</value>
+  </data>
+  <data name="this.lbCurrentTimeInfo.Text" xml:space="preserve">
+    <value>当前时间：</value>
+  </data>
+  <data name="this.lbWarning.Text" xml:space="preserve">
+    <value>培训将在 12 个月期限结束前完成。</value>
+  </data>
+  <data name="this.buttonCurrent.Text" xml:space="preserve">
+    <value>重置为当前状态</value>
+  </data>
+  <data name="this.lblUnassignedAttributePoints.Text" xml:space="preserve">
+    <value>未分配的属性点：</value>
+  </data>
+  <data name="this.buttonOptimize.Text" xml:space="preserve">
+    <value>优化</value>
+  </data>
+  <data name="this.lblNotice.Text" xml:space="preserve">
+    <value>注意！这不是您角色的活动“植入装置”。</value>
+  </data>
+  <data name="this.labelDescription.Text" xml:space="preserve">
+    <value>标签描述</value>
+  </data>
+  <data name="this.lblBooster.Text" xml:space="preserve">
+    <value>活跃助推器：+99</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.Designer.cs
@@ -45,7 +45,7 @@ namespace EVEMon.SkillPlanner
             this.buttonWholePlan.Name = "buttonWholePlan";
             this.buttonWholePlan.Size = new System.Drawing.Size(472, 48);
             this.buttonWholePlan.TabIndex = 1;
-            this.buttonWholePlan.Text = "Attributes that would be best for the first year of this plan.";
+            this.buttonWholePlan.Text = resources.GetString("this.buttonWholePlan.Text");
             this.buttonWholePlan.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.buttonWholePlan.UseVisualStyleBackColor = true;
             this.buttonWholePlan.Click += new System.EventHandler(this.buttonWholePlan_Click);
@@ -61,7 +61,7 @@ namespace EVEMon.SkillPlanner
             this.buttonRemappingPoints.Name = "buttonRemappingPoints";
             this.buttonRemappingPoints.Size = new System.Drawing.Size(472, 48);
             this.buttonRemappingPoints.TabIndex = 0;
-            this.buttonRemappingPoints.Text = "Use the remapping points I set up.";
+            this.buttonRemappingPoints.Text = resources.GetString("this.buttonRemappingPoints.Text");
             this.buttonRemappingPoints.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.buttonRemappingPoints.UseVisualStyleBackColor = true;
             this.buttonRemappingPoints.Click += new System.EventHandler(this.buttonRemappingPoints_Click);
@@ -77,7 +77,7 @@ namespace EVEMon.SkillPlanner
             this.buttonCharacter.Name = "buttonCharacter";
             this.buttonCharacter.Size = new System.Drawing.Size(472, 48);
             this.buttonCharacter.TabIndex = 2;
-            this.buttonCharacter.Text = "Attributes that would have been best for what I have trained so far.";
+            this.buttonCharacter.Text = resources.GetString("this.buttonCharacter.Text");
             this.buttonCharacter.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.buttonCharacter.UseVisualStyleBackColor = true;
             this.buttonCharacter.Click += new System.EventHandler(this.buttonCharacter_Click);
@@ -96,7 +96,7 @@ namespace EVEMon.SkillPlanner
             this.Name = "AttributesOptimizerOptionsWindow";
             this.ShowInTaskbar = false;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Attributes Optimizer Options";
+            this.Text = resources.GetString("this.Text");
             this.ResumeLayout(false);
 
         }

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.resx
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.resx
@@ -199,4 +199,16 @@
         8QqlJwniFgAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="this.buttonWholePlan.Text" xml:space="preserve">
+    <value>Attributes that would be best for the first year of this plan.</value>
+  </data>
+  <data name="this.buttonRemappingPoints.Text" xml:space="preserve">
+    <value>Use the remapping points I set up.</value>
+  </data>
+  <data name="this.buttonCharacter.Text" xml:space="preserve">
+    <value>Attributes that would have been best for what I have trained so far.</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Attributes Optimizer Options</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerOptionsWindow.zh-CN.resx
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.buttonWholePlan.Text" xml:space="preserve">
+    <value>最适合该计划第一年的属性。</value>
+  </data>
+  <data name="this.buttonRemappingPoints.Text" xml:space="preserve">
+    <value>使用我设置的重新映射点。</value>
+  </data>
+  <data name="this.buttonCharacter.Text" xml:space="preserve">
+    <value>对于我迄今为止所接受的训练来说，这些属性是最好的。</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>属性优化器选项</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/AttributesOptimizerWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/AttributesOptimizerWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/BlueprintBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/BlueprintBrowserControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/BlueprintSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/BlueprintSelectControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/CertificateBrowserControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/CertificateBrowserControl.Designer.cs
@@ -167,7 +167,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel5Time.Name = "lblLevel5Time";
             this.lblLevel5Time.Size = new System.Drawing.Size(131, 13);
             this.lblLevel5Time.TabIndex = 29;
-            this.lblLevel5Time.Text = "Level V : 11d, 6h, 33m, 3s";
+            this.lblLevel5Time.Text = resources.GetString("this.lblLevel5Time.Text");
             // 
             // tspControl
             // 
@@ -187,13 +187,13 @@ namespace EVEMon.SkillPlanner
             // 
             this.tslbTextForEligibility.Name = "tslbTextForEligibility";
             this.tslbTextForEligibility.Size = new System.Drawing.Size(202, 22);
-            this.tslbTextForEligibility.Text = "After this plan you will be eligible to :";
+            this.tslbTextForEligibility.Text = resources.GetString("this.tslbTextForEligibility.Text");
             // 
             // tslbEligible
             // 
             this.tslbEligible.Name = "tslbEligible";
             this.tslbEligible.Size = new System.Drawing.Size(34, 22);
-            this.tslbEligible.Text = "none";
+            this.tslbEligible.Text = resources.GetString("this.tslbEligible.Text");
             // 
             // toolStripSeparator1
             // 
@@ -212,42 +212,42 @@ namespace EVEMon.SkillPlanner
             this.planToLevel.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.planToLevel.Name = "planToLevel";
             this.planToLevel.Size = new System.Drawing.Size(84, 22);
-            this.planToLevel.Text = "Plan To...";
-            this.planToLevel.ToolTipText = "Plan To...";
+            this.planToLevel.Text = resources.GetString("this.planToLevel.Text");
+            this.planToLevel.ToolTipText = resources.GetString("this.planToLevel.ToolTipText");
             // 
             // tsPlanToLevelOne
             // 
             this.tsPlanToLevelOne.Name = "tsPlanToLevelOne";
             this.tsPlanToLevelOne.Size = new System.Drawing.Size(152, 22);
-            this.tsPlanToLevelOne.Text = "&Level I";
+            this.tsPlanToLevelOne.Text = resources.GetString("this.tsPlanToLevelOne.Text");
             this.tsPlanToLevelOne.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelTwo
             // 
             this.tsPlanToLevelTwo.Name = "tsPlanToLevelTwo";
             this.tsPlanToLevelTwo.Size = new System.Drawing.Size(152, 22);
-            this.tsPlanToLevelTwo.Text = "&Level II";
+            this.tsPlanToLevelTwo.Text = resources.GetString("this.tsPlanToLevelTwo.Text");
             this.tsPlanToLevelTwo.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelThree
             // 
             this.tsPlanToLevelThree.Name = "tsPlanToLevelThree";
             this.tsPlanToLevelThree.Size = new System.Drawing.Size(152, 22);
-            this.tsPlanToLevelThree.Text = "&Level III";
+            this.tsPlanToLevelThree.Text = resources.GetString("this.tsPlanToLevelThree.Text");
             this.tsPlanToLevelThree.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelFour
             // 
             this.tsPlanToLevelFour.Name = "tsPlanToLevelFour";
             this.tsPlanToLevelFour.Size = new System.Drawing.Size(152, 22);
-            this.tsPlanToLevelFour.Text = "&Level IV";
+            this.tsPlanToLevelFour.Text = resources.GetString("this.tsPlanToLevelFour.Text");
             this.tsPlanToLevelFour.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelFive
             // 
             this.tsPlanToLevelFive.Name = "tsPlanToLevelFive";
             this.tsPlanToLevelFive.Size = new System.Drawing.Size(152, 22);
-            this.tsPlanToLevelFive.Text = "&Level V";
+            this.tsPlanToLevelFive.Text = resources.GetString("this.tsPlanToLevelFive.Text");
             this.tsPlanToLevelFive.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // pictureBox1
@@ -266,7 +266,7 @@ namespace EVEMon.SkillPlanner
             this.lblCategory.Name = "lblCategory";
             this.lblCategory.Size = new System.Drawing.Size(71, 13);
             this.lblCategory.TabIndex = 26;
-            this.lblCategory.Text = "Skill Category";
+            this.lblCategory.Text = resources.GetString("this.lblCategory.Text");
             // 
             // textboxDescription
             // 
@@ -290,7 +290,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel4Time.Name = "lblLevel4Time";
             this.lblLevel4Time.Size = new System.Drawing.Size(140, 13);
             this.lblLevel4Time.TabIndex = 23;
-            this.lblLevel4Time.Text = "Level IV : 5d, 12h, 15m, 24s";
+            this.lblLevel4Time.Text = resources.GetString("this.lblLevel4Time.Text");
             // 
             // lblLevel3Time
             // 
@@ -299,7 +299,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel3Time.Name = "lblLevel3Time";
             this.lblLevel3Time.Size = new System.Drawing.Size(139, 13);
             this.lblLevel3Time.TabIndex = 22;
-            this.lblLevel3Time.Text = "Level III : 1d, 23h, 49m, 36s";
+            this.lblLevel3Time.Text = resources.GetString("this.lblLevel3Time.Text");
             // 
             // lblLevel2Time
             // 
@@ -308,7 +308,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel2Time.Name = "lblLevel2Time";
             this.lblLevel2Time.Size = new System.Drawing.Size(112, 13);
             this.lblLevel2Time.TabIndex = 21;
-            this.lblLevel2Time.Text = "Level II : 8h, 27m, 17s";
+            this.lblLevel2Time.Text = resources.GetString("this.lblLevel2Time.Text");
             // 
             // lblLevel1Time
             // 
@@ -317,7 +317,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel1Time.Name = "lblLevel1Time";
             this.lblLevel1Time.Size = new System.Drawing.Size(109, 13);
             this.lblLevel1Time.TabIndex = 20;
-            this.lblLevel1Time.Text = "Level I : 1h, 48m, 55s";
+            this.lblLevel1Time.Text = resources.GetString("this.lblLevel1Time.Text");
             // 
             // lblName
             // 
@@ -326,7 +326,7 @@ namespace EVEMon.SkillPlanner
             this.lblName.Name = "lblName";
             this.lblName.Size = new System.Drawing.Size(57, 13);
             this.lblName.TabIndex = 19;
-            this.lblName.Text = "Skill Name";
+            this.lblName.Text = resources.GetString("this.lblName.Text");
             // 
             // lblHelp
             // 
@@ -335,7 +335,7 @@ namespace EVEMon.SkillPlanner
             this.lblHelp.Name = "lblHelp";
             this.lblHelp.Size = new System.Drawing.Size(247, 13);
             this.lblHelp.TabIndex = 29;
-            this.lblHelp.Text = "Use the tree on the left to select certificate to view.";
+            this.lblHelp.Text = resources.GetString("this.lblHelp.Text");
             // 
             // CertificateBrowserControl
             // 

--- a/src/EVEMon/SkillPlanner/CertificateBrowserControl.resx
+++ b/src/EVEMon/SkillPlanner/CertificateBrowserControl.resx
@@ -293,4 +293,55 @@
         QmCC
 </value>
   </data>
+  <data name="this.lblLevel5Time.Text" xml:space="preserve">
+    <value>Level V : 11d, 6h, 33m, 3s</value>
+  </data>
+  <data name="this.tslbTextForEligibility.Text" xml:space="preserve">
+    <value>After this plan you will be eligible to :</value>
+  </data>
+  <data name="this.tslbEligible.Text" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>Plan To...</value>
+  </data>
+  <data name="this.planToLevel.ToolTipText" xml:space="preserve">
+    <value>Plan To...</value>
+  </data>
+  <data name="this.tsPlanToLevelOne.Text" xml:space="preserve">
+    <value>&amp;Level I</value>
+  </data>
+  <data name="this.tsPlanToLevelTwo.Text" xml:space="preserve">
+    <value>&amp;Level II</value>
+  </data>
+  <data name="this.tsPlanToLevelThree.Text" xml:space="preserve">
+    <value>&amp;Level III</value>
+  </data>
+  <data name="this.tsPlanToLevelFour.Text" xml:space="preserve">
+    <value>&amp;Level IV</value>
+  </data>
+  <data name="this.tsPlanToLevelFive.Text" xml:space="preserve">
+    <value>&amp;Level V</value>
+  </data>
+  <data name="this.lblCategory.Text" xml:space="preserve">
+    <value>Skill Category</value>
+  </data>
+  <data name="this.lblLevel4Time.Text" xml:space="preserve">
+    <value>Level IV : 5d, 12h, 15m, 24s</value>
+  </data>
+  <data name="this.lblLevel3Time.Text" xml:space="preserve">
+    <value>Level III : 1d, 23h, 49m, 36s</value>
+  </data>
+  <data name="this.lblLevel2Time.Text" xml:space="preserve">
+    <value>Level II : 8h, 27m, 17s</value>
+  </data>
+  <data name="this.lblLevel1Time.Text" xml:space="preserve">
+    <value>Level I : 1h, 48m, 55s</value>
+  </data>
+  <data name="this.lblName.Text" xml:space="preserve">
+    <value>Skill Name</value>
+  </data>
+  <data name="this.lblHelp.Text" xml:space="preserve">
+    <value>Use the tree on the left to select certificate to view.</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/CertificateBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/CertificateBrowserControl.zh-CN.resx
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.lblLevel5Time.Text" xml:space="preserve">
+    <value>V级：11d、6h、33m、3s</value>
+  </data>
+  <data name="this.tslbTextForEligibility.Text" xml:space="preserve">
+    <value>完成此计划后，您将有资格：</value>
+  </data>
+  <data name="this.tslbEligible.Text" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.planToLevel.ToolTipText" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.tsPlanToLevelOne.Text" xml:space="preserve">
+    <value>一级(&amp;I)</value>
+  </data>
+  <data name="this.tsPlanToLevelTwo.Text" xml:space="preserve">
+    <value>二级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelThree.Text" xml:space="preserve">
+    <value>三级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelFour.Text" xml:space="preserve">
+    <value>四级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelFive.Text" xml:space="preserve">
+    <value>V级(&amp;V)</value>
+  </data>
+  <data name="this.lblCategory.Text" xml:space="preserve">
+    <value>技能类别</value>
+  </data>
+  <data name="this.lblLevel4Time.Text" xml:space="preserve">
+    <value>IV级：5d、12h、15m、24s</value>
+  </data>
+  <data name="this.lblLevel3Time.Text" xml:space="preserve">
+    <value>三级：1d、23h、49m、36s</value>
+  </data>
+  <data name="this.lblLevel2Time.Text" xml:space="preserve">
+    <value>II级：8小时，27m，17秒</value>
+  </data>
+  <data name="this.lblLevel1Time.Text" xml:space="preserve">
+    <value>一级：1h、48m、55s</value>
+  </data>
+  <data name="this.lblName.Text" xml:space="preserve">
+    <value>技能名称</value>
+  </data>
+  <data name="this.lblHelp.Text" xml:space="preserve">
+    <value>使用左侧的树选择要查看的证书。</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/CertificateSelectControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/CertificateSelectControl.Designer.cs
@@ -111,7 +111,7 @@ namespace EVEMon.SkillPlanner
             this.lblSort.Name = "lblSort";
             this.lblSort.Size = new System.Drawing.Size(29, 13);
             this.lblSort.TabIndex = 56;
-            this.lblSort.Text = "Sort:";
+            this.lblSort.Text = resources.GetString("this.lblSort.Text");
             // 
             // pbSearchImage
             // 
@@ -136,7 +136,7 @@ namespace EVEMon.SkillPlanner
             this.lbSearchTextHint.Name = "lbSearchTextHint";
             this.lbSearchTextHint.Size = new System.Drawing.Size(65, 13);
             this.lbSearchTextHint.TabIndex = 53;
-            this.lbSearchTextHint.Text = "Search Text";
+            this.lbSearchTextHint.Text = resources.GetString("this.lbSearchTextHint.Text");
             this.lbSearchTextHint.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.lbSearchTextHint.Click += new System.EventHandler(this.lbSearchTextHint_Click);
             // 
@@ -148,7 +148,7 @@ namespace EVEMon.SkillPlanner
             this.lblFilter.Name = "lblFilter";
             this.lblFilter.Size = new System.Drawing.Size(32, 13);
             this.lblFilter.TabIndex = 54;
-            this.lblFilter.Text = "Filter:";
+            this.lblFilter.Text = resources.GetString("this.lblFilter.Text");
             // 
             // tbSearchText
             // 
@@ -186,7 +186,7 @@ namespace EVEMon.SkillPlanner
             this.lbNoMatches.Padding = new System.Windows.Forms.Padding(4, 30, 4, 4);
             this.lbNoMatches.Size = new System.Drawing.Size(227, 343);
             this.lbNoMatches.TabIndex = 23;
-            this.lbNoMatches.Text = "No certificates match your search.";
+            this.lbNoMatches.Text = resources.GetString("this.lbNoMatches.Text");
             this.lbNoMatches.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             this.lbNoMatches.Visible = false;
             // 
@@ -230,41 +230,41 @@ namespace EVEMon.SkillPlanner
             this.cmiLvPlanToLevel.Image = ((System.Drawing.Image)(resources.GetObject("cmiLvPlanToLevel.Image")));
             this.cmiLvPlanToLevel.Name = "cmiLvPlanToLevel";
             this.cmiLvPlanToLevel.Size = new System.Drawing.Size(166, 22);
-            this.cmiLvPlanToLevel.Text = "&Plan to...";
+            this.cmiLvPlanToLevel.Text = resources.GetString("this.cmiLvPlanToLevel.Text");
             // 
             // tsmLevel1
             // 
             this.tsmLevel1.Name = "tsmLevel1";
             this.tsmLevel1.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel1.Text = "Level I";
+            this.tsmLevel1.Text = resources.GetString("this.tsmLevel1.Text");
             this.tsmLevel1.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel2
             // 
             this.tsmLevel2.Name = "tsmLevel2";
             this.tsmLevel2.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel2.Text = "Level II";
+            this.tsmLevel2.Text = resources.GetString("this.tsmLevel2.Text");
             this.tsmLevel2.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel3
             // 
             this.tsmLevel3.Name = "tsmLevel3";
             this.tsmLevel3.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel3.Text = "Level III";
+            this.tsmLevel3.Text = resources.GetString("this.tsmLevel3.Text");
             this.tsmLevel3.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel4
             // 
             this.tsmLevel4.Name = "tsmLevel4";
             this.tsmLevel4.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel4.Text = "Level IV";
+            this.tsmLevel4.Text = resources.GetString("this.tsmLevel4.Text");
             this.tsmLevel4.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel5
             // 
             this.tsmLevel5.Name = "tsmLevel5";
             this.tsmLevel5.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel5.Text = "Level V";
+            this.tsmLevel5.Text = resources.GetString("this.tsmLevel5.Text");
             this.tsmLevel5.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // planToSeparator
@@ -276,14 +276,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandSelected.Name = "cmiExpandSelected";
             this.cmiExpandSelected.Size = new System.Drawing.Size(166, 22);
-            this.cmiExpandSelected.Text = "Expand Selected";
+            this.cmiExpandSelected.Text = resources.GetString("this.cmiExpandSelected.Text");
             this.cmiExpandSelected.Click += new System.EventHandler(this.cmiExpandSelected_Click);
             // 
             // cmiCollapseSelected
             // 
             this.cmiCollapseSelected.Name = "cmiCollapseSelected";
             this.cmiCollapseSelected.Size = new System.Drawing.Size(166, 22);
-            this.cmiCollapseSelected.Text = "Collapse Selected";
+            this.cmiCollapseSelected.Text = resources.GetString("this.cmiCollapseSelected.Text");
             this.cmiCollapseSelected.Click += new System.EventHandler(this.cmiCollapseSelected_Click);
             // 
             // expandCollapseSeparator
@@ -295,14 +295,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandAll.Name = "cmiExpandAll";
             this.cmiExpandAll.Size = new System.Drawing.Size(166, 22);
-            this.cmiExpandAll.Text = "&Expand All";
+            this.cmiExpandAll.Text = resources.GetString("this.cmiExpandAll.Text");
             this.cmiExpandAll.Click += new System.EventHandler(this.cmiExpandAll_Click);
             // 
             // cmiCollapseAll
             // 
             this.cmiCollapseAll.Name = "cmiCollapseAll";
             this.cmiCollapseAll.Size = new System.Drawing.Size(166, 22);
-            this.cmiCollapseAll.Text = "&Collapse All";
+            this.cmiCollapseAll.Text = resources.GetString("this.cmiCollapseAll.Text");
             this.cmiCollapseAll.Click += new System.EventHandler(this.cmiCollapseAll_Click);
             // 
             // tvItems
@@ -358,12 +358,12 @@ namespace EVEMon.SkillPlanner
             // 
             // chName
             // 
-            this.chName.Text = "Name";
+            this.chName.Text = resources.GetString("this.chName.Text");
             this.chName.Width = 120;
             // 
             // chSortKey
             // 
-            this.chSortKey.Text = "Sort";
+            this.chSortKey.Text = resources.GetString("this.chSortKey.Text");
             // 
             // pnlFilter
             // 

--- a/src/EVEMon/SkillPlanner/CertificateSelectControl.resx
+++ b/src/EVEMon/SkillPlanner/CertificateSelectControl.resx
@@ -685,4 +685,52 @@
         A6uGCYBoZDbcVGRFGJIggFcBsiSIRmaDFRF0JH5vOkYBALc2UwG7hivNAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.lblSort.Text" xml:space="preserve">
+    <value>Sort:</value>
+  </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>Search Text</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>No certificates match your search.</value>
+  </data>
+  <data name="this.cmiLvPlanToLevel.Text" xml:space="preserve">
+    <value>&amp;Plan to...</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>Level I</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>Level II</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>Level III</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>Level IV</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>Level V</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="this.chSortKey.Text" xml:space="preserve">
+    <value>Sort</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/CertificateSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/CertificateSelectControl.zh-CN.resx
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.lblSort.Text" xml:space="preserve">
+    <value>排序：</value>
+  </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>搜索文本</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>过滤器：</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>没有符合您搜索条件的证书。</value>
+  </data>
+  <data name="this.cmiLvPlanToLevel.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>一级</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>二级</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>三级</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>四级</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>Ⅴ级</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="this.chSortKey.Text" xml:space="preserve">
+    <value>排序</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.Designer.cs
@@ -69,7 +69,7 @@ namespace EVEMon.SkillPlanner
             this.planToLevel.Image = ((System.Drawing.Image)(resources.GetObject("planToLevel.Image")));
             this.planToLevel.Name = "planToLevel";
             this.planToLevel.Size = new System.Drawing.Size(194, 22);
-            this.planToLevel.Text = "&Plan...";
+            this.planToLevel.Text = resources.GetString("this.planToLevel.Text");
             this.planToLevel.Click += new System.EventHandler(this.tsmAddToPlan_Click);
             // 
             // planToLevelSeparator
@@ -81,7 +81,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInBrowserMenu.Name = "showInBrowserMenu";
             this.showInBrowserMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInBrowserMenu.Text = "Show in Skill &Browser";
+            this.showInBrowserMenu.Text = resources.GetString("this.showInBrowserMenu.Text");
             this.showInBrowserMenu.Click += new System.EventHandler(this.showInBrowserMenu_Click);
             // 
             // showInExplorerMenu
@@ -89,7 +89,7 @@ namespace EVEMon.SkillPlanner
             this.showInExplorerMenu.Image = ((System.Drawing.Image)(resources.GetObject("showInExplorerMenu.Image")));
             this.showInExplorerMenu.Name = "showInExplorerMenu";
             this.showInExplorerMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInExplorerMenu.Text = "Show in Skill &Explorer...";
+            this.showInExplorerMenu.Text = resources.GetString("this.showInExplorerMenu.Text");
             this.showInExplorerMenu.Click += new System.EventHandler(this.showInExplorerMenu_Click);
             // 
             // showInMenuSeparator
@@ -101,14 +101,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.tsmExpandSelected.Name = "tsmExpandSelected";
             this.tsmExpandSelected.Size = new System.Drawing.Size(194, 22);
-            this.tsmExpandSelected.Text = "Expand Selected";
+            this.tsmExpandSelected.Text = resources.GetString("this.tsmExpandSelected.Text");
             this.tsmExpandSelected.Click += new System.EventHandler(this.tsmExpandSelected_Click);
             // 
             // tsmCollapseSelected
             // 
             this.tsmCollapseSelected.Name = "tsmCollapseSelected";
             this.tsmCollapseSelected.Size = new System.Drawing.Size(194, 22);
-            this.tsmCollapseSelected.Text = "Collapse Selected";
+            this.tsmCollapseSelected.Text = resources.GetString("this.tsmCollapseSelected.Text");
             this.tsmCollapseSelected.Click += new System.EventHandler(this.tsmCollapseSelected_Click);
             // 
             // toggleSeparator
@@ -120,14 +120,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.tsmExpandAll.Name = "tsmExpandAll";
             this.tsmExpandAll.Size = new System.Drawing.Size(194, 22);
-            this.tsmExpandAll.Text = "&Expand All";
+            this.tsmExpandAll.Text = resources.GetString("this.tsmExpandAll.Text");
             this.tsmExpandAll.Click += new System.EventHandler(this.tsmExpandAll_Click);
             // 
             // tsmCollapseAll
             // 
             this.tsmCollapseAll.Name = "tsmCollapseAll";
             this.tsmCollapseAll.Size = new System.Drawing.Size(194, 22);
-            this.tsmCollapseAll.Text = "&Collapse All";
+            this.tsmCollapseAll.Text = resources.GetString("this.tsmCollapseAll.Text");
             this.tsmCollapseAll.Click += new System.EventHandler(this.tsmCollapseAll_Click);
             // 
             // imageList

--- a/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.resx
+++ b/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.resx
@@ -840,4 +840,25 @@
         /wBDAAs=
 </value>
   </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>&amp;Plan...</value>
+  </data>
+  <data name="this.showInBrowserMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.showInExplorerMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.tsmExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.tsmCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.tsmExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.tsmCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/CertificateTreeDisplayControl.zh-CN.resx
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>计划(&amp;P)...</value>
+  </data>
+  <data name="this.showInBrowserMenu.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.showInExplorerMenu.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.tsmExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.tsmCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.tsmExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.tsmCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/EveObjectBrowserControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/EveObjectBrowserControl.Designer.cs
@@ -128,7 +128,7 @@ namespace EVEMon.SkillPlanner
             this.gbDescription.Size = new System.Drawing.Size(240, 230);
             this.gbDescription.TabIndex = 14;
             this.gbDescription.TabStop = false;
-            this.gbDescription.Text = "Description";
+            this.gbDescription.Text = resources.GetString("this.gbDescription.Text");
             // 
             // tbDescription
             // 
@@ -170,7 +170,7 @@ namespace EVEMon.SkillPlanner
             this.lblEveObjCategory.Name = "lblEveObjCategory";
             this.lblEveObjCategory.Size = new System.Drawing.Size(102, 13);
             this.lblEveObjCategory.TabIndex = 6;
-            this.lblEveObjCategory.Text = "EveObject Category";
+            this.lblEveObjCategory.Text = resources.GetString("this.lblEveObjCategory.Text");
             this.lblEveObjCategory.UseMnemonic = false;
             // 
             // lblEveObjName
@@ -181,7 +181,7 @@ namespace EVEMon.SkillPlanner
             this.lblEveObjName.Name = "lblEveObjName";
             this.lblEveObjName.Size = new System.Drawing.Size(131, 18);
             this.lblEveObjName.TabIndex = 7;
-            this.lblEveObjName.Text = "EveObject Name";
+            this.lblEveObjName.Text = resources.GetString("this.lblEveObjName.Text");
             // 
             // lblHelp
             // 

--- a/src/EVEMon/SkillPlanner/EveObjectBrowserControl.resx
+++ b/src/EVEMon/SkillPlanner/EveObjectBrowserControl.resx
@@ -124,4 +124,13 @@ After selecting an item, you can compare similar items.
 To do this,  hold down your CTRL key and click the item you wish to compare. 
 You may compare several items at once.</value>
   </data>
+  <data name="this.gbDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="this.lblEveObjCategory.Text" xml:space="preserve">
+    <value>EveObject Category</value>
+  </data>
+  <data name="this.lblEveObjName.Text" xml:space="preserve">
+    <value>EveObject Name</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/EveObjectBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/EveObjectBrowserControl.zh-CN.resx
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="lblHelp.Text" xml:space="preserve">
+    <value>使用左侧的树选择要查看的项目。
+
+选择项目后，您可以比较类似的项目。
+为此，请按住 CTRL 键并单击要比较的项目。 
+您可以同时比较多个项目。</value>
+  </data>
+  <data name="this.gbDescription.Text" xml:space="preserve">
+    <value>描述</value>
+  </data>
+  <data name="this.lblEveObjCategory.Text" xml:space="preserve">
+    <value>EVE对象类别</value>
+  </data>
+  <data name="this.lblEveObjName.Text" xml:space="preserve">
+    <value>EVE对象名称</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/EveObjectSelectControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/EveObjectSelectControl.Designer.cs
@@ -85,7 +85,7 @@ namespace EVEMon.SkillPlanner
             this.lbSearchTextHint.Name = "lbSearchTextHint";
             this.lbSearchTextHint.Size = new System.Drawing.Size(65, 13);
             this.lbSearchTextHint.TabIndex = 23;
-            this.lbSearchTextHint.Text = "Search Text";
+            this.lbSearchTextHint.Text = resources.GetString("this.lbSearchTextHint.Text");
             this.lbSearchTextHint.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.lbSearchTextHint.Click += new System.EventHandler(this.lbSearchTextHint_Click);
             // 
@@ -100,7 +100,7 @@ namespace EVEMon.SkillPlanner
             this.lbNoMatches.Padding = new System.Windows.Forms.Padding(4, 30, 4, 4);
             this.lbNoMatches.Size = new System.Drawing.Size(185, 344);
             this.lbNoMatches.TabIndex = 24;
-            this.lbNoMatches.Text = "No ships match your search.";
+            this.lbNoMatches.Text = resources.GetString("this.lbNoMatches.Text");
             this.lbNoMatches.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             // 
             // lbSearchList
@@ -172,7 +172,7 @@ namespace EVEMon.SkillPlanner
             this.lblFilter.Name = "lblFilter";
             this.lblFilter.Size = new System.Drawing.Size(32, 13);
             this.lblFilter.TabIndex = 24;
-            this.lblFilter.Text = "Filter:";
+            this.lblFilter.Text = resources.GetString("this.lblFilter.Text");
             // 
             // pbSearchImage
             // 
@@ -239,41 +239,41 @@ namespace EVEMon.SkillPlanner
             this.cmiLvPlanTo.Image = ((System.Drawing.Image)(resources.GetObject("cmiLvPlanTo.Image")));
             this.cmiLvPlanTo.Name = "cmiLvPlanTo";
             this.cmiLvPlanTo.Size = new System.Drawing.Size(166, 22);
-            this.cmiLvPlanTo.Text = "&Plan Mastery to...";
+            this.cmiLvPlanTo.Text = resources.GetString("this.cmiLvPlanTo.Text");
             // 
             // tsmLevel1
             // 
             this.tsmLevel1.Name = "tsmLevel1";
             this.tsmLevel1.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel1.Text = "Level I";
+            this.tsmLevel1.Text = resources.GetString("this.tsmLevel1.Text");
             this.tsmLevel1.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel2
             // 
             this.tsmLevel2.Name = "tsmLevel2";
             this.tsmLevel2.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel2.Text = "Level II";
+            this.tsmLevel2.Text = resources.GetString("this.tsmLevel2.Text");
             this.tsmLevel2.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel3
             // 
             this.tsmLevel3.Name = "tsmLevel3";
             this.tsmLevel3.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel3.Text = "Level III";
+            this.tsmLevel3.Text = resources.GetString("this.tsmLevel3.Text");
             this.tsmLevel3.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel4
             // 
             this.tsmLevel4.Name = "tsmLevel4";
             this.tsmLevel4.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel4.Text = "Level IV";
+            this.tsmLevel4.Text = resources.GetString("this.tsmLevel4.Text");
             this.tsmLevel4.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel5
             // 
             this.tsmLevel5.Name = "tsmLevel5";
             this.tsmLevel5.Size = new System.Drawing.Size(114, 22);
-            this.tsmLevel5.Text = "Level V";
+            this.tsmLevel5.Text = resources.GetString("this.tsmLevel5.Text");
             this.tsmLevel5.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsSeparatorPlanTo
@@ -285,14 +285,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandSelected.Name = "cmiExpandSelected";
             this.cmiExpandSelected.Size = new System.Drawing.Size(166, 22);
-            this.cmiExpandSelected.Text = "Expand Selected";
+            this.cmiExpandSelected.Text = resources.GetString("this.cmiExpandSelected.Text");
             this.cmiExpandSelected.Click += new System.EventHandler(this.cmiExpandSelected_Click);
             // 
             // cmiCollapseSelected
             // 
             this.cmiCollapseSelected.Name = "cmiCollapseSelected";
             this.cmiCollapseSelected.Size = new System.Drawing.Size(166, 22);
-            this.cmiCollapseSelected.Text = "Collapse Selected";
+            this.cmiCollapseSelected.Text = resources.GetString("this.cmiCollapseSelected.Text");
             this.cmiCollapseSelected.Click += new System.EventHandler(this.cmiCollapseSelected_Click);
             // 
             // tsSeparatorExpandCollapse
@@ -304,14 +304,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandAll.Name = "cmiExpandAll";
             this.cmiExpandAll.Size = new System.Drawing.Size(166, 22);
-            this.cmiExpandAll.Text = "&Expand All";
+            this.cmiExpandAll.Text = resources.GetString("this.cmiExpandAll.Text");
             this.cmiExpandAll.Click += new System.EventHandler(this.cmiExpandAll_Click);
             // 
             // cmiCollapseAll
             // 
             this.cmiCollapseAll.Name = "cmiCollapseAll";
             this.cmiCollapseAll.Size = new System.Drawing.Size(166, 22);
-            this.cmiCollapseAll.Text = "&Collapse All";
+            this.cmiCollapseAll.Text = resources.GetString("this.cmiCollapseAll.Text");
             this.cmiCollapseAll.Click += new System.EventHandler(this.cmiCollapseAll_Click);
             // 
             // EveObjectSelectControl

--- a/src/EVEMon/SkillPlanner/EveObjectSelectControl.resx
+++ b/src/EVEMon/SkillPlanner/EveObjectSelectControl.resx
@@ -164,4 +164,43 @@
         /zy4NqBBwbAJN2VsB5Z9QU7ObwjkSucBbV0TAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>Search Text</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>No ships match your search.</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="this.cmiLvPlanTo.Text" xml:space="preserve">
+    <value>&amp;Plan Mastery to...</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>Level I</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>Level II</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>Level III</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>Level IV</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>Level V</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/EveObjectSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/EveObjectSelectControl.zh-CN.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>搜索文本</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>没有船舶符合您的搜索。</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>过滤器：</value>
+  </data>
+  <data name="this.cmiLvPlanTo.Text" xml:space="preserve">
+    <value>计划掌握...</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>一级</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>二级</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>三级</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>四级</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>Ⅴ级</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ImplantCalculatorWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ImplantCalculatorWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ItemBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ItemBrowserControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ItemSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ItemSelectControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/LoadoutImportationWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/LoadoutImportationWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.Designer.cs
@@ -80,7 +80,7 @@
             this.planToLevel.Image = ((System.Drawing.Image)(resources.GetObject("planToLevel.Image")));
             this.planToLevel.Name = "planToLevel";
             this.planToLevel.Size = new System.Drawing.Size(194, 22);
-            this.planToLevel.Text = "&Plan...";
+            this.planToLevel.Text = resources.GetString("this.planToLevel.Text");
             this.planToLevel.Click += new System.EventHandler(this.tsmAddToPlan_Click);
             // 
             // planToLevelSeparator
@@ -92,7 +92,7 @@
             // 
             this.showInBrowserMenu.Name = "showInBrowserMenu";
             this.showInBrowserMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInBrowserMenu.Text = "Show in Skill &Browser";
+            this.showInBrowserMenu.Text = resources.GetString("this.showInBrowserMenu.Text");
             this.showInBrowserMenu.Click += new System.EventHandler(this.showInBrowserMenu_Click);
             // 
             // showInExplorerMenu
@@ -100,7 +100,7 @@
             this.showInExplorerMenu.Image = ((System.Drawing.Image)(resources.GetObject("showInExplorerMenu.Image")));
             this.showInExplorerMenu.Name = "showInExplorerMenu";
             this.showInExplorerMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInExplorerMenu.Text = "Show in Skill &Explorer...";
+            this.showInExplorerMenu.Text = resources.GetString("this.showInExplorerMenu.Text");
             this.showInExplorerMenu.Click += new System.EventHandler(this.showInExplorerMenu_Click);
             // 
             // showInMenuSeparator
@@ -112,14 +112,14 @@
             // 
             this.tsmExpandSelected.Name = "tsmExpandSelected";
             this.tsmExpandSelected.Size = new System.Drawing.Size(194, 22);
-            this.tsmExpandSelected.Text = "Expand Selected";
+            this.tsmExpandSelected.Text = resources.GetString("this.tsmExpandSelected.Text");
             this.tsmExpandSelected.Click += new System.EventHandler(this.tsmExpandSelected_Click);
             // 
             // tsmCollapseSelected
             // 
             this.tsmCollapseSelected.Name = "tsmCollapseSelected";
             this.tsmCollapseSelected.Size = new System.Drawing.Size(194, 22);
-            this.tsmCollapseSelected.Text = "Collapse Selected";
+            this.tsmCollapseSelected.Text = resources.GetString("this.tsmCollapseSelected.Text");
             this.tsmCollapseSelected.Click += new System.EventHandler(this.tsmCollapseSelected_Click);
             // 
             // toggleSeparator
@@ -131,14 +131,14 @@
             // 
             this.tsmExpandAll.Name = "tsmExpandAll";
             this.tsmExpandAll.Size = new System.Drawing.Size(194, 22);
-            this.tsmExpandAll.Text = "&Expand All";
+            this.tsmExpandAll.Text = resources.GetString("this.tsmExpandAll.Text");
             this.tsmExpandAll.Click += new System.EventHandler(this.tsmExpandAll_Click);
             // 
             // tsmCollapseAll
             // 
             this.tsmCollapseAll.Name = "tsmCollapseAll";
             this.tsmCollapseAll.Size = new System.Drawing.Size(194, 22);
-            this.tsmCollapseAll.Text = "&Collapse All";
+            this.tsmCollapseAll.Text = resources.GetString("this.tsmCollapseAll.Text");
             this.tsmCollapseAll.Click += new System.EventHandler(this.tsmCollapseAll_Click);
             // 
             // imageList

--- a/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.resx
+++ b/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.resx
@@ -1379,4 +1379,25 @@
         Ab8BQgFNAT4HAAE+AwABKAMAAWADAAEwAwABAQEAAQEFAAFAAQIWAAP//wD/AEMACw==
 </value>
   </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>&amp;Plan...</value>
+  </data>
+  <data name="this.showInBrowserMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.showInExplorerMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.tsmExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.tsmCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.tsmExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.tsmCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/MasteryTreeDisplayControl.zh-CN.resx
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>计划(&amp;P)...</value>
+  </data>
+  <data name="this.showInBrowserMenu.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.showInExplorerMenu.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.tsmExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.tsmCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.tsmExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.tsmCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/NewPlanWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/NewPlanWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ObsoleteEntriesWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ObsoleteEntriesWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanEditorControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/PlanEditorControl.Designer.cs
@@ -136,14 +136,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.miChangeNote.Name = "miChangeNote";
             this.miChangeNote.Size = new System.Drawing.Size(216, 22);
-            this.miChangeNote.Text = "View/Change Note...";
+            this.miChangeNote.Text = resources.GetString("this.miChangeNote.Text");
             this.miChangeNote.Click += new System.EventHandler(this.miChangeNote_Click);
             // 
             // miChangePriority
             // 
             this.miChangePriority.Name = "miChangePriority";
             this.miChangePriority.Size = new System.Drawing.Size(216, 22);
-            this.miChangePriority.Text = "Change Priority...";
+            this.miChangePriority.Text = resources.GetString("this.miChangePriority.Text");
             this.miChangePriority.Click += new System.EventHandler(this.miChangePriority_Click);
             // 
             // miChangeLevel
@@ -158,14 +158,14 @@ namespace EVEMon.SkillPlanner
             this.miChangeLevel.Image = ((System.Drawing.Image)(resources.GetObject("miChangeLevel.Image")));
             this.miChangeLevel.Name = "miChangeLevel";
             this.miChangeLevel.Size = new System.Drawing.Size(216, 22);
-            this.miChangeLevel.Text = "Change Planned Level...";
+            this.miChangeLevel.Text = resources.GetString("this.miChangeLevel.Text");
             // 
             // miChangeTo0
             // 
             this.miChangeTo0.Name = "miChangeTo0";
             this.miChangeTo0.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo0.Tag = "0";
-            this.miChangeTo0.Text = "Remove";
+            this.miChangeTo0.Text = resources.GetString("this.miChangeTo0.Text");
             this.miChangeTo0.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // miChangeTo1
@@ -173,7 +173,7 @@ namespace EVEMon.SkillPlanner
             this.miChangeTo1.Name = "miChangeTo1";
             this.miChangeTo1.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo1.Tag = "1";
-            this.miChangeTo1.Text = "Level 1";
+            this.miChangeTo1.Text = resources.GetString("this.miChangeTo1.Text");
             this.miChangeTo1.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // miChangeTo2
@@ -181,7 +181,7 @@ namespace EVEMon.SkillPlanner
             this.miChangeTo2.Name = "miChangeTo2";
             this.miChangeTo2.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo2.Tag = "2";
-            this.miChangeTo2.Text = "Level 2";
+            this.miChangeTo2.Text = resources.GetString("this.miChangeTo2.Text");
             this.miChangeTo2.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // miChangeTo3
@@ -189,7 +189,7 @@ namespace EVEMon.SkillPlanner
             this.miChangeTo3.Name = "miChangeTo3";
             this.miChangeTo3.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo3.Tag = "3";
-            this.miChangeTo3.Text = "Level 3";
+            this.miChangeTo3.Text = resources.GetString("this.miChangeTo3.Text");
             this.miChangeTo3.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // miChangeTo4
@@ -197,7 +197,7 @@ namespace EVEMon.SkillPlanner
             this.miChangeTo4.Name = "miChangeTo4";
             this.miChangeTo4.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo4.Tag = "4";
-            this.miChangeTo4.Text = "Level 4";
+            this.miChangeTo4.Text = resources.GetString("this.miChangeTo4.Text");
             this.miChangeTo4.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // miChangeTo5
@@ -205,7 +205,7 @@ namespace EVEMon.SkillPlanner
             this.miChangeTo5.Name = "miChangeTo5";
             this.miChangeTo5.Size = new System.Drawing.Size(117, 22);
             this.miChangeTo5.Tag = "5";
-            this.miChangeTo5.Text = "Level 5";
+            this.miChangeTo5.Text = resources.GetString("this.miChangeTo5.Text");
             this.miChangeTo5.Click += new System.EventHandler(this.miChangeToLevel_Click);
             // 
             // changeMenuSeparator
@@ -217,14 +217,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.miRemoveFromPlan.Name = "miRemoveFromPlan";
             this.miRemoveFromPlan.Size = new System.Drawing.Size(216, 22);
-            this.miRemoveFromPlan.Text = "Remove from Plan";
+            this.miRemoveFromPlan.Text = resources.GetString("this.miRemoveFromPlan.Text");
             this.miRemoveFromPlan.Click += new System.EventHandler(this.miRemoveFromPlan_Click);
             // 
             // MoveToTopMenuItem
             // 
             this.MoveToTopMenuItem.Name = "MoveToTopMenuItem";
             this.MoveToTopMenuItem.Size = new System.Drawing.Size(216, 22);
-            this.MoveToTopMenuItem.Text = "Move to top of Plan";
+            this.MoveToTopMenuItem.Text = resources.GetString("this.MoveToTopMenuItem.Text");
             this.MoveToTopMenuItem.Click += new System.EventHandler(this.MoveToTopMenuItem_Click);
             // 
             // planMenuSeparator
@@ -236,7 +236,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.miShowInSkillBrowser.Name = "miShowInSkillBrowser";
             this.miShowInSkillBrowser.Size = new System.Drawing.Size(216, 22);
-            this.miShowInSkillBrowser.Text = "Show in Skill &Browser";
+            this.miShowInSkillBrowser.Text = resources.GetString("this.miShowInSkillBrowser.Text");
             this.miShowInSkillBrowser.Click += new System.EventHandler(this.miShowInSkillBrowser_Click);
             // 
             // miShowInSkillExplorer
@@ -244,7 +244,7 @@ namespace EVEMon.SkillPlanner
             this.miShowInSkillExplorer.Image = ((System.Drawing.Image)(resources.GetObject("miShowInSkillExplorer.Image")));
             this.miShowInSkillExplorer.Name = "miShowInSkillExplorer";
             this.miShowInSkillExplorer.Size = new System.Drawing.Size(216, 22);
-            this.miShowInSkillExplorer.Text = "Show in Skill &Explorer...";
+            this.miShowInSkillExplorer.Text = resources.GetString("this.miShowInSkillExplorer.Text");
             this.miShowInSkillExplorer.Click += new System.EventHandler(this.miShowInSkillExplorer_Click);
             // 
             // showInMenuSeparator
@@ -256,7 +256,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.miMarkOwned.Name = "miMarkOwned";
             this.miMarkOwned.Size = new System.Drawing.Size(216, 22);
-            this.miMarkOwned.Text = "Mark as Owned";
+            this.miMarkOwned.Text = resources.GetString("this.miMarkOwned.Text");
             this.miMarkOwned.Click += new System.EventHandler(this.miMarkOwned_Click);
             // 
             // markOwnedMenuSeaprator
@@ -271,20 +271,20 @@ namespace EVEMon.SkillPlanner
             this.miCopySelectedToClipboard});
             this.miCopyTo.Name = "miCopyTo";
             this.miCopyTo.Size = new System.Drawing.Size(216, 22);
-            this.miCopyTo.Text = "Copy selected entries to";
+            this.miCopyTo.Text = resources.GetString("this.miCopyTo.Text");
             // 
             // miCopyToNewPlan
             // 
             this.miCopyToNewPlan.Name = "miCopyToNewPlan";
             this.miCopyToNewPlan.Size = new System.Drawing.Size(152, 22);
-            this.miCopyToNewPlan.Text = "New Plan...";
+            this.miCopyToNewPlan.Text = resources.GetString("this.miCopyToNewPlan.Text");
             this.miCopyToNewPlan.Click += new System.EventHandler(this.miCopyToNewPlan_Click);
             // 
             // miCopySelectedToClipboard
             // 
             this.miCopySelectedToClipboard.Name = "miCopySelectedToClipboard";
             this.miCopySelectedToClipboard.Size = new System.Drawing.Size(152, 22);
-            this.miCopySelectedToClipboard.Text = "Clipboard...";
+            this.miCopySelectedToClipboard.Text = resources.GetString("this.miCopySelectedToClipboard.Text");
             this.miCopySelectedToClipboard.Click += new System.EventHandler(this.miCopySelectedToClipboard_Click);
             // 
             // copyMenuSeparator
@@ -296,13 +296,13 @@ namespace EVEMon.SkillPlanner
             // 
             this.miPlanGroups.Name = "miPlanGroups";
             this.miPlanGroups.Size = new System.Drawing.Size(216, 22);
-            this.miPlanGroups.Text = "Select entries from group...";
+            this.miPlanGroups.Text = resources.GetString("this.miPlanGroups.Text");
             // 
             // sfdSave
             // 
             this.sfdSave.Filter = "EVEMon Plan Format (*.emp)|*.emp|XML Format (*.xml)|*.xml|Text Format (*.txt)|*.t" +
     "xt";
-            this.sfdSave.Title = "Save Plan As...";
+            this.sfdSave.Title = resources.GetString("this.sfdSave.Title");
             // 
             // tmrAutoRefresh
             // 
@@ -329,13 +329,13 @@ namespace EVEMon.SkillPlanner
             this.tsPlan.Name = "tsPlan";
             this.tsPlan.Size = new System.Drawing.Size(41, 558);
             this.tsPlan.TabIndex = 0;
-            this.tsPlan.Text = "planToolStrip";
+            this.tsPlan.Text = resources.GetString("this.tsPlan.Text");
             // 
             // tslMove
             // 
             this.tslMove.Name = "tslMove";
             this.tslMove.Size = new System.Drawing.Size(38, 15);
-            this.tslMove.Text = "Move:";
+            this.tslMove.Text = resources.GetString("this.tslMove.Text");
             // 
             // tsbMoveUp
             // 
@@ -345,7 +345,7 @@ namespace EVEMon.SkillPlanner
             this.tsbMoveUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveUp.Name = "tsbMoveUp";
             this.tsbMoveUp.Size = new System.Drawing.Size(38, 20);
-            this.tsbMoveUp.Text = "Move up";
+            this.tsbMoveUp.Text = resources.GetString("this.tsbMoveUp.Text");
             this.tsbMoveUp.Click += new System.EventHandler(this.tsbMoveUp_Click);
             // 
             // tsbMoveDown
@@ -356,7 +356,7 @@ namespace EVEMon.SkillPlanner
             this.tsbMoveDown.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveDown.Name = "tsbMoveDown";
             this.tsbMoveDown.Size = new System.Drawing.Size(38, 20);
-            this.tsbMoveDown.Text = "Move down";
+            this.tsbMoveDown.Text = resources.GetString("this.tsbMoveDown.Text");
             this.tsbMoveDown.Click += new System.EventHandler(this.tsbMoveDown_Click);
             // 
             // toolStripSeparator1
@@ -369,7 +369,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.tslSort.Name = "tslSort";
             this.tslSort.Size = new System.Drawing.Size(38, 15);
-            this.tslSort.Text = "Sort:";
+            this.tslSort.Text = resources.GetString("this.tslSort.Text");
             // 
             // tsSortPriorities
             // 
@@ -379,7 +379,7 @@ namespace EVEMon.SkillPlanner
             this.tsSortPriorities.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsSortPriorities.Name = "tsSortPriorities";
             this.tsSortPriorities.Size = new System.Drawing.Size(38, 20);
-            this.tsSortPriorities.Text = "Group by priorities (Ascending only)";
+            this.tsSortPriorities.Text = resources.GetString("this.tsSortPriorities.Text");
             // 
             // toolStripSeparator4
             // 
@@ -393,8 +393,8 @@ namespace EVEMon.SkillPlanner
             this.tsbToggleSkills.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbToggleSkills.Name = "tsbToggleSkills";
             this.tsbToggleSkills.Size = new System.Drawing.Size(38, 20);
-            this.tsbToggleSkills.Text = "Toggle skills";
-            this.tsbToggleSkills.ToolTipText = "Toggle skill pane";
+            this.tsbToggleSkills.Text = resources.GetString("this.tsbToggleSkills.Text");
+            this.tsbToggleSkills.ToolTipText = resources.GetString("this.tsbToggleSkills.ToolTipText");
             this.tsbToggleSkills.Click += new System.EventHandler(this.toggleSkillsPanelButton_Click);
             // 
             // tsbToggleRemapping
@@ -404,8 +404,8 @@ namespace EVEMon.SkillPlanner
             this.tsbToggleRemapping.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbToggleRemapping.Name = "tsbToggleRemapping";
             this.tsbToggleRemapping.Size = new System.Drawing.Size(38, 20);
-            this.tsbToggleRemapping.Text = "Toggle remapping";
-            this.tsbToggleRemapping.ToolTipText = "Toggle remapping point (F9)";
+            this.tsbToggleRemapping.Text = resources.GetString("this.tsbToggleRemapping.Text");
+            this.tsbToggleRemapping.ToolTipText = resources.GetString("this.tsbToggleRemapping.ToolTipText");
             this.tsbToggleRemapping.Click += new System.EventHandler(this.tsbToggleRemapping_Click);
             // 
             // tssColorKey
@@ -420,8 +420,8 @@ namespace EVEMon.SkillPlanner
             this.tsbColorKey.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbColorKey.Name = "tsbColorKey";
             this.tsbColorKey.Size = new System.Drawing.Size(38, 20);
-            this.tsbColorKey.Text = "Toggle Color Key Panel";
-            this.tsbColorKey.ToolTipText = "Toggle Color Key Panel";
+            this.tsbColorKey.Text = resources.GetString("this.tsbColorKey.Text");
+            this.tsbColorKey.ToolTipText = resources.GetString("this.tsbColorKey.ToolTipText");
             this.tsbColorKey.Click += new System.EventHandler(this.tsbColorKey_Click);
             // 
             // ilIcons
@@ -459,7 +459,7 @@ namespace EVEMon.SkillPlanner
             this.gbColorKey.Size = new System.Drawing.Size(719, 38);
             this.gbColorKey.TabIndex = 0;
             this.gbColorKey.TabStop = false;
-            this.gbColorKey.Text = "Color Keys";
+            this.gbColorKey.Text = resources.GetString("this.gbColorKey.Text");
             // 
             // flpColorKey
             // 
@@ -492,7 +492,7 @@ namespace EVEMon.SkillPlanner
             this.lblTrainable.Name = "lblTrainable";
             this.lblTrainable.Size = new System.Drawing.Size(53, 15);
             this.lblTrainable.TabIndex = 37;
-            this.lblTrainable.Text = "Trainable";
+            this.lblTrainable.Text = resources.GetString("this.lblTrainable.Text");
             this.lblTrainable.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblNonPublic
@@ -505,7 +505,7 @@ namespace EVEMon.SkillPlanner
             this.lblNonPublic.Name = "lblNonPublic";
             this.lblNonPublic.Size = new System.Drawing.Size(61, 15);
             this.lblNonPublic.TabIndex = 35;
-            this.lblNonPublic.Text = "Non Public";
+            this.lblNonPublic.Text = resources.GetString("this.lblNonPublic.Text");
             this.lblNonPublic.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblPrereqNotMet
@@ -518,7 +518,7 @@ namespace EVEMon.SkillPlanner
             this.lblPrereqNotMet.Name = "lblPrereqNotMet";
             this.lblPrereqNotMet.Size = new System.Drawing.Size(81, 15);
             this.lblPrereqNotMet.TabIndex = 29;
-            this.lblPrereqNotMet.Text = "Prereq Not Met";
+            this.lblPrereqNotMet.Text = resources.GetString("this.lblPrereqNotMet.Text");
             this.lblPrereqNotMet.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblDepended
@@ -531,7 +531,7 @@ namespace EVEMon.SkillPlanner
             this.lblDepended.Name = "lblDepended";
             this.lblDepended.Size = new System.Drawing.Size(59, 15);
             this.lblDepended.TabIndex = 30;
-            this.lblDepended.Text = "Depended";
+            this.lblDepended.Text = resources.GetString("this.lblDepended.Text");
             this.lblDepended.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblQueued
@@ -544,7 +544,7 @@ namespace EVEMon.SkillPlanner
             this.lblQueued.Name = "lblQueued";
             this.lblQueued.Size = new System.Drawing.Size(47, 15);
             this.lblQueued.TabIndex = 32;
-            this.lblQueued.Text = "Queued";
+            this.lblQueued.Text = resources.GetString("this.lblQueued.Text");
             this.lblQueued.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblPrereqMetNotKnown
@@ -557,7 +557,7 @@ namespace EVEMon.SkillPlanner
             this.lblPrereqMetNotKnown.Name = "lblPrereqMetNotKnown";
             this.lblPrereqMetNotKnown.Size = new System.Drawing.Size(123, 15);
             this.lblPrereqMetNotKnown.TabIndex = 36;
-            this.lblPrereqMetNotKnown.Text = "Prereq Met - Not Known";
+            this.lblPrereqMetNotKnown.Text = resources.GetString("this.lblPrereqMetNotKnown.Text");
             this.lblPrereqMetNotKnown.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblDowntime
@@ -571,7 +571,7 @@ namespace EVEMon.SkillPlanner
             this.lblDowntime.Name = "lblDowntime";
             this.lblDowntime.Size = new System.Drawing.Size(56, 15);
             this.lblDowntime.TabIndex = 33;
-            this.lblDowntime.Text = "Downtime";
+            this.lblDowntime.Text = resources.GetString("this.lblDowntime.Text");
             this.lblDowntime.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblCurrentlyTraining
@@ -585,7 +585,7 @@ namespace EVEMon.SkillPlanner
             this.lblCurrentlyTraining.Name = "lblCurrentlyTraining";
             this.lblCurrentlyTraining.Size = new System.Drawing.Size(91, 15);
             this.lblCurrentlyTraining.TabIndex = 34;
-            this.lblCurrentlyTraining.Text = "Currently Training";
+            this.lblCurrentlyTraining.Text = resources.GetString("this.lblCurrentlyTraining.Text");
             this.lblCurrentlyTraining.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblPartiallyTrained
@@ -598,7 +598,7 @@ namespace EVEMon.SkillPlanner
             this.lblPartiallyTrained.Name = "lblPartiallyTrained";
             this.lblPartiallyTrained.Size = new System.Drawing.Size(84, 15);
             this.lblPartiallyTrained.TabIndex = 31;
-            this.lblPartiallyTrained.Text = "Partially Trained";
+            this.lblPartiallyTrained.Text = resources.GetString("this.lblPartiallyTrained.Text");
             this.lblPartiallyTrained.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // lblOmegaOnly
@@ -610,7 +610,7 @@ namespace EVEMon.SkillPlanner
             this.lblOmegaOnly.Margin = new System.Windows.Forms.Padding(0, 0, 4, 0);
             this.lblOmegaOnly.Name = "lblOmegaOnly";
             this.lblOmegaOnly.TabIndex = 38;
-            this.lblOmegaOnly.Text = "Requires Omega";
+            this.lblOmegaOnly.Text = resources.GetString("this.lblOmegaOnly.Text");
             this.lblOmegaOnly.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // pscPlan
@@ -696,7 +696,7 @@ namespace EVEMon.SkillPlanner
             this.lblChooseImplantSet.Name = "lblChooseImplantSet";
             this.lblChooseImplantSet.Size = new System.Drawing.Size(102, 13);
             this.lblChooseImplantSet.TabIndex = 1;
-            this.lblChooseImplantSet.Text = "Choose Implant Set:";
+            this.lblChooseImplantSet.Text = resources.GetString("this.lblChooseImplantSet.Text");
             // 
             // cbChooseImplantSet
             // 
@@ -721,7 +721,7 @@ namespace EVEMon.SkillPlanner
             this.tsPreferences.Name = "tsPreferences";
             this.tsPreferences.Size = new System.Drawing.Size(33, 33);
             this.tsPreferences.TabIndex = 3;
-            this.tsPreferences.Text = "tsPreferences";
+            this.tsPreferences.Text = resources.GetString("this.tsPreferences.Text");
             // 
             // preferencesMenu
             // 
@@ -734,21 +734,21 @@ namespace EVEMon.SkillPlanner
             this.preferencesMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.preferencesMenu.Name = "preferencesMenu";
             this.preferencesMenu.Size = new System.Drawing.Size(29, 30);
-            this.preferencesMenu.Text = "Preferences";
-            this.preferencesMenu.ToolTipText = "Preferences";
+            this.preferencesMenu.Text = resources.GetString("this.preferencesMenu.Text");
+            this.preferencesMenu.ToolTipText = resources.GetString("this.preferencesMenu.ToolTipText");
             // 
             // columnSettingsMenuItem
             // 
             this.columnSettingsMenuItem.Name = "columnSettingsMenuItem";
             this.columnSettingsMenuItem.Size = new System.Drawing.Size(176, 22);
-            this.columnSettingsMenuItem.Text = "Column Settings";
+            this.columnSettingsMenuItem.Text = resources.GetString("this.columnSettingsMenuItem.Text");
             this.columnSettingsMenuItem.Click += new System.EventHandler(this.columnSettingsMenuItem_Click);
             // 
             // autoSizeColumnsMenuItem
             // 
             this.autoSizeColumnsMenuItem.Name = "autoSizeColumnsMenuItem";
             this.autoSizeColumnsMenuItem.Size = new System.Drawing.Size(176, 22);
-            this.autoSizeColumnsMenuItem.Text = "Auto-Size Columns";
+            this.autoSizeColumnsMenuItem.Text = resources.GetString("this.autoSizeColumnsMenuItem.Text");
             this.autoSizeColumnsMenuItem.Click += new System.EventHandler(this.autoSizeColumnsMenuItem_Click);
             // 
             // skillSelectControl

--- a/src/EVEMon/SkillPlanner/PlanEditorControl.resx
+++ b/src/EVEMon/SkillPlanner/PlanEditorControl.resx
@@ -318,4 +318,148 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>83</value>
   </metadata>
+  <data name="this.miChangeNote.Text" xml:space="preserve">
+    <value>View/Change Note...</value>
+  </data>
+  <data name="this.miChangePriority.Text" xml:space="preserve">
+    <value>Change Priority...</value>
+  </data>
+  <data name="this.miChangeLevel.Text" xml:space="preserve">
+    <value>Change Planned Level...</value>
+  </data>
+  <data name="this.miChangeTo0.Text" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="this.miChangeTo1.Text" xml:space="preserve">
+    <value>Level 1</value>
+  </data>
+  <data name="this.miChangeTo2.Text" xml:space="preserve">
+    <value>Level 2</value>
+  </data>
+  <data name="this.miChangeTo3.Text" xml:space="preserve">
+    <value>Level 3</value>
+  </data>
+  <data name="this.miChangeTo4.Text" xml:space="preserve">
+    <value>Level 4</value>
+  </data>
+  <data name="this.miChangeTo5.Text" xml:space="preserve">
+    <value>Level 5</value>
+  </data>
+  <data name="this.miRemoveFromPlan.Text" xml:space="preserve">
+    <value>Remove from Plan</value>
+  </data>
+  <data name="this.MoveToTopMenuItem.Text" xml:space="preserve">
+    <value>Move to top of Plan</value>
+  </data>
+  <data name="this.miShowInSkillBrowser.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.miShowInSkillExplorer.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.miMarkOwned.Text" xml:space="preserve">
+    <value>Mark as Owned</value>
+  </data>
+  <data name="this.miCopyTo.Text" xml:space="preserve">
+    <value>Copy selected entries to</value>
+  </data>
+  <data name="this.miCopyToNewPlan.Text" xml:space="preserve">
+    <value>New Plan...</value>
+  </data>
+  <data name="this.miCopySelectedToClipboard.Text" xml:space="preserve">
+    <value>Clipboard...</value>
+  </data>
+  <data name="this.miPlanGroups.Text" xml:space="preserve">
+    <value>Select entries from group...</value>
+  </data>
+  <data name="this.sfdSave.Title" xml:space="preserve">
+    <value>Save Plan As...</value>
+  </data>
+  <data name="this.tsPlan.Text" xml:space="preserve">
+    <value>planToolStrip</value>
+  </data>
+  <data name="this.tslMove.Text" xml:space="preserve">
+    <value>Move:</value>
+  </data>
+  <data name="this.tsbMoveUp.Text" xml:space="preserve">
+    <value>Move up</value>
+  </data>
+  <data name="this.tsbMoveDown.Text" xml:space="preserve">
+    <value>Move down</value>
+  </data>
+  <data name="this.tslSort.Text" xml:space="preserve">
+    <value>Sort:</value>
+  </data>
+  <data name="this.tsSortPriorities.Text" xml:space="preserve">
+    <value>Group by priorities (Ascending only)</value>
+  </data>
+  <data name="this.tsbToggleSkills.Text" xml:space="preserve">
+    <value>Toggle skills</value>
+  </data>
+  <data name="this.tsbToggleSkills.ToolTipText" xml:space="preserve">
+    <value>Toggle skill pane</value>
+  </data>
+  <data name="this.tsbToggleRemapping.Text" xml:space="preserve">
+    <value>Toggle remapping</value>
+  </data>
+  <data name="this.tsbToggleRemapping.ToolTipText" xml:space="preserve">
+    <value>Toggle remapping point (F9)</value>
+  </data>
+  <data name="this.tsbColorKey.Text" xml:space="preserve">
+    <value>Toggle Color Key Panel</value>
+  </data>
+  <data name="this.tsbColorKey.ToolTipText" xml:space="preserve">
+    <value>Toggle Color Key Panel</value>
+  </data>
+  <data name="this.gbColorKey.Text" xml:space="preserve">
+    <value>Color Keys</value>
+  </data>
+  <data name="this.lblTrainable.Text" xml:space="preserve">
+    <value>Trainable</value>
+  </data>
+  <data name="this.lblNonPublic.Text" xml:space="preserve">
+    <value>Non Public</value>
+  </data>
+  <data name="this.lblPrereqNotMet.Text" xml:space="preserve">
+    <value>Prereq Not Met</value>
+  </data>
+  <data name="this.lblDepended.Text" xml:space="preserve">
+    <value>Depended</value>
+  </data>
+  <data name="this.lblQueued.Text" xml:space="preserve">
+    <value>Queued</value>
+  </data>
+  <data name="this.lblPrereqMetNotKnown.Text" xml:space="preserve">
+    <value>Prereq Met - Not Known</value>
+  </data>
+  <data name="this.lblDowntime.Text" xml:space="preserve">
+    <value>Downtime</value>
+  </data>
+  <data name="this.lblCurrentlyTraining.Text" xml:space="preserve">
+    <value>Currently Training</value>
+  </data>
+  <data name="this.lblPartiallyTrained.Text" xml:space="preserve">
+    <value>Partially Trained</value>
+  </data>
+  <data name="this.lblOmegaOnly.Text" xml:space="preserve">
+    <value>Requires Omega</value>
+  </data>
+  <data name="this.lblChooseImplantSet.Text" xml:space="preserve">
+    <value>Choose Implant Set:</value>
+  </data>
+  <data name="this.tsPreferences.Text" xml:space="preserve">
+    <value>tsPreferences</value>
+  </data>
+  <data name="this.preferencesMenu.Text" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="this.preferencesMenu.ToolTipText" xml:space="preserve">
+    <value>Preferences</value>
+  </data>
+  <data name="this.columnSettingsMenuItem.Text" xml:space="preserve">
+    <value>Column Settings</value>
+  </data>
+  <data name="this.autoSizeColumnsMenuItem.Text" xml:space="preserve">
+    <value>Auto-Size Columns</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/PlanEditorControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanEditorControl.zh-CN.resx
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.miChangeNote.Text" xml:space="preserve">
+    <value>查看/更改注释...</value>
+  </data>
+  <data name="this.miChangePriority.Text" xml:space="preserve">
+    <value>更改优先级...</value>
+  </data>
+  <data name="this.miChangeLevel.Text" xml:space="preserve">
+    <value>更改计划级别...</value>
+  </data>
+  <data name="this.miChangeTo0.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="this.miChangeTo1.Text" xml:space="preserve">
+    <value>1级</value>
+  </data>
+  <data name="this.miChangeTo2.Text" xml:space="preserve">
+    <value>2级</value>
+  </data>
+  <data name="this.miChangeTo3.Text" xml:space="preserve">
+    <value>3级</value>
+  </data>
+  <data name="this.miChangeTo4.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.miChangeTo5.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.miRemoveFromPlan.Text" xml:space="preserve">
+    <value>从计划中删除</value>
+  </data>
+  <data name="this.MoveToTopMenuItem.Text" xml:space="preserve">
+    <value>移至计划顶部</value>
+  </data>
+  <data name="this.miShowInSkillBrowser.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.miShowInSkillExplorer.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.miMarkOwned.Text" xml:space="preserve">
+    <value>标记为已拥有</value>
+  </data>
+  <data name="this.miCopyTo.Text" xml:space="preserve">
+    <value>将选定的条目复制到</value>
+  </data>
+  <data name="this.miCopyToNewPlan.Text" xml:space="preserve">
+    <value>新计划...</value>
+  </data>
+  <data name="this.miCopySelectedToClipboard.Text" xml:space="preserve">
+    <value>剪贴板...</value>
+  </data>
+  <data name="this.miPlanGroups.Text" xml:space="preserve">
+    <value>从组中选择条目...</value>
+  </data>
+  <data name="this.sfdSave.Title" xml:space="preserve">
+    <value>将计划另存为...</value>
+  </data>
+  <data name="this.tsPlan.Text" xml:space="preserve">
+    <value>计划工具条</value>
+  </data>
+  <data name="this.tslMove.Text" xml:space="preserve">
+    <value>移动：</value>
+  </data>
+  <data name="this.tsbMoveUp.Text" xml:space="preserve">
+    <value>向上移动</value>
+  </data>
+  <data name="this.tsbMoveDown.Text" xml:space="preserve">
+    <value>下移</value>
+  </data>
+  <data name="this.tslSort.Text" xml:space="preserve">
+    <value>排序：</value>
+  </data>
+  <data name="this.tsSortPriorities.Text" xml:space="preserve">
+    <value>按优先级分组（仅升序）</value>
+  </data>
+  <data name="this.tsbToggleSkills.Text" xml:space="preserve">
+    <value>切换技能</value>
+  </data>
+  <data name="this.tsbToggleSkills.ToolTipText" xml:space="preserve">
+    <value>切换技能面板</value>
+  </data>
+  <data name="this.tsbToggleRemapping.Text" xml:space="preserve">
+    <value>切换重新映射</value>
+  </data>
+  <data name="this.tsbToggleRemapping.ToolTipText" xml:space="preserve">
+    <value>切换重新映射点 (F9)</value>
+  </data>
+  <data name="this.tsbColorKey.Text" xml:space="preserve">
+    <value>切换颜色键面板</value>
+  </data>
+  <data name="this.tsbColorKey.ToolTipText" xml:space="preserve">
+    <value>切换颜色键面板</value>
+  </data>
+  <data name="this.gbColorKey.Text" xml:space="preserve">
+    <value>颜色键</value>
+  </data>
+  <data name="this.lblTrainable.Text" xml:space="preserve">
+    <value>可训练</value>
+  </data>
+  <data name="this.lblNonPublic.Text" xml:space="preserve">
+    <value>非公开</value>
+  </data>
+  <data name="this.lblPrereqNotMet.Text" xml:space="preserve">
+    <value>未满足先决条件</value>
+  </data>
+  <data name="this.lblDepended.Text" xml:space="preserve">
+    <value>依赖</value>
+  </data>
+  <data name="this.lblQueued.Text" xml:space="preserve">
+    <value>排队</value>
+  </data>
+  <data name="this.lblPrereqMetNotKnown.Text" xml:space="preserve">
+    <value>满足先决条件 - 未知</value>
+  </data>
+  <data name="this.lblDowntime.Text" xml:space="preserve">
+    <value>停机时间</value>
+  </data>
+  <data name="this.lblCurrentlyTraining.Text" xml:space="preserve">
+    <value>目前正在训练</value>
+  </data>
+  <data name="this.lblPartiallyTrained.Text" xml:space="preserve">
+    <value>部分训练</value>
+  </data>
+  <data name="this.lblOmegaOnly.Text" xml:space="preserve">
+    <value>需要欧米茄</value>
+  </data>
+  <data name="this.lblChooseImplantSet.Text" xml:space="preserve">
+    <value>选择种植体套件：</value>
+  </data>
+  <data name="this.tsPreferences.Text" xml:space="preserve">
+    <value>ts首选项</value>
+  </data>
+  <data name="this.preferencesMenu.Text" xml:space="preserve">
+    <value>偏好设置</value>
+  </data>
+  <data name="this.preferencesMenu.ToolTipText" xml:space="preserve">
+    <value>偏好设置</value>
+  </data>
+  <data name="this.columnSettingsMenuItem.Text" xml:space="preserve">
+    <value>列设置</value>
+  </data>
+  <data name="this.autoSizeColumnsMenuItem.Text" xml:space="preserve">
+    <value>自动调整列大小</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanImportationFromCharacterWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanImportationFromCharacterWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanManagementWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/PlanManagementWindow.Designer.cs
@@ -84,7 +84,7 @@ namespace EVEMon.SkillPlanner
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(236, 13);
             this.label1.TabIndex = 1;
-            this.label1.Text = "Select a plan to open, or multiple plans to merge:";
+            this.label1.Text = resources.GetString("this.label1.Text");
             // 
             // btnClose
             // 
@@ -94,14 +94,14 @@ namespace EVEMon.SkillPlanner
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(75, 23);
             this.btnClose.TabIndex = 3;
-            this.btnClose.Text = "Close";
+            this.btnClose.Text = resources.GetString("this.btnClose.Text");
             this.btnClose.UseVisualStyleBackColor = true;
             this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
             // 
             // ofdOpenDialog
             // 
-            this.ofdOpenDialog.Filter = "Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*";
-            this.ofdOpenDialog.Title = "Open Plan File";
+            this.ofdOpenDialog.Filter = resources.GetString("this.ofdOpenDialog.Filter");
+            this.ofdOpenDialog.Title = resources.GetString("this.ofdOpenDialog.Title");
             // 
             // panel1
             // 
@@ -144,21 +144,21 @@ namespace EVEMon.SkillPlanner
             // 
             // PlanName
             // 
-            this.PlanName.Text = "Plan Name";
+            this.PlanName.Text = resources.GetString("this.PlanName.Text");
             this.PlanName.Width = 176;
             // 
             // PlanDate
             // 
-            this.PlanDate.Text = "Completion Time";
+            this.PlanDate.Text = resources.GetString("this.PlanDate.Text");
             this.PlanDate.Width = 197;
             // 
             // PlanSkills
             // 
-            this.PlanSkills.Text = "Skills";
+            this.PlanSkills.Text = resources.GetString("this.PlanSkills.Text");
             // 
             // PlanDescription
             // 
-            this.PlanDescription.Text = "Description";
+            this.PlanDescription.Text = resources.GetString("this.PlanDescription.Text");
             this.PlanDescription.Width = 170;
             // 
             // contextMenu
@@ -178,7 +178,7 @@ namespace EVEMon.SkillPlanner
             this.cmiOpen.Image = ((System.Drawing.Image)(resources.GetObject("cmiOpen.Image")));
             this.cmiOpen.Name = "cmiOpen";
             this.cmiOpen.Size = new System.Drawing.Size(126, 22);
-            this.cmiOpen.Text = "Open...";
+            this.cmiOpen.Text = resources.GetString("this.cmiOpen.Text");
             this.cmiOpen.Click += new System.EventHandler(this.btnOpen_Click);
             // 
             // cmiExport
@@ -186,7 +186,7 @@ namespace EVEMon.SkillPlanner
             this.cmiExport.Image = ((System.Drawing.Image)(resources.GetObject("cmiExport.Image")));
             this.cmiExport.Name = "cmiExport";
             this.cmiExport.Size = new System.Drawing.Size(126, 22);
-            this.cmiExport.Text = "Export...";
+            this.cmiExport.Text = resources.GetString("this.cmiExport.Text");
             this.cmiExport.Click += new System.EventHandler(this.miExportPlan_Click);
             // 
             // toolStripSeparator
@@ -199,7 +199,7 @@ namespace EVEMon.SkillPlanner
             this.cmiRenameEdit.Image = ((System.Drawing.Image)(resources.GetObject("cmiRenameEdit.Image")));
             this.cmiRenameEdit.Name = "cmiRenameEdit";
             this.cmiRenameEdit.Size = new System.Drawing.Size(126, 22);
-            this.cmiRenameEdit.Text = "Rename...";
+            this.cmiRenameEdit.Text = resources.GetString("this.cmiRenameEdit.Text");
             this.cmiRenameEdit.Click += new System.EventHandler(this.miRenameEdit_Click);
             // 
             // cmiDelete
@@ -207,7 +207,7 @@ namespace EVEMon.SkillPlanner
             this.cmiDelete.Image = ((System.Drawing.Image)(resources.GetObject("cmiDelete.Image")));
             this.cmiDelete.Name = "cmiDelete";
             this.cmiDelete.Size = new System.Drawing.Size(126, 22);
-            this.cmiDelete.Text = "Delete";
+            this.cmiDelete.Text = resources.GetString("this.cmiDelete.Text");
             this.cmiDelete.Click += new System.EventHandler(this.miDelete_Click);
             // 
             // toolStrip
@@ -222,13 +222,13 @@ namespace EVEMon.SkillPlanner
             this.toolStrip.Name = "toolStrip";
             this.toolStrip.Size = new System.Drawing.Size(41, 327);
             this.toolStrip.TabIndex = 0;
-            this.toolStrip.Text = "toolStrip";
+            this.toolStrip.Text = resources.GetString("this.toolStrip.Text");
             // 
             // toolStripLabel1
             // 
             this.toolStripLabel1.Name = "toolStripLabel1";
             this.toolStripLabel1.Size = new System.Drawing.Size(38, 15);
-            this.toolStripLabel1.Text = "Move:";
+            this.toolStripLabel1.Text = resources.GetString("this.toolStripLabel1.Text");
             // 
             // tsbMoveUp
             // 
@@ -238,7 +238,7 @@ namespace EVEMon.SkillPlanner
             this.tsbMoveUp.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveUp.Name = "tsbMoveUp";
             this.tsbMoveUp.Size = new System.Drawing.Size(38, 20);
-            this.tsbMoveUp.Text = "Move Up";
+            this.tsbMoveUp.Text = resources.GetString("this.tsbMoveUp.Text");
             this.tsbMoveUp.Click += new System.EventHandler(this.tsbMoveUp_Click);
             // 
             // tsbMoveDown
@@ -249,7 +249,7 @@ namespace EVEMon.SkillPlanner
             this.tsbMoveDown.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbMoveDown.Name = "tsbMoveDown";
             this.tsbMoveDown.Size = new System.Drawing.Size(38, 20);
-            this.tsbMoveDown.Text = "Move Down";
+            this.tsbMoveDown.Text = resources.GetString("this.tsbMoveDown.Text");
             this.tsbMoveDown.Click += new System.EventHandler(this.tsbMoveDown_Click);
             // 
             // tableLayoutPanel
@@ -297,7 +297,7 @@ namespace EVEMon.SkillPlanner
             this.btnOpen.Name = "btnOpen";
             this.btnOpen.Size = new System.Drawing.Size(75, 23);
             this.btnOpen.TabIndex = 4;
-            this.btnOpen.Text = "Open";
+            this.btnOpen.Text = resources.GetString("this.btnOpen.Text");
             this.btnOpen.UseVisualStyleBackColor = true;
             this.btnOpen.Click += new System.EventHandler(this.btnOpen_Click);
             // 
@@ -311,7 +311,7 @@ namespace EVEMon.SkillPlanner
             this.menuStrip.Padding = new System.Windows.Forms.Padding(4, 2, 0, 2);
             this.menuStrip.Size = new System.Drawing.Size(659, 24);
             this.menuStrip.TabIndex = 9;
-            this.menuStrip.Text = "menuBar";
+            this.menuStrip.Text = resources.GetString("this.menuStrip.Text");
             // 
             // mFile
             // 
@@ -328,7 +328,7 @@ namespace EVEMon.SkillPlanner
             this.miSavePlans});
             this.mFile.Name = "mFile";
             this.mFile.Size = new System.Drawing.Size(37, 20);
-            this.mFile.Text = "&File";
+            this.mFile.Text = resources.GetString("this.mFile.Text");
             this.mFile.DropDownOpening += new System.EventHandler(this.mFile_DropDownOpening);
             // 
             // miNewPlan
@@ -336,7 +336,7 @@ namespace EVEMon.SkillPlanner
             this.miNewPlan.Image = ((System.Drawing.Image)(resources.GetObject("miNewPlan.Image")));
             this.miNewPlan.Name = "miNewPlan";
             this.miNewPlan.Size = new System.Drawing.Size(239, 22);
-            this.miNewPlan.Text = "&New Plan…";
+            this.miNewPlan.Text = resources.GetString("this.miNewPlan.Text");
             this.miNewPlan.Click += new System.EventHandler(this.miNewPlan_Click);
             // 
             // NewPlanToolStripSeparator
@@ -349,7 +349,7 @@ namespace EVEMon.SkillPlanner
             this.miImportPlanFromFile.Image = ((System.Drawing.Image)(resources.GetObject("miImportPlanFromFile.Image")));
             this.miImportPlanFromFile.Name = "miImportPlanFromFile";
             this.miImportPlanFromFile.Size = new System.Drawing.Size(239, 22);
-            this.miImportPlanFromFile.Text = "&Import Plan from File…";
+            this.miImportPlanFromFile.Text = resources.GetString("this.miImportPlanFromFile.Text");
             this.miImportPlanFromFile.Click += new System.EventHandler(this.miImportPlanFromFile_Click);
             // 
             // miImportPlanFromCharacter
@@ -357,7 +357,7 @@ namespace EVEMon.SkillPlanner
             this.miImportPlanFromCharacter.Image = ((System.Drawing.Image)(resources.GetObject("miImportPlanFromCharacter.Image")));
             this.miImportPlanFromCharacter.Name = "miImportPlanFromCharacter";
             this.miImportPlanFromCharacter.Size = new System.Drawing.Size(239, 22);
-            this.miImportPlanFromCharacter.Text = "Import Plan from &Character…";
+            this.miImportPlanFromCharacter.Text = resources.GetString("this.miImportPlanFromCharacter.Text");
             this.miImportPlanFromCharacter.Click += new System.EventHandler(this.miImportPlanFromCharacter_Click);
             // 
             // ImportExportPlanToolStripSeparator
@@ -370,7 +370,7 @@ namespace EVEMon.SkillPlanner
             this.miExportPlan.Image = ((System.Drawing.Image)(resources.GetObject("miExportPlan.Image")));
             this.miExportPlan.Name = "miExportPlan";
             this.miExportPlan.Size = new System.Drawing.Size(239, 22);
-            this.miExportPlan.Text = "&Export Plan...";
+            this.miExportPlan.Text = resources.GetString("this.miExportPlan.Text");
             this.miExportPlan.Click += new System.EventHandler(this.miExportPlan_Click);
             // 
             // miExportCharacterSkillsAsPlan
@@ -378,7 +378,7 @@ namespace EVEMon.SkillPlanner
             this.miExportCharacterSkillsAsPlan.Image = ((System.Drawing.Image)(resources.GetObject("miExportCharacterSkillsAsPlan.Image")));
             this.miExportCharacterSkillsAsPlan.Name = "miExportCharacterSkillsAsPlan";
             this.miExportCharacterSkillsAsPlan.Size = new System.Drawing.Size(239, 22);
-            this.miExportCharacterSkillsAsPlan.Text = "Export Character &Skills as Plan...";
+            this.miExportCharacterSkillsAsPlan.Text = resources.GetString("this.miExportCharacterSkillsAsPlan.Text");
             this.miExportCharacterSkillsAsPlan.Click += new System.EventHandler(this.miExportCharacterSkillsAsPlan_Click);
             // 
             // ExportCharAsPlanToolStripSeparator
@@ -391,7 +391,7 @@ namespace EVEMon.SkillPlanner
             this.miRestorePlans.Image = ((System.Drawing.Image)(resources.GetObject("miRestorePlans.Image")));
             this.miRestorePlans.Name = "miRestorePlans";
             this.miRestorePlans.Size = new System.Drawing.Size(239, 22);
-            this.miRestorePlans.Text = "&Restore Plans...";
+            this.miRestorePlans.Text = resources.GetString("this.miRestorePlans.Text");
             this.miRestorePlans.Click += new System.EventHandler(this.miRestorePlans_Click);
             // 
             // miSavePlans
@@ -399,7 +399,7 @@ namespace EVEMon.SkillPlanner
             this.miSavePlans.Image = ((System.Drawing.Image)(resources.GetObject("miSavePlans.Image")));
             this.miSavePlans.Name = "miSavePlans";
             this.miSavePlans.Size = new System.Drawing.Size(239, 22);
-            this.miSavePlans.Text = "&Save Plans...";
+            this.miSavePlans.Text = resources.GetString("this.miSavePlans.Text");
             this.miSavePlans.Click += new System.EventHandler(this.miSavePlans_Click);
             // 
             // mEdit
@@ -409,7 +409,7 @@ namespace EVEMon.SkillPlanner
             this.miDelete});
             this.mEdit.Name = "mEdit";
             this.mEdit.Size = new System.Drawing.Size(39, 20);
-            this.mEdit.Text = "&Edit";
+            this.mEdit.Text = resources.GetString("this.mEdit.Text");
             this.mEdit.DropDownOpening += new System.EventHandler(this.mEdit_DropDownOpening);
             // 
             // miRenameEdit
@@ -418,7 +418,7 @@ namespace EVEMon.SkillPlanner
             this.miRenameEdit.Name = "miRenameEdit";
             this.miRenameEdit.ShortcutKeys = System.Windows.Forms.Keys.F2;
             this.miRenameEdit.Size = new System.Drawing.Size(145, 22);
-            this.miRenameEdit.Text = "&Rename...";
+            this.miRenameEdit.Text = resources.GetString("this.miRenameEdit.Text");
             this.miRenameEdit.Click += new System.EventHandler(this.miRenameEdit_Click);
             // 
             // miDelete
@@ -427,7 +427,7 @@ namespace EVEMon.SkillPlanner
             this.miDelete.Name = "miDelete";
             this.miDelete.ShortcutKeys = System.Windows.Forms.Keys.Delete;
             this.miDelete.Size = new System.Drawing.Size(145, 22);
-            this.miDelete.Text = "&Delete";
+            this.miDelete.Text = resources.GetString("this.miDelete.Text");
             this.miDelete.Click += new System.EventHandler(this.miDelete_Click);
             // 
             // PlanManagementWindow
@@ -443,7 +443,7 @@ namespace EVEMon.SkillPlanner
             this.MinimizeBox = false;
             this.Name = "PlanManagementWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Manage Plans";
+            this.Text = resources.GetString("this.Text");
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.contextMenu.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/PlanManagementWindow.resx
+++ b/src/EVEMon/SkillPlanner/PlanManagementWindow.resx
@@ -786,4 +786,94 @@
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>44</value>
   </metadata>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>Select a plan to open, or multiple plans to merge:</value>
+  </data>
+  <data name="this.btnClose.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="this.ofdOpenDialog.Filter" xml:space="preserve">
+    <value>Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*</value>
+  </data>
+  <data name="this.ofdOpenDialog.Title" xml:space="preserve">
+    <value>Open Plan File</value>
+  </data>
+  <data name="this.PlanName.Text" xml:space="preserve">
+    <value>Plan Name</value>
+  </data>
+  <data name="this.PlanDate.Text" xml:space="preserve">
+    <value>Completion Time</value>
+  </data>
+  <data name="this.PlanSkills.Text" xml:space="preserve">
+    <value>Skills</value>
+  </data>
+  <data name="this.PlanDescription.Text" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="this.cmiOpen.Text" xml:space="preserve">
+    <value>Open...</value>
+  </data>
+  <data name="this.cmiExport.Text" xml:space="preserve">
+    <value>Export...</value>
+  </data>
+  <data name="this.cmiRenameEdit.Text" xml:space="preserve">
+    <value>Rename...</value>
+  </data>
+  <data name="this.cmiDelete.Text" xml:space="preserve">
+    <value>Delete</value>
+  </data>
+  <data name="this.toolStrip.Text" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="this.toolStripLabel1.Text" xml:space="preserve">
+    <value>Move:</value>
+  </data>
+  <data name="this.tsbMoveUp.Text" xml:space="preserve">
+    <value>Move Up</value>
+  </data>
+  <data name="this.tsbMoveDown.Text" xml:space="preserve">
+    <value>Move Down</value>
+  </data>
+  <data name="this.btnOpen.Text" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="this.menuStrip.Text" xml:space="preserve">
+    <value>menuBar</value>
+  </data>
+  <data name="this.mFile.Text" xml:space="preserve">
+    <value>&amp;File</value>
+  </data>
+  <data name="this.miNewPlan.Text" xml:space="preserve">
+    <value>&amp;New Plan…</value>
+  </data>
+  <data name="this.miImportPlanFromFile.Text" xml:space="preserve">
+    <value>&amp;Import Plan from File…</value>
+  </data>
+  <data name="this.miImportPlanFromCharacter.Text" xml:space="preserve">
+    <value>Import Plan from &amp;Character…</value>
+  </data>
+  <data name="this.miExportPlan.Text" xml:space="preserve">
+    <value>&amp;Export Plan...</value>
+  </data>
+  <data name="this.miExportCharacterSkillsAsPlan.Text" xml:space="preserve">
+    <value>Export Character &amp;Skills as Plan...</value>
+  </data>
+  <data name="this.miRestorePlans.Text" xml:space="preserve">
+    <value>&amp;Restore Plans...</value>
+  </data>
+  <data name="this.miSavePlans.Text" xml:space="preserve">
+    <value>&amp;Save Plans...</value>
+  </data>
+  <data name="this.mEdit.Text" xml:space="preserve">
+    <value>&amp;Edit</value>
+  </data>
+  <data name="this.miRenameEdit.Text" xml:space="preserve">
+    <value>&amp;Rename...</value>
+  </data>
+  <data name="this.miDelete.Text" xml:space="preserve">
+    <value>&amp;Delete</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Manage Plans</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/PlanManagementWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanManagementWindow.zh-CN.resx
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>选择要打开的计划或要合并的多个计划：</value>
+  </data>
+  <data name="this.btnClose.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.ofdOpenDialog.Filter" xml:space="preserve">
+    <value>Plan Files (*.emp)|*.emp|Plan Files (*.xml)|*.xml|All Files (*.*)|*.*</value>
+  </data>
+  <data name="this.ofdOpenDialog.Title" xml:space="preserve">
+    <value>打开计划文件</value>
+  </data>
+  <data name="this.PlanName.Text" xml:space="preserve">
+    <value>计划名称</value>
+  </data>
+  <data name="this.PlanDate.Text" xml:space="preserve">
+    <value>完成时间</value>
+  </data>
+  <data name="this.PlanSkills.Text" xml:space="preserve">
+    <value>技能</value>
+  </data>
+  <data name="this.PlanDescription.Text" xml:space="preserve">
+    <value>描述</value>
+  </data>
+  <data name="this.cmiOpen.Text" xml:space="preserve">
+    <value>打开...</value>
+  </data>
+  <data name="this.cmiExport.Text" xml:space="preserve">
+    <value>出口...</value>
+  </data>
+  <data name="this.cmiRenameEdit.Text" xml:space="preserve">
+    <value>重命名...</value>
+  </data>
+  <data name="this.cmiDelete.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="this.toolStrip.Text" xml:space="preserve">
+    <value>工具条</value>
+  </data>
+  <data name="this.toolStripLabel1.Text" xml:space="preserve">
+    <value>移动：</value>
+  </data>
+  <data name="this.tsbMoveUp.Text" xml:space="preserve">
+    <value>向上移动</value>
+  </data>
+  <data name="this.tsbMoveDown.Text" xml:space="preserve">
+    <value>下移</value>
+  </data>
+  <data name="this.btnOpen.Text" xml:space="preserve">
+    <value>打开</value>
+  </data>
+  <data name="this.menuStrip.Text" xml:space="preserve">
+    <value>菜单栏</value>
+  </data>
+  <data name="this.mFile.Text" xml:space="preserve">
+    <value>文件(&amp;F)</value>
+  </data>
+  <data name="this.miNewPlan.Text" xml:space="preserve">
+    <value>新计划(&amp;N)...</value>
+  </data>
+  <data name="this.miImportPlanFromFile.Text" xml:space="preserve">
+    <value>从文件导入计划(&amp;I)...</value>
+  </data>
+  <data name="this.miImportPlanFromCharacter.Text" xml:space="preserve">
+    <value>从角色导入计划(&amp;C)...</value>
+  </data>
+  <data name="this.miExportPlan.Text" xml:space="preserve">
+    <value>出口计划(&amp;E)...</value>
+  </data>
+  <data name="this.miExportCharacterSkillsAsPlan.Text" xml:space="preserve">
+    <value>按计划导出角色和技能...</value>
+  </data>
+  <data name="this.miRestorePlans.Text" xml:space="preserve">
+    <value>恢复计划(&amp;R)...</value>
+  </data>
+  <data name="this.miSavePlans.Text" xml:space="preserve">
+    <value>保存计划(&amp;S)...</value>
+  </data>
+  <data name="this.mEdit.Text" xml:space="preserve">
+    <value>编辑(&amp;E)</value>
+  </data>
+  <data name="this.miRenameEdit.Text" xml:space="preserve">
+    <value>重命名(&amp;E)...</value>
+  </data>
+  <data name="this.miDelete.Text" xml:space="preserve">
+    <value>删除(&amp;D)</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>管理计划</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanNotesEditorWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanNotesEditorWindow.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.Designer.cs
@@ -66,7 +66,7 @@ namespace EVEMon.SkillPlanner
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(41, 13);
             this.label1.TabIndex = 1;
-            this.label1.Text = "Priority";
+            this.label1.Text = resources.GetString("this.label1.Text");
             // 
             // btnCancel
             // 
@@ -76,7 +76,7 @@ namespace EVEMon.SkillPlanner
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 4;
-            this.btnCancel.Text = "Cancel";
+            this.btnCancel.Text = resources.GetString("this.btnCancel.Text");
             this.btnCancel.UseVisualStyleBackColor = true;
             // 
             // btnOk
@@ -86,7 +86,7 @@ namespace EVEMon.SkillPlanner
             this.btnOk.Name = "btnOk";
             this.btnOk.Size = new System.Drawing.Size(75, 23);
             this.btnOk.TabIndex = 3;
-            this.btnOk.Text = "OK";
+            this.btnOk.Text = resources.GetString("this.btnOk.Text");
             this.btnOk.UseVisualStyleBackColor = true;
             this.btnOk.Click += new System.EventHandler(this.btnOk_Click);
             // 
@@ -113,7 +113,7 @@ namespace EVEMon.SkillPlanner
             this.Controls.Add(this.label2);
             this.Name = "PlanPrioritiesEditorForm";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Change Plan Entry Priorty";
+            this.Text = resources.GetString("this.Text");
             this.Load += new System.EventHandler(this.ChangePriorityForm_Load);
             ((System.ComponentModel.ISupportInitialize)(this.nudPriority)).EndInit();
             this.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.resx
+++ b/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.resx
@@ -126,4 +126,16 @@ Dependant skills must have same or lower priority.
 
 </value>
   </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>Priority</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="this.btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Change Plan Entry Priorty</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanPrioritiesEditorWindow.zh-CN.resx
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>注意：先决条件和依赖项的优先级 
+技能可能会调整。
+先决条件必须具有更高或相同的优先级。
+相关技能必须具有相同或较低的优先级。
+（1 的优先级高于 5）
+
+</value>
+  </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>优先级</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>取消</value>
+  </data>
+  <data name="this.btnOk.Text" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>变更计划进入优先级</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanToOperationWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/PlanToOperationWindow.Designer.cs
@@ -67,7 +67,7 @@ namespace EVEMon.SkillPlanner
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(175, 13);
             this.label1.TabIndex = 1;
-            this.label1.Text = "The following entries will be added.";
+            this.label1.Text = resources.GetString("this.label1.Text");
             // 
             // warningPicture
             // 
@@ -87,7 +87,7 @@ namespace EVEMon.SkillPlanner
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(90, 13);
             this.label5.TabIndex = 14;
-            this.label5.Text = "Add with priority:";
+            this.label5.Text = resources.GetString("this.label5.Text");
             // 
             // label3
             // 
@@ -96,7 +96,7 @@ namespace EVEMon.SkillPlanner
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(287, 26);
             this.label3.TabIndex = 6;
-            this.label3.Text = "You have exisiting pre-requisites in your plan, so you must\r\n\r\n";
+            this.label3.Text = resources.GetString("this.label3.Text");
             // 
             // previousButton
             // 
@@ -105,7 +105,7 @@ namespace EVEMon.SkillPlanner
             this.previousButton.Name = "previousButton";
             this.previousButton.Size = new System.Drawing.Size(75, 23);
             this.previousButton.TabIndex = 2;
-            this.previousButton.Text = "< &Previous";
+            this.previousButton.Text = resources.GetString("this.previousButton.Text");
             this.previousButton.UseVisualStyleBackColor = true;
             this.previousButton.Click += new System.EventHandler(this.previousButton_Click);
             // 
@@ -117,7 +117,7 @@ namespace EVEMon.SkillPlanner
             this.cancelButton.Name = "cancelButton";
             this.cancelButton.Size = new System.Drawing.Size(75, 23);
             this.cancelButton.TabIndex = 3;
-            this.cancelButton.Text = "&Cancel";
+            this.cancelButton.Text = resources.GetString("this.cancelButton.Text");
             this.cancelButton.UseVisualStyleBackColor = true;
             this.cancelButton.Click += new System.EventHandler(this.cancelButton_Click);
             // 
@@ -128,7 +128,7 @@ namespace EVEMon.SkillPlanner
             this.nextButton.Name = "nextButton";
             this.nextButton.Size = new System.Drawing.Size(75, 23);
             this.nextButton.TabIndex = 1;
-            this.nextButton.Text = "Next >";
+            this.nextButton.Text = resources.GetString("this.nextButton.Text");
             this.nextButton.UseVisualStyleBackColor = true;
             this.nextButton.Click += new System.EventHandler(this.nextButton_Click);
             // 
@@ -158,7 +158,7 @@ namespace EVEMon.SkillPlanner
             this.additionPage.Name = "additionPage";
             this.additionPage.Size = new System.Drawing.Size(304, 350);
             this.additionPage.TabIndex = 0;
-            this.additionPage.Text = "additionPage";
+            this.additionPage.Text = resources.GetString("this.additionPage.Text");
             // 
             // priorityGroup
             // 
@@ -170,7 +170,7 @@ namespace EVEMon.SkillPlanner
             this.priorityGroup.Size = new System.Drawing.Size(294, 84);
             this.priorityGroup.TabIndex = 13;
             this.priorityGroup.TabStop = false;
-            this.priorityGroup.Text = "Existing Priorities";
+            this.priorityGroup.Text = resources.GetString("this.priorityGroup.Text");
             // 
             // priorityLabel
             // 
@@ -179,7 +179,7 @@ namespace EVEMon.SkillPlanner
             this.priorityLabel.Name = "priorityLabel";
             this.priorityLabel.Size = new System.Drawing.Size(178, 13);
             this.priorityLabel.TabIndex = 10;
-            this.priorityLabel.Text = "The highest priority you can set is 3";
+            this.priorityLabel.Text = resources.GetString("this.priorityLabel.Text");
             // 
             // lbExisting
             // 
@@ -188,7 +188,7 @@ namespace EVEMon.SkillPlanner
             this.lbExisting.Name = "lbExisting";
             this.lbExisting.Size = new System.Drawing.Size(251, 13);
             this.lbExisting.TabIndex = 9;
-            this.lbExisting.Text = "select a lower priority than that of existing entries.";
+            this.lbExisting.Text = resources.GetString("this.lbExisting.Text");
             // 
             // priorityNumericBox
             // 
@@ -236,7 +236,7 @@ namespace EVEMon.SkillPlanner
             this.dependenciesSuppressionPage.Name = "dependenciesSuppressionPage";
             this.dependenciesSuppressionPage.Size = new System.Drawing.Size(304, 350);
             this.dependenciesSuppressionPage.TabIndex = 0;
-            this.dependenciesSuppressionPage.Text = "dependenciesSuppressionPage";
+            this.dependenciesSuppressionPage.Text = resources.GetString("this.dependenciesSuppressionPage.Text");
             // 
             // suppressionListBox
             // 
@@ -257,7 +257,7 @@ namespace EVEMon.SkillPlanner
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(190, 13);
             this.label2.TabIndex = 1;
-            this.label2.Text = "The following entries will be removed :";
+            this.label2.Text = resources.GetString("this.label2.Text");
             // 
             // uselessPrereqsSuppressionPage
             // 
@@ -268,7 +268,7 @@ namespace EVEMon.SkillPlanner
             this.uselessPrereqsSuppressionPage.Name = "uselessPrereqsSuppressionPage";
             this.uselessPrereqsSuppressionPage.Size = new System.Drawing.Size(304, 273);
             this.uselessPrereqsSuppressionPage.TabIndex = 1;
-            this.uselessPrereqsSuppressionPage.Text = "uselessPrereqsSuppressionPage";
+            this.uselessPrereqsSuppressionPage.Text = resources.GetString("this.uselessPrereqsSuppressionPage.Text");
             // 
             // uselessPrereqsListBox
             // 
@@ -289,7 +289,7 @@ namespace EVEMon.SkillPlanner
             this.uselessPrereqsCheckbox.Name = "uselessPrereqsCheckbox";
             this.uselessPrereqsCheckbox.Size = new System.Drawing.Size(273, 17);
             this.uselessPrereqsCheckbox.TabIndex = 0;
-            this.uselessPrereqsCheckbox.Text = "Remove the now useless prerequisites listed below.";
+            this.uselessPrereqsCheckbox.Text = resources.GetString("this.uselessPrereqsCheckbox.Text");
             this.uselessPrereqsCheckbox.UseVisualStyleBackColor = true;
             // 
             // PlanToOperationForm
@@ -307,7 +307,7 @@ namespace EVEMon.SkillPlanner
             this.MaximizeBox = false;
             this.MinimizeBox = false;
             this.Name = "PlanToOperationForm";
-            this.Text = "PlanToOperationForm";
+            this.Text = resources.GetString("this.Text");
             ((System.ComponentModel.ISupportInitialize)(this.warningPicture)).EndInit();
             this.rootMultiPanel.ResumeLayout(false);
             this.additionPage.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/PlanToOperationWindow.resx
+++ b/src/EVEMon/SkillPlanner/PlanToOperationWindow.resx
@@ -157,4 +157,51 @@
         zm9OViqdD02pN+jzQaq/T9YBOqd8WZ/9lR17eRvbQhMQ/m+Xc4Q7dCv0TAAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>The following entries will be added.</value>
+  </data>
+  <data name="this.label5.Text" xml:space="preserve">
+    <value>Add with priority:</value>
+  </data>
+  <data name="this.label3.Text" xml:space="preserve">
+    <value>You have exisiting pre-requisites in your plan, so you must
+
+</value>
+  </data>
+  <data name="this.previousButton.Text" xml:space="preserve">
+    <value>&lt; &amp;Previous</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>&amp;Cancel</value>
+  </data>
+  <data name="this.nextButton.Text" xml:space="preserve">
+    <value>Next &gt;</value>
+  </data>
+  <data name="this.additionPage.Text" xml:space="preserve">
+    <value>additionPage</value>
+  </data>
+  <data name="this.priorityGroup.Text" xml:space="preserve">
+    <value>Existing Priorities</value>
+  </data>
+  <data name="this.priorityLabel.Text" xml:space="preserve">
+    <value>The highest priority you can set is 3</value>
+  </data>
+  <data name="this.lbExisting.Text" xml:space="preserve">
+    <value>select a lower priority than that of existing entries.</value>
+  </data>
+  <data name="this.dependenciesSuppressionPage.Text" xml:space="preserve">
+    <value>dependenciesSuppressionPage</value>
+  </data>
+  <data name="this.label2.Text" xml:space="preserve">
+    <value>The following entries will be removed :</value>
+  </data>
+  <data name="this.uselessPrereqsSuppressionPage.Text" xml:space="preserve">
+    <value>uselessPrereqsSuppressionPage</value>
+  </data>
+  <data name="this.uselessPrereqsCheckbox.Text" xml:space="preserve">
+    <value>Remove the now useless prerequisites listed below.</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>PlanToOperationForm</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/PlanToOperationWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanToOperationWindow.zh-CN.resx
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.label1.Text" xml:space="preserve">
+    <value>将添加以下条目。</value>
+  </data>
+  <data name="this.label5.Text" xml:space="preserve">
+    <value>优先添加：</value>
+  </data>
+  <data name="this.label3.Text" xml:space="preserve">
+    <value>您的计划中已有先决条件，因此您必须
+
+</value>
+  </data>
+  <data name="this.previousButton.Text" xml:space="preserve">
+    <value>&lt;&amp;上一页</value>
+  </data>
+  <data name="this.cancelButton.Text" xml:space="preserve">
+    <value>取消(&amp;C)</value>
+  </data>
+  <data name="this.nextButton.Text" xml:space="preserve">
+    <value>下一页&gt;</value>
+  </data>
+  <data name="this.additionPage.Text" xml:space="preserve">
+    <value>加法页</value>
+  </data>
+  <data name="this.priorityGroup.Text" xml:space="preserve">
+    <value>现有的优先事项</value>
+  </data>
+  <data name="this.priorityLabel.Text" xml:space="preserve">
+    <value>您可以设置的最高优先级是 3</value>
+  </data>
+  <data name="this.lbExisting.Text" xml:space="preserve">
+    <value>选择比现有条目低的优先级。</value>
+  </data>
+  <data name="this.dependenciesSuppressionPage.Text" xml:space="preserve">
+    <value>依赖抑制页面</value>
+  </data>
+  <data name="this.label2.Text" xml:space="preserve">
+    <value>以下条目将被删除：</value>
+  </data>
+  <data name="this.uselessPrereqsSuppressionPage.Text" xml:space="preserve">
+    <value>无用先决条件抑制页面</value>
+  </data>
+  <data name="this.uselessPrereqsCheckbox.Text" xml:space="preserve">
+    <value>删除下面列出的现在无用的先决条件。</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>计划到操作表</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/PlanWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/PlanWindow.Designer.cs
@@ -101,7 +101,7 @@ namespace EVEMon.SkillPlanner
             this.ObsoleteEntriesStatusLabel.LinkColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(0)))), ((int)(((byte)(255)))));
             this.ObsoleteEntriesStatusLabel.Name = "ObsoleteEntriesStatusLabel";
             this.ObsoleteEntriesStatusLabel.Size = new System.Drawing.Size(117, 17);
-            this.ObsoleteEntriesStatusLabel.Text = "Obsolete Entries...";
+            this.ObsoleteEntriesStatusLabel.Text = resources.GetString("this.ObsoleteEntriesStatusLabel.Text");
             this.ObsoleteEntriesStatusLabel.Visible = false;
             this.ObsoleteEntriesStatusLabel.Click += new System.EventHandler(this.obsoleteEntriesToolStripStatusLabel_Click);
             // 
@@ -111,7 +111,7 @@ namespace EVEMon.SkillPlanner
             this.SkillsStatusLabel.Image = ((System.Drawing.Image)(resources.GetObject("SkillsStatusLabel.Image")));
             this.SkillsStatusLabel.Name = "SkillsStatusLabel";
             this.SkillsStatusLabel.Size = new System.Drawing.Size(104, 17);
-            this.SkillsStatusLabel.Text = "0 Skills Planned";
+            this.SkillsStatusLabel.Text = resources.GetString("this.SkillsStatusLabel.Text");
             this.SkillsStatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // TimeStatusLabel
@@ -119,7 +119,7 @@ namespace EVEMon.SkillPlanner
             this.TimeStatusLabel.Image = ((System.Drawing.Image)(resources.GetObject("TimeStatusLabel.Image")));
             this.TimeStatusLabel.Name = "TimeStatusLabel";
             this.TimeStatusLabel.Size = new System.Drawing.Size(116, 17);
-            this.TimeStatusLabel.Text = "356d 23h 25m 10s";
+            this.TimeStatusLabel.Text = resources.GetString("this.TimeStatusLabel.Text");
             this.TimeStatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // CostStatusLabel
@@ -127,7 +127,7 @@ namespace EVEMon.SkillPlanner
             this.CostStatusLabel.Image = ((System.Drawing.Image)(resources.GetObject("CostStatusLabel.Image")));
             this.CostStatusLabel.Name = "CostStatusLabel";
             this.CostStatusLabel.Size = new System.Drawing.Size(98, 17);
-            this.CostStatusLabel.Text = "0 ISK Required";
+            this.CostStatusLabel.Text = resources.GetString("this.CostStatusLabel.Text");
             this.CostStatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // SkillPointsStatusLabel
@@ -135,7 +135,7 @@ namespace EVEMon.SkillPlanner
             this.SkillPointsStatusLabel.Image = ((System.Drawing.Image)(resources.GetObject("SkillPointsStatusLabel.Image")));
             this.SkillPointsStatusLabel.Name = "SkillPointsStatusLabel";
             this.SkillPointsStatusLabel.Size = new System.Drawing.Size(95, 17);
-            this.SkillPointsStatusLabel.Text = "0 SP Required";
+            this.SkillPointsStatusLabel.Text = resources.GetString("this.SkillPointsStatusLabel.Text");
             this.SkillPointsStatusLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // upperToolStrip
@@ -157,7 +157,7 @@ namespace EVEMon.SkillPlanner
             this.upperToolStrip.Name = "upperToolStrip";
             this.upperToolStrip.Size = new System.Drawing.Size(943, 25);
             this.upperToolStrip.TabIndex = 3;
-            this.upperToolStrip.Text = "toolStrip1";
+            this.upperToolStrip.Text = resources.GetString("this.upperToolStrip.Text");
             // 
             // tsddbPlans
             // 
@@ -169,7 +169,7 @@ namespace EVEMon.SkillPlanner
             this.tsddbPlans.ImageTransparentColor = System.Drawing.Color.Black;
             this.tsddbPlans.Name = "tsddbPlans";
             this.tsddbPlans.Size = new System.Drawing.Size(93, 22);
-            this.tsddbPlans.Text = "Select Plan";
+            this.tsddbPlans.Text = resources.GetString("this.tsddbPlans.Text");
             this.tsddbPlans.DropDownOpening += new System.EventHandler(this.tsddbPlans_DropDownOpening);
             this.tsddbPlans.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.tsddbPlans_DropDownItemClicked);
             // 
@@ -178,7 +178,7 @@ namespace EVEMon.SkillPlanner
             this.newPlanToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("newPlanToolStripMenuItem.Image")));
             this.newPlanToolStripMenuItem.Name = "newPlanToolStripMenuItem";
             this.newPlanToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-            this.newPlanToolStripMenuItem.Text = "New Plan...";
+            this.newPlanToolStripMenuItem.Text = resources.GetString("this.newPlanToolStripMenuItem.Text");
             this.newPlanToolStripMenuItem.Click += new System.EventHandler(this.newPlanToolStripMenuItem_Click);
             // 
             // createPlanFromSkillQueueToolStripMenuItem
@@ -186,7 +186,7 @@ namespace EVEMon.SkillPlanner
             this.createPlanFromSkillQueueToolStripMenuItem.Image = ((System.Drawing.Image)(resources.GetObject("createPlanFromSkillQueueToolStripMenuItem.Image")));
             this.createPlanFromSkillQueueToolStripMenuItem.Name = "createPlanFromSkillQueueToolStripMenuItem";
             this.createPlanFromSkillQueueToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
-            this.createPlanFromSkillQueueToolStripMenuItem.Text = "Create Plan from Skill Queue...";
+            this.createPlanFromSkillQueueToolStripMenuItem.Text = resources.GetString("this.createPlanFromSkillQueueToolStripMenuItem.Text");
             this.createPlanFromSkillQueueToolStripMenuItem.Click += new System.EventHandler(this.createPlanFromSkillQueueToolStripMenuItem_Click);
             // 
             // toolStripSeparator3
@@ -203,14 +203,14 @@ namespace EVEMon.SkillPlanner
             this.tsddbSave.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsddbSave.Name = "tsddbSave";
             this.tsddbSave.Size = new System.Drawing.Size(69, 22);
-            this.tsddbSave.Text = "Export";
+            this.tsddbSave.Text = resources.GetString("this.tsddbSave.Text");
             // 
             // tsmiExportPlan
             // 
             this.tsmiExportPlan.Image = ((System.Drawing.Image)(resources.GetObject("tsmiExportPlan.Image")));
             this.tsmiExportPlan.Name = "tsmiExportPlan";
             this.tsmiExportPlan.Size = new System.Drawing.Size(189, 22);
-            this.tsmiExportPlan.Text = "&Plan...";
+            this.tsmiExportPlan.Text = resources.GetString("this.tsmiExportPlan.Text");
             this.tsmiExportPlan.Click += new System.EventHandler(this.tsmiExportPlan_Click);
             // 
             // tsmiAfterPlanCharacter
@@ -218,7 +218,7 @@ namespace EVEMon.SkillPlanner
             this.tsmiAfterPlanCharacter.Image = ((System.Drawing.Image)(resources.GetObject("tsmiAfterPlanCharacter.Image")));
             this.tsmiAfterPlanCharacter.Name = "tsmiAfterPlanCharacter";
             this.tsmiAfterPlanCharacter.Size = new System.Drawing.Size(189, 22);
-            this.tsmiAfterPlanCharacter.Text = "After Plan &Character...";
+            this.tsmiAfterPlanCharacter.Text = resources.GetString("this.tsmiAfterPlanCharacter.Text");
             this.tsmiAfterPlanCharacter.Click += new System.EventHandler(this.tsmiAfterPlanCharacter_Click);
             // 
             // tsbDeletePlan
@@ -227,7 +227,7 @@ namespace EVEMon.SkillPlanner
             this.tsbDeletePlan.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbDeletePlan.Name = "tsbDeletePlan";
             this.tsbDeletePlan.Size = new System.Drawing.Size(69, 22);
-            this.tsbDeletePlan.Text = "Delete...";
+            this.tsbDeletePlan.Text = resources.GetString("this.tsbDeletePlan.Text");
             this.tsbDeletePlan.Click += new System.EventHandler(this.tsbDeletePlan_Click);
             // 
             // tsbPrintPlan
@@ -236,8 +236,8 @@ namespace EVEMon.SkillPlanner
             this.tsbPrintPlan.ImageTransparentColor = System.Drawing.Color.Black;
             this.tsbPrintPlan.Name = "tsbPrintPlan";
             this.tsbPrintPlan.Size = new System.Drawing.Size(61, 22);
-            this.tsbPrintPlan.Text = "Print...";
-            this.tsbPrintPlan.ToolTipText = "Print this plan";
+            this.tsbPrintPlan.Text = resources.GetString("this.tsbPrintPlan.Text");
+            this.tsbPrintPlan.ToolTipText = resources.GetString("this.tsbPrintPlan.ToolTipText");
             this.tsbPrintPlan.Click += new System.EventHandler(this.tsbPrintPlan_Click);
             // 
             // tsbCopyToClipboard
@@ -246,7 +246,7 @@ namespace EVEMon.SkillPlanner
             this.tsbCopyToClipboard.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbCopyToClipboard.Name = "tsbCopyToClipboard";
             this.tsbCopyToClipboard.Size = new System.Drawing.Size(133, 22);
-            this.tsbCopyToClipboard.Text = "Copy to Clipboard...";
+            this.tsbCopyToClipboard.Text = resources.GetString("this.tsbCopyToClipboard.Text");
             this.tsbCopyToClipboard.Click += new System.EventHandler(this.tsbCopyToClipboard_Click);
             // 
             // toolStripSeparator1
@@ -260,7 +260,7 @@ namespace EVEMon.SkillPlanner
             this.tsbImplantCalculator.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbImplantCalculator.Name = "tsbImplantCalculator";
             this.tsbImplantCalculator.Size = new System.Drawing.Size(103, 22);
-            this.tsbImplantCalculator.Text = "Implant Calc...";
+            this.tsbImplantCalculator.Text = resources.GetString("this.tsbImplantCalculator.Text");
             this.tsbImplantCalculator.Click += new System.EventHandler(this.tsbImplantCalculator_Click);
             // 
             // attributesOptimizerStripButton
@@ -269,7 +269,7 @@ namespace EVEMon.SkillPlanner
             this.attributesOptimizerStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.attributesOptimizerStripButton.Name = "attributesOptimizerStripButton";
             this.attributesOptimizerStripButton.Size = new System.Drawing.Size(143, 22);
-            this.attributesOptimizerStripButton.Text = "Attributes Optimizer...";
+            this.attributesOptimizerStripButton.Text = resources.GetString("this.attributesOptimizerStripButton.Text");
             this.attributesOptimizerStripButton.Click += new System.EventHandler(this.tsbAttributesOptimizer_Click);
             // 
             // toolStripSeparator2
@@ -283,7 +283,7 @@ namespace EVEMon.SkillPlanner
             this.tsbLoadoutImport.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbLoadoutImport.Name = "tsbLoadoutImport";
             this.tsbLoadoutImport.Size = new System.Drawing.Size(119, 22);
-            this.tsbLoadoutImport.Text = "Loadout Import...";
+            this.tsbLoadoutImport.Text = resources.GetString("this.tsbLoadoutImport.Text");
             this.tsbLoadoutImport.Click += new System.EventHandler(this.tsbLoadoutImport_Click);
             // 
             // tsbClipboardImport
@@ -292,8 +292,8 @@ namespace EVEMon.SkillPlanner
             this.tsbClipboardImport.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsbClipboardImport.Name = "tsbClipboardImport";
             this.tsbClipboardImport.Size = new System.Drawing.Size(118, 22);
-            this.tsbClipboardImport.Text = "Clipboard Import";
-            this.tsbClipboardImport.ToolTipText = "Clipboard Import...";
+            this.tsbClipboardImport.Text = resources.GetString("this.tsbClipboardImport.Text");
+            this.tsbClipboardImport.ToolTipText = resources.GetString("this.tsbClipboardImport.ToolTipText");
             this.tsbClipboardImport.Click += new System.EventHandler(this.tsbClipboardImport_Click);
             // 
             // ttToolTip
@@ -306,7 +306,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.sfdSave.Filter = "EVEMon Plan Format (*.emp)|*.emp|XML  Format (*.xml)|*.xml|Text Format (*.txt)|*." +
     "txt";
-            this.sfdSave.Title = "Save to File";
+            this.sfdSave.Title = resources.GetString("this.sfdSave.Title");
             // 
             // tabControl
             // 
@@ -334,7 +334,7 @@ namespace EVEMon.SkillPlanner
             this.tpPlanEditor.Name = "tpPlanEditor";
             this.tpPlanEditor.Size = new System.Drawing.Size(935, 480);
             this.tpPlanEditor.TabIndex = 1;
-            this.tpPlanEditor.Text = "Plan editor";
+            this.tpPlanEditor.Text = resources.GetString("this.tpPlanEditor.Text");
             this.tpPlanEditor.UseVisualStyleBackColor = true;
             // 
             // planEditor
@@ -355,7 +355,7 @@ namespace EVEMon.SkillPlanner
             this.tpSkillBrowser.Name = "tpSkillBrowser";
             this.tpSkillBrowser.Size = new System.Drawing.Size(935, 480);
             this.tpSkillBrowser.TabIndex = 0;
-            this.tpSkillBrowser.Text = "Skill browser";
+            this.tpSkillBrowser.Text = resources.GetString("this.tpSkillBrowser.Text");
             this.tpSkillBrowser.UseVisualStyleBackColor = true;
             // 
             // skillBrowser
@@ -375,7 +375,7 @@ namespace EVEMon.SkillPlanner
             this.tpCertificateBrowser.Padding = new System.Windows.Forms.Padding(3);
             this.tpCertificateBrowser.Size = new System.Drawing.Size(935, 480);
             this.tpCertificateBrowser.TabIndex = 6;
-            this.tpCertificateBrowser.Text = "Certificate browser";
+            this.tpCertificateBrowser.Text = resources.GetString("this.tpCertificateBrowser.Text");
             this.tpCertificateBrowser.UseVisualStyleBackColor = true;
             // 
             // certBrowser
@@ -395,7 +395,7 @@ namespace EVEMon.SkillPlanner
             this.tpShipBrowser.Name = "tpShipBrowser";
             this.tpShipBrowser.Size = new System.Drawing.Size(935, 480);
             this.tpShipBrowser.TabIndex = 2;
-            this.tpShipBrowser.Text = "Ship browser";
+            this.tpShipBrowser.Text = resources.GetString("this.tpShipBrowser.Text");
             this.tpShipBrowser.UseVisualStyleBackColor = true;
             // 
             // shipBrowser
@@ -415,7 +415,7 @@ namespace EVEMon.SkillPlanner
             this.tpItemBrowser.Name = "tpItemBrowser";
             this.tpItemBrowser.Size = new System.Drawing.Size(935, 480);
             this.tpItemBrowser.TabIndex = 3;
-            this.tpItemBrowser.Text = "Item browser";
+            this.tpItemBrowser.Text = resources.GetString("this.tpItemBrowser.Text");
             this.tpItemBrowser.UseVisualStyleBackColor = true;
             // 
             // itemBrowser
@@ -434,7 +434,7 @@ namespace EVEMon.SkillPlanner
             this.tpBlueprintBrowser.Name = "tpBlueprintBrowser";
             this.tpBlueprintBrowser.Size = new System.Drawing.Size(935, 480);
             this.tpBlueprintBrowser.TabIndex = 5;
-            this.tpBlueprintBrowser.Text = "Blueprint browser";
+            this.tpBlueprintBrowser.Text = resources.GetString("this.tpBlueprintBrowser.Text");
             this.tpBlueprintBrowser.UseVisualStyleBackColor = true;
             // 
             // blueprintBrowser
@@ -467,7 +467,7 @@ namespace EVEMon.SkillPlanner
             this.MinimumSize = new System.Drawing.Size(780, 350);
             this.Name = "PlanWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "EVEMon Skill Planner";
+            this.Text = resources.GetString("this.Text");
             this.MainStatusStrip.ResumeLayout(false);
             this.MainStatusStrip.PerformLayout();
             this.upperToolStrip.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/PlanWindow.resx
+++ b/src/EVEMon/SkillPlanner/PlanWindow.resx
@@ -902,4 +902,91 @@
         Af4Bdwr/Cw==
 </value>
   </data>
+  <data name="this.ObsoleteEntriesStatusLabel.Text" xml:space="preserve">
+    <value>Obsolete Entries...</value>
+  </data>
+  <data name="this.SkillsStatusLabel.Text" xml:space="preserve">
+    <value>0 Skills Planned</value>
+  </data>
+  <data name="this.TimeStatusLabel.Text" xml:space="preserve">
+    <value>356d 23h 25m 10s</value>
+  </data>
+  <data name="this.CostStatusLabel.Text" xml:space="preserve">
+    <value>0 ISK Required</value>
+  </data>
+  <data name="this.SkillPointsStatusLabel.Text" xml:space="preserve">
+    <value>0 SP Required</value>
+  </data>
+  <data name="this.upperToolStrip.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="this.tsddbPlans.Text" xml:space="preserve">
+    <value>Select Plan</value>
+  </data>
+  <data name="this.newPlanToolStripMenuItem.Text" xml:space="preserve">
+    <value>New Plan...</value>
+  </data>
+  <data name="this.createPlanFromSkillQueueToolStripMenuItem.Text" xml:space="preserve">
+    <value>Create Plan from Skill Queue...</value>
+  </data>
+  <data name="this.tsddbSave.Text" xml:space="preserve">
+    <value>Export</value>
+  </data>
+  <data name="this.tsmiExportPlan.Text" xml:space="preserve">
+    <value>&amp;Plan...</value>
+  </data>
+  <data name="this.tsmiAfterPlanCharacter.Text" xml:space="preserve">
+    <value>After Plan &amp;Character...</value>
+  </data>
+  <data name="this.tsbDeletePlan.Text" xml:space="preserve">
+    <value>Delete...</value>
+  </data>
+  <data name="this.tsbPrintPlan.Text" xml:space="preserve">
+    <value>Print...</value>
+  </data>
+  <data name="this.tsbPrintPlan.ToolTipText" xml:space="preserve">
+    <value>Print this plan</value>
+  </data>
+  <data name="this.tsbCopyToClipboard.Text" xml:space="preserve">
+    <value>Copy to Clipboard...</value>
+  </data>
+  <data name="this.tsbImplantCalculator.Text" xml:space="preserve">
+    <value>Implant Calc...</value>
+  </data>
+  <data name="this.attributesOptimizerStripButton.Text" xml:space="preserve">
+    <value>Attributes Optimizer...</value>
+  </data>
+  <data name="this.tsbLoadoutImport.Text" xml:space="preserve">
+    <value>Loadout Import...</value>
+  </data>
+  <data name="this.tsbClipboardImport.Text" xml:space="preserve">
+    <value>Clipboard Import</value>
+  </data>
+  <data name="this.tsbClipboardImport.ToolTipText" xml:space="preserve">
+    <value>Clipboard Import...</value>
+  </data>
+  <data name="this.sfdSave.Title" xml:space="preserve">
+    <value>Save to File</value>
+  </data>
+  <data name="this.tpPlanEditor.Text" xml:space="preserve">
+    <value>Plan editor</value>
+  </data>
+  <data name="this.tpSkillBrowser.Text" xml:space="preserve">
+    <value>Skill browser</value>
+  </data>
+  <data name="this.tpCertificateBrowser.Text" xml:space="preserve">
+    <value>Certificate browser</value>
+  </data>
+  <data name="this.tpShipBrowser.Text" xml:space="preserve">
+    <value>Ship browser</value>
+  </data>
+  <data name="this.tpItemBrowser.Text" xml:space="preserve">
+    <value>Item browser</value>
+  </data>
+  <data name="this.tpBlueprintBrowser.Text" xml:space="preserve">
+    <value>Blueprint browser</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>EVEMon Skill Planner</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/PlanWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/PlanWindow.zh-CN.resx
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.ObsoleteEntriesStatusLabel.Text" xml:space="preserve">
+    <value>过时的条目...</value>
+  </data>
+  <data name="this.SkillsStatusLabel.Text" xml:space="preserve">
+    <value>0 计划技能</value>
+  </data>
+  <data name="this.TimeStatusLabel.Text" xml:space="preserve">
+    <value>356d 23h 25m 10s</value>
+  </data>
+  <data name="this.CostStatusLabel.Text" xml:space="preserve">
+    <value>需要 0 ISK</value>
+  </data>
+  <data name="this.SkillPointsStatusLabel.Text" xml:space="preserve">
+    <value>需要 0 SP</value>
+  </data>
+  <data name="this.upperToolStrip.Text" xml:space="preserve">
+    <value>工具条1</value>
+  </data>
+  <data name="this.tsddbPlans.Text" xml:space="preserve">
+    <value>选择计划</value>
+  </data>
+  <data name="this.newPlanToolStripMenuItem.Text" xml:space="preserve">
+    <value>新计划...</value>
+  </data>
+  <data name="this.createPlanFromSkillQueueToolStripMenuItem.Text" xml:space="preserve">
+    <value>从技能队列创建计划...</value>
+  </data>
+  <data name="this.tsddbSave.Text" xml:space="preserve">
+    <value>出口</value>
+  </data>
+  <data name="this.tsmiExportPlan.Text" xml:space="preserve">
+    <value>计划(&amp;P)...</value>
+  </data>
+  <data name="this.tsmiAfterPlanCharacter.Text" xml:space="preserve">
+    <value>计划和角色之后...</value>
+  </data>
+  <data name="this.tsbDeletePlan.Text" xml:space="preserve">
+    <value>删除...</value>
+  </data>
+  <data name="this.tsbPrintPlan.Text" xml:space="preserve">
+    <value>打印...</value>
+  </data>
+  <data name="this.tsbPrintPlan.ToolTipText" xml:space="preserve">
+    <value>打印此计划</value>
+  </data>
+  <data name="this.tsbCopyToClipboard.Text" xml:space="preserve">
+    <value>复制到剪贴板...</value>
+  </data>
+  <data name="this.tsbImplantCalculator.Text" xml:space="preserve">
+    <value>种植体计算...</value>
+  </data>
+  <data name="this.attributesOptimizerStripButton.Text" xml:space="preserve">
+    <value>属性优化器...</value>
+  </data>
+  <data name="this.tsbLoadoutImport.Text" xml:space="preserve">
+    <value>装载导入...</value>
+  </data>
+  <data name="this.tsbClipboardImport.Text" xml:space="preserve">
+    <value>剪贴板导入</value>
+  </data>
+  <data name="this.tsbClipboardImport.ToolTipText" xml:space="preserve">
+    <value>剪贴板导入...</value>
+  </data>
+  <data name="this.sfdSave.Title" xml:space="preserve">
+    <value>保存到文件</value>
+  </data>
+  <data name="this.tpPlanEditor.Text" xml:space="preserve">
+    <value>计划编辑</value>
+  </data>
+  <data name="this.tpSkillBrowser.Text" xml:space="preserve">
+    <value>技能浏览器</value>
+  </data>
+  <data name="this.tpCertificateBrowser.Text" xml:space="preserve">
+    <value>证书浏览器</value>
+  </data>
+  <data name="this.tpShipBrowser.Text" xml:space="preserve">
+    <value>船舶浏览器</value>
+  </data>
+  <data name="this.tpItemBrowser.Text" xml:space="preserve">
+    <value>项目浏览器</value>
+  </data>
+  <data name="this.tpBlueprintBrowser.Text" xml:space="preserve">
+    <value>蓝图浏览器</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>EVEMon技能规划师</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/RequiredSkillsControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/RequiredSkillsControl.Designer.cs
@@ -62,7 +62,7 @@ namespace EVEMon.SkillPlanner
             this.btnAddSkills.Name = "btnAddSkills";
             this.btnAddSkills.Size = new System.Drawing.Size(88, 23);
             this.btnAddSkills.TabIndex = 0;
-            this.btnAddSkills.Text = "Add All To Plan";
+            this.btnAddSkills.Text = resources.GetString("this.btnAddSkills.Text");
             this.btnAddSkills.UseVisualStyleBackColor = true;
             this.btnAddSkills.Click += new System.EventHandler(this.btnAddSkills_Click);
             // 
@@ -84,7 +84,7 @@ namespace EVEMon.SkillPlanner
             this.lblTimeRequired.Name = "lblTimeRequired";
             this.lblTimeRequired.Size = new System.Drawing.Size(71, 13);
             this.lblTimeRequired.TabIndex = 1;
-            this.lblTimeRequired.Text = "Time required";
+            this.lblTimeRequired.Text = resources.GetString("this.lblTimeRequired.Text");
             // 
             // panel2
             // 
@@ -121,48 +121,48 @@ namespace EVEMon.SkillPlanner
             this.planToMenu.Image = ((System.Drawing.Image)(resources.GetObject("planToMenu.Image")));
             this.planToMenu.Name = "planToMenu";
             this.planToMenu.Size = new System.Drawing.Size(194, 22);
-            this.planToMenu.Text = "&Plan to...";
+            this.planToMenu.Text = resources.GetString("this.planToMenu.Text");
             // 
             // level0ToolStripMenuItem
             // 
             this.level0ToolStripMenuItem.Name = "level0ToolStripMenuItem";
             this.level0ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level0ToolStripMenuItem.Text = "&Remove";
+            this.level0ToolStripMenuItem.Text = resources.GetString("this.level0ToolStripMenuItem.Text");
             this.level0ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // level1ToolStripMenuItem
             // 
             this.level1ToolStripMenuItem.Name = "level1ToolStripMenuItem";
             this.level1ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level1ToolStripMenuItem.Text = "Level &1";
+            this.level1ToolStripMenuItem.Text = resources.GetString("this.level1ToolStripMenuItem.Text");
             this.level1ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // level2ToolStripMenuItem
             // 
             this.level2ToolStripMenuItem.Name = "level2ToolStripMenuItem";
             this.level2ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level2ToolStripMenuItem.Text = "Level &2";
+            this.level2ToolStripMenuItem.Text = resources.GetString("this.level2ToolStripMenuItem.Text");
             this.level2ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // level3ToolStripMenuItem
             // 
             this.level3ToolStripMenuItem.Name = "level3ToolStripMenuItem";
             this.level3ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level3ToolStripMenuItem.Text = "Level &3";
+            this.level3ToolStripMenuItem.Text = resources.GetString("this.level3ToolStripMenuItem.Text");
             this.level3ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // level4ToolStripMenuItem
             // 
             this.level4ToolStripMenuItem.Name = "level4ToolStripMenuItem";
             this.level4ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level4ToolStripMenuItem.Text = "Level &4";
+            this.level4ToolStripMenuItem.Text = resources.GetString("this.level4ToolStripMenuItem.Text");
             this.level4ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // level5ToolStripMenuItem
             // 
             this.level5ToolStripMenuItem.Name = "level5ToolStripMenuItem";
             this.level5ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level5ToolStripMenuItem.Text = "Level &5";
+            this.level5ToolStripMenuItem.Text = resources.GetString("this.level5ToolStripMenuItem.Text");
             this.level5ToolStripMenuItem.Click += new System.EventHandler(this.planToMenuItem_Click);
             // 
             // showInMenuSeparator
@@ -174,7 +174,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillBrowserMenu.Name = "showInSkillBrowserMenu";
             this.showInSkillBrowserMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillBrowserMenu.Text = "Show in Skill &Browser";
+            this.showInSkillBrowserMenu.Text = resources.GetString("this.showInSkillBrowserMenu.Text");
             this.showInSkillBrowserMenu.Click += new System.EventHandler(this.showInSkillBrowserMenu_Click);
             // 
             // showInSkillExplorerMenu
@@ -182,7 +182,7 @@ namespace EVEMon.SkillPlanner
             this.showInSkillExplorerMenu.Image = ((System.Drawing.Image)(resources.GetObject("showInSkillExplorerMenu.Image")));
             this.showInSkillExplorerMenu.Name = "showInSkillExplorerMenu";
             this.showInSkillExplorerMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillExplorerMenu.Text = "Show in Skill &Explorer...";
+            this.showInSkillExplorerMenu.Text = resources.GetString("this.showInSkillExplorerMenu.Text");
             this.showInSkillExplorerMenu.Click += new System.EventHandler(this.showInSkillExplorerMenu_Click);
             // 
             // tsSeparatorBrowser
@@ -194,14 +194,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.tsmExpand.Name = "tsmExpand";
             this.tsmExpand.Size = new System.Drawing.Size(194, 22);
-            this.tsmExpand.Text = "&Expand all";
+            this.tsmExpand.Text = resources.GetString("this.tsmExpand.Text");
             this.tsmExpand.Click += new System.EventHandler(this.tsmExpandAll_Click);
             // 
             // tsmCollapse
             // 
             this.tsmCollapse.Name = "tsmCollapse";
             this.tsmCollapse.Size = new System.Drawing.Size(194, 22);
-            this.tsmCollapse.Text = "&Collapse all";
+            this.tsmCollapse.Text = resources.GetString("this.tsmCollapse.Text");
             this.tsmCollapse.Click += new System.EventHandler(this.tsmCollapseAll_Click);
             // 
             // ilIcons

--- a/src/EVEMon/SkillPlanner/RequiredSkillsControl.resx
+++ b/src/EVEMon/SkillPlanner/RequiredSkillsControl.resx
@@ -218,4 +218,43 @@
         Bv8BwAEDBv8BwAEHAv8L
 </value>
   </data>
+  <data name="this.btnAddSkills.Text" xml:space="preserve">
+    <value>Add All To Plan</value>
+  </data>
+  <data name="this.lblTimeRequired.Text" xml:space="preserve">
+    <value>Time required</value>
+  </data>
+  <data name="this.planToMenu.Text" xml:space="preserve">
+    <value>&amp;Plan to...</value>
+  </data>
+  <data name="this.level0ToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="this.level1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;1</value>
+  </data>
+  <data name="this.level2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;2</value>
+  </data>
+  <data name="this.level3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;3</value>
+  </data>
+  <data name="this.level4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;4</value>
+  </data>
+  <data name="this.level5ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;5</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.tsmExpand.Text" xml:space="preserve">
+    <value>&amp;Expand all</value>
+  </data>
+  <data name="this.tsmCollapse.Text" xml:space="preserve">
+    <value>&amp;Collapse all</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/RequiredSkillsControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/RequiredSkillsControl.zh-CN.resx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.btnAddSkills.Text" xml:space="preserve">
+    <value>全部添加到计划</value>
+  </data>
+  <data name="this.lblTimeRequired.Text" xml:space="preserve">
+    <value>所需时间</value>
+  </data>
+  <data name="this.planToMenu.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.level0ToolStripMenuItem.Text" xml:space="preserve">
+    <value>删除(&amp;R)</value>
+  </data>
+  <data name="this.level1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;1</value>
+  </data>
+  <data name="this.level2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;2</value>
+  </data>
+  <data name="this.level3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;3</value>
+  </data>
+  <data name="this.level4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.level5ToolStripMenuItem.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.tsmExpand.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.tsmCollapse.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ShipBrowserControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/ShipBrowserControl.Designer.cs
@@ -150,7 +150,7 @@ namespace EVEMon.SkillPlanner
             this.gbAttributes.Size = new System.Drawing.Size(339, 410);
             this.gbAttributes.TabIndex = 4;
             this.gbAttributes.TabStop = false;
-            this.gbAttributes.Text = "Attributes";
+            this.gbAttributes.Text = resources.GetString("this.gbAttributes.Text");
             // 
             // lvShipProperties
             // 
@@ -171,12 +171,12 @@ namespace EVEMon.SkillPlanner
             // 
             // chAttribute
             // 
-            this.chAttribute.Text = "Attribute";
+            this.chAttribute.Text = resources.GetString("this.chAttribute.Text");
             this.chAttribute.Width = 120;
             // 
             // chValue
             // 
-            this.chValue.Text = "Value";
+            this.chValue.Text = resources.GetString("this.chValue.Text");
             this.chValue.Width = 120;
             // 
             // ShipAttributeContextMenu
@@ -194,7 +194,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.exportToCSVToolStripMenuItem.Name = "exportToCSVToolStripMenuItem";
             this.exportToCSVToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.exportToCSVToolStripMenuItem.Text = "Export To CSV...";
+            this.exportToCSVToolStripMenuItem.Text = resources.GetString("this.exportToCSVToolStripMenuItem.Text");
             this.exportToCSVToolStripMenuItem.Click += new System.EventHandler(this.exportToCSVToolStripMenuItem_Click);
             // 
             // shipSelectControl
@@ -217,7 +217,7 @@ namespace EVEMon.SkillPlanner
             this.gbRequiredSkills.Size = new System.Drawing.Size(240, 108);
             this.gbRequiredSkills.TabIndex = 0;
             this.gbRequiredSkills.TabStop = false;
-            this.gbRequiredSkills.Text = "Required Skills";
+            this.gbRequiredSkills.Text = resources.GetString("this.gbRequiredSkills.Text");
             // 
             // requiredSkillsControl
             // 
@@ -247,7 +247,7 @@ namespace EVEMon.SkillPlanner
             this.tbPgShipDetails.Padding = new System.Windows.Forms.Padding(3);
             this.tbPgShipDetails.Size = new System.Drawing.Size(345, 416);
             this.tbPgShipDetails.TabIndex = 0;
-            this.tbPgShipDetails.Text = "Overview";
+            this.tbPgShipDetails.Text = resources.GetString("this.tbPgShipDetails.Text");
             this.tbPgShipDetails.UseVisualStyleBackColor = true;
             // 
             // tbPgShipMastery
@@ -258,7 +258,7 @@ namespace EVEMon.SkillPlanner
             this.tbPgShipMastery.Padding = new System.Windows.Forms.Padding(3);
             this.tbPgShipMastery.Size = new System.Drawing.Size(230, 317);
             this.tbPgShipMastery.TabIndex = 1;
-            this.tbPgShipMastery.Text = "Mastery";
+            this.tbPgShipMastery.Text = resources.GetString("this.tbPgShipMastery.Text");
             this.tbPgShipMastery.UseVisualStyleBackColor = true;
             // 
             // pnlMastery
@@ -291,19 +291,19 @@ namespace EVEMon.SkillPlanner
             this.tlStrpPlanTo.Name = "tlStrpPlanTo";
             this.tlStrpPlanTo.Size = new System.Drawing.Size(224, 25);
             this.tlStrpPlanTo.TabIndex = 1;
-            this.tlStrpPlanTo.Text = "toolStrip1";
+            this.tlStrpPlanTo.Text = resources.GetString("this.tlStrpPlanTo.Text");
             // 
             // tslbTextForEligibility
             // 
             this.tslbTextForEligibility.Name = "tslbTextForEligibility";
             this.tslbTextForEligibility.Size = new System.Drawing.Size(202, 22);
-            this.tslbTextForEligibility.Text = "After this plan you will be eligible to :";
+            this.tslbTextForEligibility.Text = resources.GetString("this.tslbTextForEligibility.Text");
             // 
             // tslbEligible
             // 
             this.tslbEligible.Name = "tslbEligible";
             this.tslbEligible.Size = new System.Drawing.Size(34, 22);
-            this.tslbEligible.Text = "none";
+            this.tslbEligible.Text = resources.GetString("this.tslbEligible.Text");
             // 
             // tsPlanToMenu
             // 
@@ -317,41 +317,41 @@ namespace EVEMon.SkillPlanner
             this.tsPlanToMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.tsPlanToMenu.Name = "tsPlanToMenu";
             this.tsPlanToMenu.Size = new System.Drawing.Size(84, 22);
-            this.tsPlanToMenu.Text = "Plan To...";
+            this.tsPlanToMenu.Text = resources.GetString("this.tsPlanToMenu.Text");
             // 
             // tsPlanToLevelOne
             // 
             this.tsPlanToLevelOne.Name = "tsPlanToLevelOne";
             this.tsPlanToLevelOne.Size = new System.Drawing.Size(114, 22);
-            this.tsPlanToLevelOne.Text = "&Level I";
+            this.tsPlanToLevelOne.Text = resources.GetString("this.tsPlanToLevelOne.Text");
             this.tsPlanToLevelOne.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelTwo
             // 
             this.tsPlanToLevelTwo.Name = "tsPlanToLevelTwo";
             this.tsPlanToLevelTwo.Size = new System.Drawing.Size(114, 22);
-            this.tsPlanToLevelTwo.Text = "&Level II";
+            this.tsPlanToLevelTwo.Text = resources.GetString("this.tsPlanToLevelTwo.Text");
             this.tsPlanToLevelTwo.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelThree
             // 
             this.tsPlanToLevelThree.Name = "tsPlanToLevelThree";
             this.tsPlanToLevelThree.Size = new System.Drawing.Size(114, 22);
-            this.tsPlanToLevelThree.Text = "&Level III";
+            this.tsPlanToLevelThree.Text = resources.GetString("this.tsPlanToLevelThree.Text");
             this.tsPlanToLevelThree.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelFour
             // 
             this.tsPlanToLevelFour.Name = "tsPlanToLevelFour";
             this.tsPlanToLevelFour.Size = new System.Drawing.Size(114, 22);
-            this.tsPlanToLevelFour.Text = "&Level IV";
+            this.tsPlanToLevelFour.Text = resources.GetString("this.tsPlanToLevelFour.Text");
             this.tsPlanToLevelFour.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // tsPlanToLevelFive
             // 
             this.tsPlanToLevelFive.Name = "tsPlanToLevelFive";
             this.tsPlanToLevelFive.Size = new System.Drawing.Size(114, 22);
-            this.tsPlanToLevelFive.Text = "&Level V";
+            this.tsPlanToLevelFive.Text = resources.GetString("this.tsPlanToLevelFive.Text");
             this.tsPlanToLevelFive.Click += new System.EventHandler(this.tsPlanToLevel_Click);
             // 
             // splitButtonLoadouts
@@ -362,7 +362,7 @@ namespace EVEMon.SkillPlanner
             this.splitButtonLoadouts.Name = "splitButtonLoadouts";
             this.splitButtonLoadouts.Size = new System.Drawing.Size(97, 23);
             this.splitButtonLoadouts.TabIndex = 12;
-            this.splitButtonLoadouts.Text = "Select provider";
+            this.splitButtonLoadouts.Text = resources.GetString("this.splitButtonLoadouts.Text");
             this.splitButtonLoadouts.UseVisualStyleBackColor = true;
             this.splitButtonLoadouts.Click += new System.EventHandler(this.splitButtonLoadouts_Click);
             // 
@@ -378,7 +378,7 @@ namespace EVEMon.SkillPlanner
             this.lblViewLoadouts.Name = "lblViewLoadouts";
             this.lblViewLoadouts.Size = new System.Drawing.Size(99, 13);
             this.lblViewLoadouts.TabIndex = 13;
-            this.lblViewLoadouts.Text = "View loadouts from:";
+            this.lblViewLoadouts.Text = resources.GetString("this.lblViewLoadouts.Text");
             // 
             // showInMenuSeparator
             // 
@@ -389,14 +389,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillBrowser.Name = "showInSkillBrowser";
             this.showInSkillBrowser.Size = new System.Drawing.Size(188, 22);
-            this.showInSkillBrowser.Text = "Show In Skill Browser";
+            this.showInSkillBrowser.Text = resources.GetString("this.showInSkillBrowser.Text");
             this.showInSkillBrowser.Click += new System.EventHandler(this.propertiesList_DoubleClick);
             // 
             // showInItemBrowser
             // 
             this.showInItemBrowser.Name = "showInItemBrowser";
             this.showInItemBrowser.Size = new System.Drawing.Size(188, 22);
-            this.showInItemBrowser.Text = "Show In Item Browser";
+            this.showInItemBrowser.Text = resources.GetString("this.showInItemBrowser.Text");
             this.showInItemBrowser.Click += new System.EventHandler(this.propertiesList_DoubleClick);
             // 
             // ShipBrowserControl

--- a/src/EVEMon/SkillPlanner/ShipBrowserControl.resx
+++ b/src/EVEMon/SkillPlanner/ShipBrowserControl.resx
@@ -145,4 +145,64 @@
         vJnCVUkPit+NorRLhWsDOtxSmHGPzk6QFRQV/QFZaUl1TyHaOQAAAABJRU5ErkJggg==
 </value>
   </data>
+  <data name="this.gbAttributes.Text" xml:space="preserve">
+    <value>Attributes</value>
+  </data>
+  <data name="this.chAttribute.Text" xml:space="preserve">
+    <value>Attribute</value>
+  </data>
+  <data name="this.chValue.Text" xml:space="preserve">
+    <value>Value</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>Export To CSV...</value>
+  </data>
+  <data name="this.gbRequiredSkills.Text" xml:space="preserve">
+    <value>Required Skills</value>
+  </data>
+  <data name="this.tbPgShipDetails.Text" xml:space="preserve">
+    <value>Overview</value>
+  </data>
+  <data name="this.tbPgShipMastery.Text" xml:space="preserve">
+    <value>Mastery</value>
+  </data>
+  <data name="this.tlStrpPlanTo.Text" xml:space="preserve">
+    <value>toolStrip1</value>
+  </data>
+  <data name="this.tslbTextForEligibility.Text" xml:space="preserve">
+    <value>After this plan you will be eligible to :</value>
+  </data>
+  <data name="this.tslbEligible.Text" xml:space="preserve">
+    <value>none</value>
+  </data>
+  <data name="this.tsPlanToMenu.Text" xml:space="preserve">
+    <value>Plan To...</value>
+  </data>
+  <data name="this.tsPlanToLevelOne.Text" xml:space="preserve">
+    <value>&amp;Level I</value>
+  </data>
+  <data name="this.tsPlanToLevelTwo.Text" xml:space="preserve">
+    <value>&amp;Level II</value>
+  </data>
+  <data name="this.tsPlanToLevelThree.Text" xml:space="preserve">
+    <value>&amp;Level III</value>
+  </data>
+  <data name="this.tsPlanToLevelFour.Text" xml:space="preserve">
+    <value>&amp;Level IV</value>
+  </data>
+  <data name="this.tsPlanToLevelFive.Text" xml:space="preserve">
+    <value>&amp;Level V</value>
+  </data>
+  <data name="this.splitButtonLoadouts.Text" xml:space="preserve">
+    <value>Select provider</value>
+  </data>
+  <data name="this.lblViewLoadouts.Text" xml:space="preserve">
+    <value>View loadouts from:</value>
+  </data>
+  <data name="this.showInSkillBrowser.Text" xml:space="preserve">
+    <value>Show In Skill Browser</value>
+  </data>
+  <data name="this.showInItemBrowser.Text" xml:space="preserve">
+    <value>Show In Item Browser</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/ShipBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ShipBrowserControl.zh-CN.resx
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.gbAttributes.Text" xml:space="preserve">
+    <value>属性</value>
+  </data>
+  <data name="this.chAttribute.Text" xml:space="preserve">
+    <value>属性</value>
+  </data>
+  <data name="this.chValue.Text" xml:space="preserve">
+    <value>价值</value>
+  </data>
+  <data name="this.exportToCSVToolStripMenuItem.Text" xml:space="preserve">
+    <value>导出至 CSV...</value>
+  </data>
+  <data name="this.gbRequiredSkills.Text" xml:space="preserve">
+    <value>所需技能</value>
+  </data>
+  <data name="this.tbPgShipDetails.Text" xml:space="preserve">
+    <value>概述</value>
+  </data>
+  <data name="this.tbPgShipMastery.Text" xml:space="preserve">
+    <value>精通</value>
+  </data>
+  <data name="this.tlStrpPlanTo.Text" xml:space="preserve">
+    <value>工具条1</value>
+  </data>
+  <data name="this.tslbTextForEligibility.Text" xml:space="preserve">
+    <value>完成此计划后，您将有资格：</value>
+  </data>
+  <data name="this.tslbEligible.Text" xml:space="preserve">
+    <value>无</value>
+  </data>
+  <data name="this.tsPlanToMenu.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.tsPlanToLevelOne.Text" xml:space="preserve">
+    <value>一级(&amp;I)</value>
+  </data>
+  <data name="this.tsPlanToLevelTwo.Text" xml:space="preserve">
+    <value>二级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelThree.Text" xml:space="preserve">
+    <value>三级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelFour.Text" xml:space="preserve">
+    <value>四级(&amp;L)</value>
+  </data>
+  <data name="this.tsPlanToLevelFive.Text" xml:space="preserve">
+    <value>V级(&amp;V)</value>
+  </data>
+  <data name="this.splitButtonLoadouts.Text" xml:space="preserve">
+    <value>选择提供商</value>
+  </data>
+  <data name="this.lblViewLoadouts.Text" xml:space="preserve">
+    <value>查看负载：</value>
+  </data>
+  <data name="this.showInSkillBrowser.Text" xml:space="preserve">
+    <value>在技能浏览器中显示</value>
+  </data>
+  <data name="this.showInItemBrowser.Text" xml:space="preserve">
+    <value>在项目浏览器中显示</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.Designer.cs
@@ -88,7 +88,7 @@ namespace EVEMon.SkillPlanner
             this.lblLoadouts.Name = "lblLoadouts";
             this.lblLoadouts.Size = new System.Drawing.Size(101, 13);
             this.lblLoadouts.TabIndex = 1;
-            this.lblLoadouts.Text = "Found {0} Loadouts";
+            this.lblLoadouts.Text = resources.GetString("this.lblLoadouts.Text");
             // 
             // btnCancel
             // 
@@ -98,7 +98,7 @@ namespace EVEMon.SkillPlanner
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(75, 23);
             this.btnCancel.TabIndex = 3;
-            this.btnCancel.Text = "Close";
+            this.btnCancel.Text = resources.GetString("this.btnCancel.Text");
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
@@ -160,22 +160,22 @@ namespace EVEMon.SkillPlanner
             // 
             // colName
             // 
-            this.colName.Text = "Name";
+            this.colName.Text = resources.GetString("this.colName.Text");
             this.colName.Width = 153;
             // 
             // colAuthor
             // 
-            this.colAuthor.Text = "Author";
+            this.colAuthor.Text = resources.GetString("this.colAuthor.Text");
             this.colAuthor.Width = 68;
             // 
             // colRating
             // 
-            this.colRating.Text = "Rating";
+            this.colRating.Text = resources.GetString("this.colRating.Text");
             this.colRating.Width = 56;
             // 
             // colDate
             // 
-            this.colDate.Text = "Date";
+            this.colDate.Text = resources.GetString("this.colDate.Text");
             this.colDate.Width = 90;
             // 
             // ilIcons
@@ -231,7 +231,7 @@ namespace EVEMon.SkillPlanner
             this.lblSubmitDate.Name = "lblSubmitDate";
             this.lblSubmitDate.Size = new System.Drawing.Size(62, 13);
             this.lblSubmitDate.TabIndex = 25;
-            this.lblSubmitDate.Text = "SubmitDate";
+            this.lblSubmitDate.Text = resources.GetString("this.lblSubmitDate.Text");
             // 
             // SubDateLabel
             // 
@@ -240,7 +240,7 @@ namespace EVEMon.SkillPlanner
             this.SubDateLabel.Name = "SubDateLabel";
             this.SubDateLabel.Size = new System.Drawing.Size(89, 13);
             this.SubDateLabel.TabIndex = 24;
-            this.SubDateLabel.Text = "Submission Date:";
+            this.SubDateLabel.Text = resources.GetString("this.SubDateLabel.Text");
             // 
             // AuthorLabel
             // 
@@ -249,7 +249,7 @@ namespace EVEMon.SkillPlanner
             this.AuthorLabel.Name = "AuthorLabel";
             this.AuthorLabel.Size = new System.Drawing.Size(41, 13);
             this.AuthorLabel.TabIndex = 22;
-            this.AuthorLabel.Text = "Author:";
+            this.AuthorLabel.Text = resources.GetString("this.AuthorLabel.Text");
             // 
             // LoadoutNameLabel
             // 
@@ -258,7 +258,7 @@ namespace EVEMon.SkillPlanner
             this.LoadoutNameLabel.Name = "LoadoutNameLabel";
             this.LoadoutNameLabel.Size = new System.Drawing.Size(80, 13);
             this.LoadoutNameLabel.TabIndex = 21;
-            this.LoadoutNameLabel.Text = "Loadout Name:";
+            this.LoadoutNameLabel.Text = resources.GetString("this.LoadoutNameLabel.Text");
             // 
             // ShipLabel
             // 
@@ -267,7 +267,7 @@ namespace EVEMon.SkillPlanner
             this.ShipLabel.Name = "ShipLabel";
             this.ShipLabel.Size = new System.Drawing.Size(31, 13);
             this.ShipLabel.TabIndex = 20;
-            this.ShipLabel.Text = "Ship:";
+            this.ShipLabel.Text = resources.GetString("this.ShipLabel.Text");
             // 
             // lblAuthor
             // 
@@ -276,7 +276,7 @@ namespace EVEMon.SkillPlanner
             this.lblAuthor.Name = "lblAuthor";
             this.lblAuthor.Size = new System.Drawing.Size(66, 13);
             this.lblAuthor.TabIndex = 19;
-            this.lblAuthor.Text = "AuthorName";
+            this.lblAuthor.Text = resources.GetString("this.lblAuthor.Text");
             // 
             // lblLoadoutName
             // 
@@ -285,7 +285,7 @@ namespace EVEMon.SkillPlanner
             this.lblLoadoutName.Name = "lblLoadoutName";
             this.lblLoadoutName.Size = new System.Drawing.Size(74, 13);
             this.lblLoadoutName.TabIndex = 18;
-            this.lblLoadoutName.Text = "LoadoutName";
+            this.lblLoadoutName.Text = resources.GetString("this.lblLoadoutName.Text");
             // 
             // lblShipName
             // 
@@ -294,7 +294,7 @@ namespace EVEMon.SkillPlanner
             this.lblShipName.Name = "lblShipName";
             this.lblShipName.Size = new System.Drawing.Size(56, 13);
             this.lblShipName.TabIndex = 17;
-            this.lblShipName.Text = "ShipName";
+            this.lblShipName.Text = resources.GetString("this.lblShipName.Text");
             // 
             // lblPlanned
             // 
@@ -313,7 +313,7 @@ namespace EVEMon.SkillPlanner
             this.TrainingTimeLabel.Name = "TrainingTimeLabel";
             this.TrainingTimeLabel.Size = new System.Drawing.Size(173, 13);
             this.TrainingTimeLabel.TabIndex = 26;
-            this.TrainingTimeLabel.Text = "Training Time for selected loadout: ";
+            this.TrainingTimeLabel.Text = resources.GetString("this.TrainingTimeLabel.Text");
             // 
             // lblTrainTime
             // 
@@ -323,7 +323,7 @@ namespace EVEMon.SkillPlanner
             this.lblTrainTime.Name = "lblTrainTime";
             this.lblTrainTime.Size = new System.Drawing.Size(27, 13);
             this.lblTrainTime.TabIndex = 27;
-            this.lblTrainTime.Text = "N/A";
+            this.lblTrainTime.Text = resources.GetString("this.lblTrainTime.Text");
             // 
             // btnPlan
             // 
@@ -333,7 +333,7 @@ namespace EVEMon.SkillPlanner
             this.btnPlan.Name = "btnPlan";
             this.btnPlan.Size = new System.Drawing.Size(75, 23);
             this.btnPlan.TabIndex = 29;
-            this.btnPlan.Text = "Add To Plan";
+            this.btnPlan.Text = resources.GetString("this.btnPlan.Text");
             this.btnPlan.UseVisualStyleBackColor = true;
             this.btnPlan.Click += new System.EventHandler(this.btnPlan_Click);
             // 
@@ -357,7 +357,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.miShowInBrowser.Name = "miShowInBrowser";
             this.miShowInBrowser.Size = new System.Drawing.Size(225, 22);
-            this.miShowInBrowser.Text = "Show in Item Browser...";
+            this.miShowInBrowser.Text = resources.GetString("this.miShowInBrowser.Text");
             this.miShowInBrowser.Click += new System.EventHandler(this.tvLoadout_DoubleClick);
             // 
             // showInMenuSeparator
@@ -369,7 +369,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.miExportToClipboard.Name = "miExportToClipboard";
             this.miExportToClipboard.Size = new System.Drawing.Size(225, 22);
-            this.miExportToClipboard.Text = "Copy Loadout To Clipboard";
+            this.miExportToClipboard.Text = resources.GetString("this.miExportToClipboard.Text");
             this.miExportToClipboard.Click += new System.EventHandler(this.miExportToClipboard_Click);
             // 
             // exportLoadoutSeparator
@@ -381,14 +381,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandSelected.Name = "cmiExpandSelected";
             this.cmiExpandSelected.Size = new System.Drawing.Size(225, 22);
-            this.cmiExpandSelected.Text = "Expand Selected";
+            this.cmiExpandSelected.Text = resources.GetString("this.cmiExpandSelected.Text");
             this.cmiExpandSelected.Click += new System.EventHandler(this.cmiExpandSelected_Click);
             // 
             // cmiCollapseSelected
             // 
             this.cmiCollapseSelected.Name = "cmiCollapseSelected";
             this.cmiCollapseSelected.Size = new System.Drawing.Size(225, 22);
-            this.cmiCollapseSelected.Text = "Collapse Selected";
+            this.cmiCollapseSelected.Text = resources.GetString("this.cmiCollapseSelected.Text");
             this.cmiCollapseSelected.Click += new System.EventHandler(this.cmiCollapseSelected_Click);
             // 
             // selectedSeparator
@@ -400,14 +400,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandAll.Name = "cmiExpandAll";
             this.cmiExpandAll.Size = new System.Drawing.Size(225, 22);
-            this.cmiExpandAll.Text = "&Expand All";
+            this.cmiExpandAll.Text = resources.GetString("this.cmiExpandAll.Text");
             this.cmiExpandAll.Click += new System.EventHandler(this.cmiExpandAll_Click);
             // 
             // cmiCollapseAll
             // 
             this.cmiCollapseAll.Name = "cmiCollapseAll";
             this.cmiCollapseAll.Size = new System.Drawing.Size(225, 22);
-            this.cmiCollapseAll.Text = "&Collapse All";
+            this.cmiCollapseAll.Text = resources.GetString("this.cmiCollapseAll.Text");
             this.cmiCollapseAll.Click += new System.EventHandler(this.cmiCollapseAll_Click);
             // 
             // eveImage
@@ -426,7 +426,7 @@ namespace EVEMon.SkillPlanner
             this.buttonForumTopic.Name = "buttonForumTopic";
             this.buttonForumTopic.Size = new System.Drawing.Size(109, 23);
             this.buttonForumTopic.TabIndex = 31;
-            this.buttonForumTopic.Text = "Discuss this loadout";
+            this.buttonForumTopic.Text = resources.GetString("this.buttonForumTopic.Text");
             this.buttonForumTopic.UseVisualStyleBackColor = true;
             this.buttonForumTopic.Click += new System.EventHandler(this.buttonForumTopic_Click);
             // 
@@ -454,7 +454,7 @@ namespace EVEMon.SkillPlanner
             this.MinimumSize = new System.Drawing.Size(744, 544);
             this.Name = "ShipLoadoutSelectWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Loadout Selection";
+            this.Text = resources.GetString("this.Text");
             this.lowerPanel.ResumeLayout(false);
             this.persistentSplitContainer.Panel1.ResumeLayout(false);
             this.persistentSplitContainer.Panel2.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.resx
+++ b/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.resx
@@ -134,4 +134,79 @@
   <metadata name="contextMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <data name="this.lblLoadouts.Text" xml:space="preserve">
+    <value>Found {0} Loadouts</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="this.colName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="this.colAuthor.Text" xml:space="preserve">
+    <value>Author</value>
+  </data>
+  <data name="this.colRating.Text" xml:space="preserve">
+    <value>Rating</value>
+  </data>
+  <data name="this.colDate.Text" xml:space="preserve">
+    <value>Date</value>
+  </data>
+  <data name="this.lblSubmitDate.Text" xml:space="preserve">
+    <value>SubmitDate</value>
+  </data>
+  <data name="this.SubDateLabel.Text" xml:space="preserve">
+    <value>Submission Date:</value>
+  </data>
+  <data name="this.AuthorLabel.Text" xml:space="preserve">
+    <value>Author:</value>
+  </data>
+  <data name="this.LoadoutNameLabel.Text" xml:space="preserve">
+    <value>Loadout Name:</value>
+  </data>
+  <data name="this.ShipLabel.Text" xml:space="preserve">
+    <value>Ship:</value>
+  </data>
+  <data name="this.lblAuthor.Text" xml:space="preserve">
+    <value>AuthorName</value>
+  </data>
+  <data name="this.lblLoadoutName.Text" xml:space="preserve">
+    <value>LoadoutName</value>
+  </data>
+  <data name="this.lblShipName.Text" xml:space="preserve">
+    <value>ShipName</value>
+  </data>
+  <data name="this.TrainingTimeLabel.Text" xml:space="preserve">
+    <value>Training Time for selected loadout: </value>
+  </data>
+  <data name="this.lblTrainTime.Text" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="this.btnPlan.Text" xml:space="preserve">
+    <value>Add To Plan</value>
+  </data>
+  <data name="this.miShowInBrowser.Text" xml:space="preserve">
+    <value>Show in Item Browser...</value>
+  </data>
+  <data name="this.miExportToClipboard.Text" xml:space="preserve">
+    <value>Copy Loadout To Clipboard</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
+  <data name="this.buttonForumTopic.Text" xml:space="preserve">
+    <value>Discuss this loadout</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Loadout Selection</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ShipLoadoutSelectWindow.zh-CN.resx
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.lblLoadouts.Text" xml:space="preserve">
+    <value>找到 {0} 个负载</value>
+  </data>
+  <data name="this.btnCancel.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.colName.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="this.colAuthor.Text" xml:space="preserve">
+    <value>作者</value>
+  </data>
+  <data name="this.colRating.Text" xml:space="preserve">
+    <value>评级</value>
+  </data>
+  <data name="this.colDate.Text" xml:space="preserve">
+    <value>日期</value>
+  </data>
+  <data name="this.lblSubmitDate.Text" xml:space="preserve">
+    <value>提交日期</value>
+  </data>
+  <data name="this.SubDateLabel.Text" xml:space="preserve">
+    <value>提交日期：</value>
+  </data>
+  <data name="this.AuthorLabel.Text" xml:space="preserve">
+    <value>作者：</value>
+  </data>
+  <data name="this.LoadoutNameLabel.Text" xml:space="preserve">
+    <value>装载名称：</value>
+  </data>
+  <data name="this.ShipLabel.Text" xml:space="preserve">
+    <value>船舶：</value>
+  </data>
+  <data name="this.lblAuthor.Text" xml:space="preserve">
+    <value>作者姓名</value>
+  </data>
+  <data name="this.lblLoadoutName.Text" xml:space="preserve">
+    <value>装载名称</value>
+  </data>
+  <data name="this.lblShipName.Text" xml:space="preserve">
+    <value>船名</value>
+  </data>
+  <data name="this.TrainingTimeLabel.Text" xml:space="preserve">
+    <value>所选负载的训练时间： </value>
+  </data>
+  <data name="this.lblTrainTime.Text" xml:space="preserve">
+    <value>N/A</value>
+  </data>
+  <data name="this.btnPlan.Text" xml:space="preserve">
+    <value>添加到计划</value>
+  </data>
+  <data name="this.miShowInBrowser.Text" xml:space="preserve">
+    <value>在项目浏览器中显示...</value>
+  </data>
+  <data name="this.miExportToClipboard.Text" xml:space="preserve">
+    <value>将装载复制到剪贴板</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+  <data name="this.buttonForumTopic.Text" xml:space="preserve">
+    <value>讨论这个加载</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>装载选择</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/ShipSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/ShipSelectControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/SkillBrowserControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/SkillBrowserControl.Designer.cs
@@ -97,42 +97,42 @@ namespace EVEMon.SkillPlanner
             // 
             this.miPlanTo0.Name = "miPlanTo0";
             this.miPlanTo0.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo0.Text = "Remove";
+            this.miPlanTo0.Text = resources.GetString("this.miPlanTo0.Text");
             this.miPlanTo0.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // miPlanTo1
             // 
             this.miPlanTo1.Name = "miPlanTo1";
             this.miPlanTo1.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo1.Text = "Plan to Level 1";
+            this.miPlanTo1.Text = resources.GetString("this.miPlanTo1.Text");
             this.miPlanTo1.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // miPlanTo2
             // 
             this.miPlanTo2.Name = "miPlanTo2";
             this.miPlanTo2.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo2.Text = "Plan to Level 2";
+            this.miPlanTo2.Text = resources.GetString("this.miPlanTo2.Text");
             this.miPlanTo2.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // miPlanTo3
             // 
             this.miPlanTo3.Name = "miPlanTo3";
             this.miPlanTo3.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo3.Text = "Plan to Level 3";
+            this.miPlanTo3.Text = resources.GetString("this.miPlanTo3.Text");
             this.miPlanTo3.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // miPlanTo4
             // 
             this.miPlanTo4.Name = "miPlanTo4";
             this.miPlanTo4.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo4.Text = "Plan to Level 4";
+            this.miPlanTo4.Text = resources.GetString("this.miPlanTo4.Text");
             this.miPlanTo4.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // miPlanTo5
             // 
             this.miPlanTo5.Name = "miPlanTo5";
             this.miPlanTo5.Size = new System.Drawing.Size(150, 22);
-            this.miPlanTo5.Text = "Plan to Level 5";
+            this.miPlanTo5.Text = resources.GetString("this.miPlanTo5.Text");
             this.miPlanTo5.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // tmrTrainingSkillTick
@@ -219,7 +219,7 @@ namespace EVEMon.SkillPlanner
             this.toolStrip.Name = "toolStrip";
             this.toolStrip.Size = new System.Drawing.Size(637, 25);
             this.toolStrip.TabIndex = 20;
-            this.toolStrip.Text = "toolStrip";
+            this.toolStrip.Text = resources.GetString("this.toolStrip.Text");
             // 
             // showSkillExplorerMenu
             // 
@@ -228,8 +228,8 @@ namespace EVEMon.SkillPlanner
             this.showSkillExplorerMenu.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.showSkillExplorerMenu.Name = "showSkillExplorerMenu";
             this.showSkillExplorerMenu.Size = new System.Drawing.Size(147, 22);
-            this.showSkillExplorerMenu.Text = "Show In Skill Explorer...";
-            this.showSkillExplorerMenu.ToolTipText = "Opens the Skill Explorer.";
+            this.showSkillExplorerMenu.Text = resources.GetString("this.showSkillExplorerMenu.Text");
+            this.showSkillExplorerMenu.ToolTipText = resources.GetString("this.showSkillExplorerMenu.ToolTipText");
             this.showSkillExplorerMenu.Click += new System.EventHandler(this.showSkillExplorerMenu_Click);
             // 
             // toolStripSeparator1
@@ -247,7 +247,7 @@ namespace EVEMon.SkillPlanner
             this.ownsBookToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.ownsBookToolStripButton.Name = "ownsBookToolStripButton";
             this.ownsBookToolStripButton.Size = new System.Drawing.Size(71, 22);
-            this.ownsBookToolStripButton.Text = "&Owns book";
+            this.ownsBookToolStripButton.Text = resources.GetString("this.ownsBookToolStripButton.Text");
             this.ownsBookToolStripButton.CheckedChanged += new System.EventHandler(this.ownsBookToolStripButton_CheckedChanged);
             // 
             // planToLevel
@@ -263,48 +263,48 @@ namespace EVEMon.SkillPlanner
             this.planToLevel.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.planToLevel.Name = "planToLevel";
             this.planToLevel.Size = new System.Drawing.Size(82, 22);
-            this.planToLevel.Text = "&Plan to...";
+            this.planToLevel.Text = resources.GetString("this.planToLevel.Text");
             // 
             // planTo0Menu
             // 
             this.planTo0Menu.Name = "planTo0Menu";
             this.planTo0Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo0Menu.Text = "&Remove";
+            this.planTo0Menu.Text = resources.GetString("this.planTo0Menu.Text");
             this.planTo0Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // planTo1Menu
             // 
             this.planTo1Menu.Name = "planTo1Menu";
             this.planTo1Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo1Menu.Text = "Level &1";
+            this.planTo1Menu.Text = resources.GetString("this.planTo1Menu.Text");
             this.planTo1Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // planTo2Menu
             // 
             this.planTo2Menu.Name = "planTo2Menu";
             this.planTo2Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo2Menu.Text = "Level &2";
+            this.planTo2Menu.Text = resources.GetString("this.planTo2Menu.Text");
             this.planTo2Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // planTo3Menu
             // 
             this.planTo3Menu.Name = "planTo3Menu";
             this.planTo3Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo3Menu.Text = "Level &3";
+            this.planTo3Menu.Text = resources.GetString("this.planTo3Menu.Text");
             this.planTo3Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // planTo4Menu
             // 
             this.planTo4Menu.Name = "planTo4Menu";
             this.planTo4Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo4Menu.Text = "Level &4";
+            this.planTo4Menu.Text = resources.GetString("this.planTo4Menu.Text");
             this.planTo4Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // planTo5Menu
             // 
             this.planTo5Menu.Name = "planTo5Menu";
             this.planTo5Menu.Size = new System.Drawing.Size(117, 22);
-            this.planTo5Menu.Text = "Level &5";
+            this.planTo5Menu.Text = resources.GetString("this.planTo5Menu.Text");
             this.planTo5Menu.Click += new System.EventHandler(this.planToMenu_Click);
             // 
             // pnlPlanControl
@@ -343,7 +343,7 @@ namespace EVEMon.SkillPlanner
             this.lblSkillName.Name = "lblSkillName";
             this.lblSkillName.Size = new System.Drawing.Size(57, 13);
             this.lblSkillName.TabIndex = 0;
-            this.lblSkillName.Text = "Skill Name";
+            this.lblSkillName.Text = resources.GetString("this.lblSkillName.Text");
             // 
             // lblSkillCost
             // 
@@ -354,7 +354,7 @@ namespace EVEMon.SkillPlanner
             this.lblSkillCost.Name = "lblSkillCost";
             this.lblSkillCost.Size = new System.Drawing.Size(50, 13);
             this.lblSkillCost.TabIndex = 19;
-            this.lblSkillCost.Text = "Skill Cost";
+            this.lblSkillCost.Text = resources.GetString("this.lblSkillCost.Text");
             // 
             // lblSkillClass
             // 
@@ -363,7 +363,7 @@ namespace EVEMon.SkillPlanner
             this.lblSkillClass.Name = "lblSkillClass";
             this.lblSkillClass.Size = new System.Drawing.Size(71, 13);
             this.lblSkillClass.TabIndex = 18;
-            this.lblSkillClass.Text = "Skill Category";
+            this.lblSkillClass.Text = resources.GetString("this.lblSkillClass.Text");
             // 
             // descriptionTextBox
             // 
@@ -379,7 +379,7 @@ namespace EVEMon.SkillPlanner
             this.descriptionTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Vertical;
             this.descriptionTextBox.Size = new System.Drawing.Size(300, 81);
             this.descriptionTextBox.TabIndex = 17;
-            this.descriptionTextBox.Text = "Description of the skill";
+            this.descriptionTextBox.Text = resources.GetString("this.descriptionTextBox.Text");
             // 
             // lblAttributes
             // 
@@ -388,7 +388,7 @@ namespace EVEMon.SkillPlanner
             this.lblAttributes.Name = "lblAttributes";
             this.lblAttributes.Size = new System.Drawing.Size(338, 13);
             this.lblAttributes.TabIndex = 14;
-            this.lblAttributes.Text = "Primary: Intelligence, Secondary: Perception (SP/Hour : 2,000)";
+            this.lblAttributes.Text = resources.GetString("this.lblAttributes.Text");
             this.lblAttributes.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // lblLevel5Time
@@ -398,7 +398,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel5Time.Name = "lblLevel5Time";
             this.lblLevel5Time.Size = new System.Drawing.Size(268, 13);
             this.lblLevel5Time.TabIndex = 5;
-            this.lblLevel5Time.Text = "Level V: 63d, 18hh, 27m, 56s (plus 154d, 2h, 54m, 24s)";
+            this.lblLevel5Time.Text = resources.GetString("this.lblLevel5Time.Text");
             // 
             // lblLevel4Time
             // 
@@ -407,7 +407,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel4Time.Name = "lblLevel4Time";
             this.lblLevel4Time.Size = new System.Drawing.Size(259, 13);
             this.lblLevel4Time.TabIndex = 4;
-            this.lblLevel4Time.Text = "Level IV: 11d, 6h, 33m, 3s (plus 142d, 20h, 21m, 21s)";
+            this.lblLevel4Time.Text = resources.GetString("this.lblLevel4Time.Text");
             // 
             // lblLevel3Time
             // 
@@ -416,7 +416,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel3Time.Name = "lblLevel3Time";
             this.lblLevel3Time.Size = new System.Drawing.Size(264, 13);
             this.lblLevel3Time.TabIndex = 3;
-            this.lblLevel3Time.Text = "Level III: 1d, 23h, 49m, 36s (plus 140d, 12h, 31m, 10s)";
+            this.lblLevel3Time.Text = resources.GetString("this.lblLevel3Time.Text");
             // 
             // lblLevel2Time
             // 
@@ -425,7 +425,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel2Time.Name = "lblLevel2Time";
             this.lblLevel2Time.Size = new System.Drawing.Size(231, 13);
             this.lblLevel2Time.TabIndex = 2;
-            this.lblLevel2Time.Text = "Level II: 8h, 27m, 17s (plus 140d, 12h, 4m, 26s)";
+            this.lblLevel2Time.Text = resources.GetString("this.lblLevel2Time.Text");
             // 
             // lblLevel1Time
             // 
@@ -434,7 +434,7 @@ namespace EVEMon.SkillPlanner
             this.lblLevel1Time.Name = "lblLevel1Time";
             this.lblLevel1Time.Size = new System.Drawing.Size(234, 13);
             this.lblLevel1Time.TabIndex = 1;
-            this.lblLevel1Time.Text = "Level I: 1h, 48m, 55s (plus 140d, 10h, 15m, 30s)";
+            this.lblLevel1Time.Text = resources.GetString("this.lblLevel1Time.Text");
             // 
             // lblHelp
             // 
@@ -443,7 +443,7 @@ namespace EVEMon.SkillPlanner
             this.lblHelp.Name = "lblHelp";
             this.lblHelp.Size = new System.Drawing.Size(218, 13);
             this.lblHelp.TabIndex = 30;
-            this.lblHelp.Text = "Use the tree on the left to select skill to view.";
+            this.lblHelp.Text = resources.GetString("this.lblHelp.Text");
             // 
             // SkillBrowserControl
             // 

--- a/src/EVEMon/SkillPlanner/SkillBrowserControl.resx
+++ b/src/EVEMon/SkillPlanner/SkillBrowserControl.resx
@@ -176,4 +176,88 @@
         SdpC4WpHH0rfjaC8V4Nrg3rcUlpwT52fIC8oKfkDVINIp0nV8IoAAAAASUVORK5CYII=
 </value>
   </data>
+  <data name="this.miPlanTo0.Text" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="this.miPlanTo1.Text" xml:space="preserve">
+    <value>Plan to Level 1</value>
+  </data>
+  <data name="this.miPlanTo2.Text" xml:space="preserve">
+    <value>Plan to Level 2</value>
+  </data>
+  <data name="this.miPlanTo3.Text" xml:space="preserve">
+    <value>Plan to Level 3</value>
+  </data>
+  <data name="this.miPlanTo4.Text" xml:space="preserve">
+    <value>Plan to Level 4</value>
+  </data>
+  <data name="this.miPlanTo5.Text" xml:space="preserve">
+    <value>Plan to Level 5</value>
+  </data>
+  <data name="this.toolStrip.Text" xml:space="preserve">
+    <value>toolStrip</value>
+  </data>
+  <data name="this.showSkillExplorerMenu.Text" xml:space="preserve">
+    <value>Show In Skill Explorer...</value>
+  </data>
+  <data name="this.showSkillExplorerMenu.ToolTipText" xml:space="preserve">
+    <value>Opens the Skill Explorer.</value>
+  </data>
+  <data name="this.ownsBookToolStripButton.Text" xml:space="preserve">
+    <value>&amp;Owns book</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>&amp;Plan to...</value>
+  </data>
+  <data name="this.planTo0Menu.Text" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="this.planTo1Menu.Text" xml:space="preserve">
+    <value>Level &amp;1</value>
+  </data>
+  <data name="this.planTo2Menu.Text" xml:space="preserve">
+    <value>Level &amp;2</value>
+  </data>
+  <data name="this.planTo3Menu.Text" xml:space="preserve">
+    <value>Level &amp;3</value>
+  </data>
+  <data name="this.planTo4Menu.Text" xml:space="preserve">
+    <value>Level &amp;4</value>
+  </data>
+  <data name="this.planTo5Menu.Text" xml:space="preserve">
+    <value>Level &amp;5</value>
+  </data>
+  <data name="this.lblSkillName.Text" xml:space="preserve">
+    <value>Skill Name</value>
+  </data>
+  <data name="this.lblSkillCost.Text" xml:space="preserve">
+    <value>Skill Cost</value>
+  </data>
+  <data name="this.lblSkillClass.Text" xml:space="preserve">
+    <value>Skill Category</value>
+  </data>
+  <data name="this.descriptionTextBox.Text" xml:space="preserve">
+    <value>Description of the skill</value>
+  </data>
+  <data name="this.lblAttributes.Text" xml:space="preserve">
+    <value>Primary: Intelligence, Secondary: Perception (SP/Hour : 2,000)</value>
+  </data>
+  <data name="this.lblLevel5Time.Text" xml:space="preserve">
+    <value>Level V: 63d, 18hh, 27m, 56s (plus 154d, 2h, 54m, 24s)</value>
+  </data>
+  <data name="this.lblLevel4Time.Text" xml:space="preserve">
+    <value>Level IV: 11d, 6h, 33m, 3s (plus 142d, 20h, 21m, 21s)</value>
+  </data>
+  <data name="this.lblLevel3Time.Text" xml:space="preserve">
+    <value>Level III: 1d, 23h, 49m, 36s (plus 140d, 12h, 31m, 10s)</value>
+  </data>
+  <data name="this.lblLevel2Time.Text" xml:space="preserve">
+    <value>Level II: 8h, 27m, 17s (plus 140d, 12h, 4m, 26s)</value>
+  </data>
+  <data name="this.lblLevel1Time.Text" xml:space="preserve">
+    <value>Level I: 1h, 48m, 55s (plus 140d, 10h, 15m, 30s)</value>
+  </data>
+  <data name="this.lblHelp.Text" xml:space="preserve">
+    <value>Use the tree on the left to select skill to view.</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/SkillBrowserControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/SkillBrowserControl.zh-CN.resx
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.miPlanTo0.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="this.miPlanTo1.Text" xml:space="preserve">
+    <value>计划至 1 级</value>
+  </data>
+  <data name="this.miPlanTo2.Text" xml:space="preserve">
+    <value>计划到 2 级</value>
+  </data>
+  <data name="this.miPlanTo3.Text" xml:space="preserve">
+    <value>计划升级至 3 级</value>
+  </data>
+  <data name="this.miPlanTo4.Text" xml:space="preserve">
+    <value>计划升级至 4 级</value>
+  </data>
+  <data name="this.miPlanTo5.Text" xml:space="preserve">
+    <value>计划升级至 5 级</value>
+  </data>
+  <data name="this.toolStrip.Text" xml:space="preserve">
+    <value>工具条</value>
+  </data>
+  <data name="this.showSkillExplorerMenu.Text" xml:space="preserve">
+    <value>在技能资源管理器中显示...</value>
+  </data>
+  <data name="this.showSkillExplorerMenu.ToolTipText" xml:space="preserve">
+    <value>打开技能浏览器。</value>
+  </data>
+  <data name="this.ownsBookToolStripButton.Text" xml:space="preserve">
+    <value>拥有书籍(&amp;O)</value>
+  </data>
+  <data name="this.planToLevel.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.planTo0Menu.Text" xml:space="preserve">
+    <value>删除(&amp;R)</value>
+  </data>
+  <data name="this.planTo1Menu.Text" xml:space="preserve">
+    <value>等级&amp;1</value>
+  </data>
+  <data name="this.planTo2Menu.Text" xml:space="preserve">
+    <value>等级&amp;2</value>
+  </data>
+  <data name="this.planTo3Menu.Text" xml:space="preserve">
+    <value>等级&amp;3</value>
+  </data>
+  <data name="this.planTo4Menu.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.planTo5Menu.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.lblSkillName.Text" xml:space="preserve">
+    <value>技能名称</value>
+  </data>
+  <data name="this.lblSkillCost.Text" xml:space="preserve">
+    <value>技能成本</value>
+  </data>
+  <data name="this.lblSkillClass.Text" xml:space="preserve">
+    <value>技能类别</value>
+  </data>
+  <data name="this.descriptionTextBox.Text" xml:space="preserve">
+    <value>技能描述</value>
+  </data>
+  <data name="this.lblAttributes.Text" xml:space="preserve">
+    <value>主要：智力，次要：感知（SP/小时：2,000）</value>
+  </data>
+  <data name="this.lblLevel5Time.Text" xml:space="preserve">
+    <value>V级：63d、18hh、27m、56s（加上154d、2h、54m、24s）</value>
+  </data>
+  <data name="this.lblLevel4Time.Text" xml:space="preserve">
+    <value>IV级：11d、6h、33m、3s（加上142d、20h、21m、21s）</value>
+  </data>
+  <data name="this.lblLevel3Time.Text" xml:space="preserve">
+    <value>III级：1d、23h、49m、36s（加上140d、12h、31m、10s）</value>
+  </data>
+  <data name="this.lblLevel2Time.Text" xml:space="preserve">
+    <value>II级：8h、27m、17s（加上140d、12h、4m、26s）</value>
+  </data>
+  <data name="this.lblLevel1Time.Text" xml:space="preserve">
+    <value>I级：1h、48m、55s（加上140d、10h、15m、30s）</value>
+  </data>
+  <data name="this.lblHelp.Text" xml:space="preserve">
+    <value>使用左侧的树选择要查看的技能。</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/SkillExplorerWindow.Designer.cs
+++ b/src/EVEMon/SkillPlanner/SkillExplorerWindow.Designer.cs
@@ -31,9 +31,9 @@ namespace EVEMon.SkillPlanner
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.TreeNode treeNode1 = new System.Windows.Forms.TreeNode("Node0");
-            System.Windows.Forms.TreeNode treeNode2 = new System.Windows.Forms.TreeNode("Node0");
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SkillExplorerWindow));
+            System.Windows.Forms.TreeNode treeNode1 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode1.Text"));
+            System.Windows.Forms.TreeNode treeNode2 = new System.Windows.Forms.TreeNode(resources.GetString("treeNode2.Text"));
             this.grpPlanName = new System.Windows.Forms.GroupBox();
             this.lblSkillInfo = new System.Windows.Forms.Label();
             this.btnClose = new System.Windows.Forms.Button();
@@ -107,7 +107,7 @@ namespace EVEMon.SkillPlanner
             this.grpPlanName.Size = new System.Drawing.Size(560, 40);
             this.grpPlanName.TabIndex = 0;
             this.grpPlanName.TabStop = false;
-            this.grpPlanName.Text = "Selected Skill Details";
+            this.grpPlanName.Text = resources.GetString("this.grpPlanName.Text");
             // 
             // lblSkillInfo
             // 
@@ -116,7 +116,7 @@ namespace EVEMon.SkillPlanner
             this.lblSkillInfo.Name = "lblSkillInfo";
             this.lblSkillInfo.Size = new System.Drawing.Size(47, 13);
             this.lblSkillInfo.TabIndex = 0;
-            this.lblSkillInfo.Text = "Skill Info";
+            this.lblSkillInfo.Text = resources.GetString("this.lblSkillInfo.Text");
             // 
             // btnClose
             // 
@@ -126,7 +126,7 @@ namespace EVEMon.SkillPlanner
             this.btnClose.Name = "btnClose";
             this.btnClose.Size = new System.Drawing.Size(75, 23);
             this.btnClose.TabIndex = 2;
-            this.btnClose.Text = "Close";
+            this.btnClose.Text = resources.GetString("this.btnClose.Text");
             this.btnClose.UseVisualStyleBackColor = true;
             this.btnClose.Click += new System.EventHandler(this.btnClose_Click);
             // 
@@ -153,7 +153,7 @@ namespace EVEMon.SkillPlanner
             this.lblRedFont.Name = "lblRedFont";
             this.lblRedFont.Size = new System.Drawing.Size(27, 13);
             this.lblRedFont.TabIndex = 8;
-            this.lblRedFont.Text = "Red";
+            this.lblRedFont.Text = resources.GetString("this.lblRedFont.Text");
             // 
             // lblDimmedFont
             // 
@@ -163,7 +163,7 @@ namespace EVEMon.SkillPlanner
             this.lblDimmedFont.Name = "lblDimmedFont";
             this.lblDimmedFont.Size = new System.Drawing.Size(45, 13);
             this.lblDimmedFont.TabIndex = 6;
-            this.lblDimmedFont.Text = "Dimmed";
+            this.lblDimmedFont.Text = resources.GetString("this.lblDimmedFont.Text");
             // 
             // lblRedFontInfo
             // 
@@ -172,7 +172,7 @@ namespace EVEMon.SkillPlanner
             this.lblRedFontInfo.Name = "lblRedFontInfo";
             this.lblRedFontInfo.Size = new System.Drawing.Size(151, 13);
             this.lblRedFontInfo.TabIndex = 9;
-            this.lblRedFontInfo.Text = "= other untrained skills needed";
+            this.lblRedFontInfo.Text = resources.GetString("this.lblRedFontInfo.Text");
             // 
             // lblDimmedFontInfo
             // 
@@ -181,7 +181,7 @@ namespace EVEMon.SkillPlanner
             this.lblDimmedFontInfo.Name = "lblDimmedFontInfo";
             this.lblDimmedFontInfo.Size = new System.Drawing.Size(138, 13);
             this.lblDimmedFontInfo.TabIndex = 7;
-            this.lblDimmedFontInfo.Text = "= unlocked by this skill level";
+            this.lblDimmedFontInfo.Text = resources.GetString("this.lblDimmedFontInfo.Text");
             // 
             // lblNormalFont
             // 
@@ -190,7 +190,7 @@ namespace EVEMon.SkillPlanner
             this.lblNormalFont.Name = "lblNormalFont";
             this.lblNormalFont.Size = new System.Drawing.Size(142, 13);
             this.lblNormalFont.TabIndex = 5;
-            this.lblNormalFont.Text = "Normal font = already trained";
+            this.lblNormalFont.Text = resources.GetString("this.lblNormalFont.Text");
             // 
             // middlePanel
             // 
@@ -232,7 +232,7 @@ namespace EVEMon.SkillPlanner
             this.tvSkills.Location = new System.Drawing.Point(0, 18);
             this.tvSkills.Name = "tvSkills";
             treeNode1.Name = "Node0";
-            treeNode1.Text = "Node0";
+            treeNode1.Text = resources.GetString("treeNode1.Text");
             this.tvSkills.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode1});
             this.tvSkills.ShowNodeToolTips = true;
@@ -258,7 +258,7 @@ namespace EVEMon.SkillPlanner
             this.lblSkills.Name = "lblSkills";
             this.lblSkills.Size = new System.Drawing.Size(73, 13);
             this.lblSkills.TabIndex = 0;
-            this.lblSkills.Text = "Enabled Skills";
+            this.lblSkills.Text = resources.GetString("this.lblSkills.Text");
             // 
             // tvEntity
             // 
@@ -266,7 +266,7 @@ namespace EVEMon.SkillPlanner
             this.tvEntity.Location = new System.Drawing.Point(0, 18);
             this.tvEntity.Name = "tvEntity";
             treeNode2.Name = "Node0";
-            treeNode2.Text = "Node0";
+            treeNode2.Text = resources.GetString("treeNode2.Text");
             this.tvEntity.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode2});
             this.tvEntity.ShowNodeToolTips = true;
@@ -291,7 +291,7 @@ namespace EVEMon.SkillPlanner
             this.lblItems.Name = "lblItems";
             this.lblItems.Size = new System.Drawing.Size(74, 13);
             this.lblItems.TabIndex = 0;
-            this.lblItems.Text = "Enabled Items";
+            this.lblItems.Text = resources.GetString("this.lblItems.Text");
             // 
             // cmSkills
             // 
@@ -321,48 +321,48 @@ namespace EVEMon.SkillPlanner
             this.planToMenu.Image = ((System.Drawing.Image)(resources.GetObject("planToMenu.Image")));
             this.planToMenu.Name = "planToMenu";
             this.planToMenu.Size = new System.Drawing.Size(241, 22);
-            this.planToMenu.Text = "Plan to...";
+            this.planToMenu.Text = resources.GetString("this.planToMenu.Text");
             // 
             // tsRemove
             // 
             this.tsRemove.Name = "tsRemove";
             this.tsRemove.Size = new System.Drawing.Size(117, 22);
-            this.tsRemove.Text = "Remove";
+            this.tsRemove.Text = resources.GetString("this.tsRemove.Text");
             this.tsRemove.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsAddL1
             // 
             this.tsAddL1.Name = "tsAddL1";
             this.tsAddL1.Size = new System.Drawing.Size(117, 22);
-            this.tsAddL1.Text = "Level 1";
+            this.tsAddL1.Text = resources.GetString("this.tsAddL1.Text");
             this.tsAddL1.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsAddL2
             // 
             this.tsAddL2.Name = "tsAddL2";
             this.tsAddL2.Size = new System.Drawing.Size(117, 22);
-            this.tsAddL2.Text = "Level 2";
+            this.tsAddL2.Text = resources.GetString("this.tsAddL2.Text");
             this.tsAddL2.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsAddL3
             // 
             this.tsAddL3.Name = "tsAddL3";
             this.tsAddL3.Size = new System.Drawing.Size(117, 22);
-            this.tsAddL3.Text = "Level 3";
+            this.tsAddL3.Text = resources.GetString("this.tsAddL3.Text");
             this.tsAddL3.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsAddL4
             // 
             this.tsAddL4.Name = "tsAddL4";
             this.tsAddL4.Size = new System.Drawing.Size(117, 22);
-            this.tsAddL4.Text = "Level 4";
+            this.tsAddL4.Text = resources.GetString("this.tsAddL4.Text");
             this.tsAddL4.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsAddL5
             // 
             this.tsAddL5.Name = "tsAddL5";
             this.tsAddL5.Size = new System.Drawing.Size(117, 22);
-            this.tsAddL5.Text = "Level 5";
+            this.tsAddL5.Text = resources.GetString("this.tsAddL5.Text");
             this.tsAddL5.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // planToSeparator
@@ -374,7 +374,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillBrowserMenu.Name = "showInSkillBrowserMenu";
             this.showInSkillBrowserMenu.Size = new System.Drawing.Size(241, 22);
-            this.showInSkillBrowserMenu.Text = "Show In Skill Browser...";
+            this.showInSkillBrowserMenu.Text = resources.GetString("this.showInSkillBrowserMenu.Text");
             this.showInSkillBrowserMenu.Click += new System.EventHandler(this.showInSkillBrowserMenu_Click);
             // 
             // showInBrowserSeperator
@@ -386,14 +386,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillExplorerMenu.Name = "showInSkillExplorerMenu";
             this.showInSkillExplorerMenu.Size = new System.Drawing.Size(241, 22);
-            this.showInSkillExplorerMenu.Text = "Show me what this skill unlocks";
+            this.showInSkillExplorerMenu.Text = resources.GetString("this.showInSkillExplorerMenu.Text");
             this.showInSkillExplorerMenu.Click += new System.EventHandler(this.showInSkillExplorerMenu_Click);
             // 
             // showPrerequisitiesMenu
             // 
             this.showPrerequisitiesMenu.Name = "showPrerequisitiesMenu";
             this.showPrerequisitiesMenu.Size = new System.Drawing.Size(241, 22);
-            this.showPrerequisitiesMenu.Text = "Show Untrained Prerequisites";
+            this.showPrerequisitiesMenu.Text = resources.GetString("this.showPrerequisitiesMenu.Text");
             this.showPrerequisitiesMenu.Click += new System.EventHandler(this.showPrerequisitiesMenu_Click);
             // 
             // showInMenuSeperator
@@ -405,14 +405,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.tsmiSkillsExpandAll.Name = "tsmiSkillsExpandAll";
             this.tsmiSkillsExpandAll.Size = new System.Drawing.Size(241, 22);
-            this.tsmiSkillsExpandAll.Text = "&Expand All";
+            this.tsmiSkillsExpandAll.Text = resources.GetString("this.tsmiSkillsExpandAll.Text");
             this.tsmiSkillsExpandAll.Click += new System.EventHandler(this.tsmiExpandAll_Click);
             // 
             // tsmiSkillsCollapseAll
             // 
             this.tsmiSkillsCollapseAll.Name = "tsmiSkillsCollapseAll";
             this.tsmiSkillsCollapseAll.Size = new System.Drawing.Size(241, 22);
-            this.tsmiSkillsCollapseAll.Text = "&Collapse All";
+            this.tsmiSkillsCollapseAll.Text = resources.GetString("this.tsmiSkillsCollapseAll.Text");
             this.tsmiSkillsCollapseAll.Click += new System.EventHandler(this.tsmiColapseAll_Click);
             // 
             // cmEntity
@@ -434,7 +434,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.planToObject.Name = "planToObject";
             this.planToObject.Size = new System.Drawing.Size(228, 22);
-            this.planToObject.Text = "Add To Plan...";
+            this.planToObject.Text = resources.GetString("this.planToObject.Text");
             this.planToObject.Click += new System.EventHandler(this.planToObjectMenuItem_Click);
             // 
             // planToObjectSeperator
@@ -446,7 +446,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showObjectInBrowserMenuItem.Name = "showObjectInBrowserMenuItem";
             this.showObjectInBrowserMenuItem.Size = new System.Drawing.Size(228, 22);
-            this.showObjectInBrowserMenuItem.Text = "Show In Browser...";
+            this.showObjectInBrowserMenuItem.Text = resources.GetString("this.showObjectInBrowserMenuItem.Text");
             this.showObjectInBrowserMenuItem.Click += new System.EventHandler(this.tvEntity_DoubleClick);
             // 
             // showObjectInBrowserSeperator
@@ -458,7 +458,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showObjectPrerequisitiesMenu.Name = "showObjectPrerequisitiesMenu";
             this.showObjectPrerequisitiesMenu.Size = new System.Drawing.Size(228, 22);
-            this.showObjectPrerequisitiesMenu.Text = "Show Untrained Prerequisites";
+            this.showObjectPrerequisitiesMenu.Text = resources.GetString("this.showObjectPrerequisitiesMenu.Text");
             this.showObjectPrerequisitiesMenu.Click += new System.EventHandler(this.tsShowItemPrereqs_Click);
             // 
             // showObjectInMenuSeperator
@@ -470,14 +470,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.tsmiObjectsExpandAll.Name = "tsmiObjectsExpandAll";
             this.tsmiObjectsExpandAll.Size = new System.Drawing.Size(228, 22);
-            this.tsmiObjectsExpandAll.Text = "&Expand All";
+            this.tsmiObjectsExpandAll.Text = resources.GetString("this.tsmiObjectsExpandAll.Text");
             this.tsmiObjectsExpandAll.Click += new System.EventHandler(this.tsmiObjectExpandAll_Click);
             // 
             // tsmiObjectsCollapseAll
             // 
             this.tsmiObjectsCollapseAll.Name = "tsmiObjectsCollapseAll";
             this.tsmiObjectsCollapseAll.Size = new System.Drawing.Size(228, 22);
-            this.tsmiObjectsCollapseAll.Text = "&Collapse All";
+            this.tsmiObjectsCollapseAll.Text = resources.GetString("this.tsmiObjectsCollapseAll.Text");
             this.tsmiObjectsCollapseAll.Click += new System.EventHandler(this.tsmiObjectCollapseAll_Click);
             // 
             // groupBox2
@@ -493,7 +493,7 @@ namespace EVEMon.SkillPlanner
             this.groupBox2.Size = new System.Drawing.Size(560, 51);
             this.groupBox2.TabIndex = 0;
             this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Options";
+            this.groupBox2.Text = resources.GetString("this.groupBox2.Text");
             // 
             // cbHistory
             // 
@@ -513,7 +513,7 @@ namespace EVEMon.SkillPlanner
             this.cbShowBaseOnly.Name = "cbShowBaseOnly";
             this.cbShowBaseOnly.Size = new System.Drawing.Size(109, 17);
             this.cbShowBaseOnly.TabIndex = 2;
-            this.cbShowBaseOnly.Text = "Only show T1/T2";
+            this.cbShowBaseOnly.Text = resources.GetString("this.cbShowBaseOnly.Text");
             this.cbShowBaseOnly.UseVisualStyleBackColor = true;
             this.cbShowBaseOnly.CheckedChanged += new System.EventHandler(this.cbShowBaseOnly_CheckedChanged);
             // 
@@ -526,7 +526,7 @@ namespace EVEMon.SkillPlanner
             this.rbShowAlpha.Size = new System.Drawing.Size(124, 17);
             this.rbShowAlpha.TabIndex = 1;
             this.rbShowAlpha.TabStop = true;
-            this.rbShowAlpha.Text = "Show Alphabetic List";
+            this.rbShowAlpha.Text = resources.GetString("this.rbShowAlpha.Text");
             this.rbShowAlpha.UseVisualStyleBackColor = true;
             this.rbShowAlpha.CheckedChanged += new System.EventHandler(this.rbShowAlpha_CheckedChanged);
             // 
@@ -537,7 +537,7 @@ namespace EVEMon.SkillPlanner
             this.rbShowTree.Name = "rbShowTree";
             this.rbShowTree.Size = new System.Drawing.Size(127, 17);
             this.rbShowTree.TabIndex = 0;
-            this.rbShowTree.Text = "Show Category Trees";
+            this.rbShowTree.Text = resources.GetString("this.rbShowTree.Text");
             this.rbShowTree.UseVisualStyleBackColor = true;
             // 
             // tmrAutoUpdate
@@ -563,7 +563,7 @@ namespace EVEMon.SkillPlanner
             this.MinimumSize = new System.Drawing.Size(600, 480);
             this.Name = "SkillExplorerWindow";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-            this.Text = "Skill Explorer - What Is This Skill Used For?";
+            this.Text = resources.GetString("this.Text");
             this.grpPlanName.ResumeLayout(false);
             this.grpPlanName.PerformLayout();
             this.lowerPanel.ResumeLayout(false);

--- a/src/EVEMon/SkillPlanner/SkillExplorerWindow.resx
+++ b/src/EVEMon/SkillPlanner/SkillExplorerWindow.resx
@@ -149,4 +149,106 @@
   <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>333, 19</value>
   </metadata>
+  <data name="this.grpPlanName.Text" xml:space="preserve">
+    <value>Selected Skill Details</value>
+  </data>
+  <data name="this.lblSkillInfo.Text" xml:space="preserve">
+    <value>Skill Info</value>
+  </data>
+  <data name="this.btnClose.Text" xml:space="preserve">
+    <value>Close</value>
+  </data>
+  <data name="this.lblRedFont.Text" xml:space="preserve">
+    <value>Red</value>
+  </data>
+  <data name="this.lblDimmedFont.Text" xml:space="preserve">
+    <value>Dimmed</value>
+  </data>
+  <data name="this.lblRedFontInfo.Text" xml:space="preserve">
+    <value>= other untrained skills needed</value>
+  </data>
+  <data name="this.lblDimmedFontInfo.Text" xml:space="preserve">
+    <value>= unlocked by this skill level</value>
+  </data>
+  <data name="this.lblNormalFont.Text" xml:space="preserve">
+    <value>Normal font = already trained</value>
+  </data>
+  <data name="treeNode1.Text" xml:space="preserve">
+    <value>Node0</value>
+  </data>
+  <data name="this.lblSkills.Text" xml:space="preserve">
+    <value>Enabled Skills</value>
+  </data>
+  <data name="treeNode2.Text" xml:space="preserve">
+    <value>Node0</value>
+  </data>
+  <data name="this.lblItems.Text" xml:space="preserve">
+    <value>Enabled Items</value>
+  </data>
+  <data name="this.planToMenu.Text" xml:space="preserve">
+    <value>Plan to...</value>
+  </data>
+  <data name="this.tsRemove.Text" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="this.tsAddL1.Text" xml:space="preserve">
+    <value>Level 1</value>
+  </data>
+  <data name="this.tsAddL2.Text" xml:space="preserve">
+    <value>Level 2</value>
+  </data>
+  <data name="this.tsAddL3.Text" xml:space="preserve">
+    <value>Level 3</value>
+  </data>
+  <data name="this.tsAddL4.Text" xml:space="preserve">
+    <value>Level 4</value>
+  </data>
+  <data name="this.tsAddL5.Text" xml:space="preserve">
+    <value>Level 5</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>Show In Skill Browser...</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>Show me what this skill unlocks</value>
+  </data>
+  <data name="this.showPrerequisitiesMenu.Text" xml:space="preserve">
+    <value>Show Untrained Prerequisites</value>
+  </data>
+  <data name="this.tsmiSkillsExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.tsmiSkillsCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
+  <data name="this.planToObject.Text" xml:space="preserve">
+    <value>Add To Plan...</value>
+  </data>
+  <data name="this.showObjectInBrowserMenuItem.Text" xml:space="preserve">
+    <value>Show In Browser...</value>
+  </data>
+  <data name="this.showObjectPrerequisitiesMenu.Text" xml:space="preserve">
+    <value>Show Untrained Prerequisites</value>
+  </data>
+  <data name="this.tsmiObjectsExpandAll.Text" xml:space="preserve">
+    <value>&amp;Expand All</value>
+  </data>
+  <data name="this.tsmiObjectsCollapseAll.Text" xml:space="preserve">
+    <value>&amp;Collapse All</value>
+  </data>
+  <data name="this.groupBox2.Text" xml:space="preserve">
+    <value>Options</value>
+  </data>
+  <data name="this.cbShowBaseOnly.Text" xml:space="preserve">
+    <value>Only show T1/T2</value>
+  </data>
+  <data name="this.rbShowAlpha.Text" xml:space="preserve">
+    <value>Show Alphabetic List</value>
+  </data>
+  <data name="this.rbShowTree.Text" xml:space="preserve">
+    <value>Show Category Trees</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>Skill Explorer - What Is This Skill Used For?</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/SkillExplorerWindow.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/SkillExplorerWindow.zh-CN.resx
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.grpPlanName.Text" xml:space="preserve">
+    <value>所选技能详细信息</value>
+  </data>
+  <data name="this.lblSkillInfo.Text" xml:space="preserve">
+    <value>技能信息</value>
+  </data>
+  <data name="this.btnClose.Text" xml:space="preserve">
+    <value>关闭</value>
+  </data>
+  <data name="this.lblRedFont.Text" xml:space="preserve">
+    <value>红色</value>
+  </data>
+  <data name="this.lblDimmedFont.Text" xml:space="preserve">
+    <value>变暗</value>
+  </data>
+  <data name="this.lblRedFontInfo.Text" xml:space="preserve">
+    <value>= 需要其他未经培训的技能</value>
+  </data>
+  <data name="this.lblDimmedFontInfo.Text" xml:space="preserve">
+    <value>= 通过此技能等级解锁</value>
+  </data>
+  <data name="this.lblNormalFont.Text" xml:space="preserve">
+    <value>普通字体 = 已训练</value>
+  </data>
+  <data name="treeNode1.Text" xml:space="preserve">
+    <value>节点0</value>
+  </data>
+  <data name="this.lblSkills.Text" xml:space="preserve">
+    <value>启用技能</value>
+  </data>
+  <data name="treeNode2.Text" xml:space="preserve">
+    <value>节点0</value>
+  </data>
+  <data name="this.lblItems.Text" xml:space="preserve">
+    <value>启用项目</value>
+  </data>
+  <data name="this.planToMenu.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.tsRemove.Text" xml:space="preserve">
+    <value>删除</value>
+  </data>
+  <data name="this.tsAddL1.Text" xml:space="preserve">
+    <value>1级</value>
+  </data>
+  <data name="this.tsAddL2.Text" xml:space="preserve">
+    <value>2级</value>
+  </data>
+  <data name="this.tsAddL3.Text" xml:space="preserve">
+    <value>3级</value>
+  </data>
+  <data name="this.tsAddL4.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.tsAddL5.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>在技能浏览器中显示...</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>告诉我这个技能可以解锁什么</value>
+  </data>
+  <data name="this.showPrerequisitiesMenu.Text" xml:space="preserve">
+    <value>显示未经训练的先决条件</value>
+  </data>
+  <data name="this.tsmiSkillsExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.tsmiSkillsCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+  <data name="this.planToObject.Text" xml:space="preserve">
+    <value>添加到计划...</value>
+  </data>
+  <data name="this.showObjectInBrowserMenuItem.Text" xml:space="preserve">
+    <value>在浏览器中显示...</value>
+  </data>
+  <data name="this.showObjectPrerequisitiesMenu.Text" xml:space="preserve">
+    <value>显示未经训练的先决条件</value>
+  </data>
+  <data name="this.tsmiObjectsExpandAll.Text" xml:space="preserve">
+    <value>全部展开(&amp;A)</value>
+  </data>
+  <data name="this.tsmiObjectsCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠(&amp;C)</value>
+  </data>
+  <data name="this.groupBox2.Text" xml:space="preserve">
+    <value>选项</value>
+  </data>
+  <data name="this.cbShowBaseOnly.Text" xml:space="preserve">
+    <value>只显示T1/T2</value>
+  </data>
+  <data name="this.rbShowAlpha.Text" xml:space="preserve">
+    <value>显示字母列表</value>
+  </data>
+  <data name="this.rbShowTree.Text" xml:space="preserve">
+    <value>显示类别树</value>
+  </data>
+  <data name="this.Text" xml:space="preserve">
+    <value>技能探索者 - 该技能有什么用？</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/SkillSelectControl.Designer.cs
+++ b/src/EVEMon/SkillPlanner/SkillSelectControl.Designer.cs
@@ -154,48 +154,48 @@ namespace EVEMon.SkillPlanner
             this.cmiPlanToLevel.Image = ((System.Drawing.Image)(resources.GetObject("cmiPlanToLevel.Image")));
             this.cmiPlanToLevel.Name = "cmiPlanToLevel";
             this.cmiPlanToLevel.Size = new System.Drawing.Size(194, 22);
-            this.cmiPlanToLevel.Text = "&Plan to...";
+            this.cmiPlanToLevel.Text = resources.GetString("this.cmiPlanToLevel.Text");
             // 
             // level0ToolStripMenuItem
             // 
             this.level0ToolStripMenuItem.Name = "level0ToolStripMenuItem";
             this.level0ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level0ToolStripMenuItem.Text = "&Remove";
+            this.level0ToolStripMenuItem.Text = resources.GetString("this.level0ToolStripMenuItem.Text");
             this.level0ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // level1ToolStripMenuItem
             // 
             this.level1ToolStripMenuItem.Name = "level1ToolStripMenuItem";
             this.level1ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level1ToolStripMenuItem.Text = "Level &1";
+            this.level1ToolStripMenuItem.Text = resources.GetString("this.level1ToolStripMenuItem.Text");
             this.level1ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // level2ToolStripMenuItem
             // 
             this.level2ToolStripMenuItem.Name = "level2ToolStripMenuItem";
             this.level2ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level2ToolStripMenuItem.Text = "Level &2";
+            this.level2ToolStripMenuItem.Text = resources.GetString("this.level2ToolStripMenuItem.Text");
             this.level2ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // level3ToolStripMenuItem
             // 
             this.level3ToolStripMenuItem.Name = "level3ToolStripMenuItem";
             this.level3ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level3ToolStripMenuItem.Text = "Level &3";
+            this.level3ToolStripMenuItem.Text = resources.GetString("this.level3ToolStripMenuItem.Text");
             this.level3ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // level4ToolStripMenuItem
             // 
             this.level4ToolStripMenuItem.Name = "level4ToolStripMenuItem";
             this.level4ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level4ToolStripMenuItem.Text = "Level &4";
+            this.level4ToolStripMenuItem.Text = resources.GetString("this.level4ToolStripMenuItem.Text");
             this.level4ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // level5ToolStripMenuItem
             // 
             this.level5ToolStripMenuItem.Name = "level5ToolStripMenuItem";
             this.level5ToolStripMenuItem.Size = new System.Drawing.Size(117, 22);
-            this.level5ToolStripMenuItem.Text = "Level &5";
+            this.level5ToolStripMenuItem.Text = resources.GetString("this.level5ToolStripMenuItem.Text");
             this.level5ToolStripMenuItem.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // planToMenuSkillSeparator
@@ -207,7 +207,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillBrowserMenu.Name = "showInSkillBrowserMenu";
             this.showInSkillBrowserMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillBrowserMenu.Text = "Show in Skill &Browser";
+            this.showInSkillBrowserMenu.Text = resources.GetString("this.showInSkillBrowserMenu.Text");
             this.showInSkillBrowserMenu.Click += new System.EventHandler(this.showInSkillBrowserMenu_Click);
             // 
             // showInSkillExplorerMenu
@@ -215,21 +215,21 @@ namespace EVEMon.SkillPlanner
             this.showInSkillExplorerMenu.Image = ((System.Drawing.Image)(resources.GetObject("showInSkillExplorerMenu.Image")));
             this.showInSkillExplorerMenu.Name = "showInSkillExplorerMenu";
             this.showInSkillExplorerMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillExplorerMenu.Text = "Show in Skill &Explorer...";
+            this.showInSkillExplorerMenu.Text = resources.GetString("this.showInSkillExplorerMenu.Text");
             this.showInSkillExplorerMenu.Click += new System.EventHandler(this.showInSkillExplorerMenu_Click);
             // 
             // cmiExpandSelected
             // 
             this.cmiExpandSelected.Name = "cmiExpandSelected";
             this.cmiExpandSelected.Size = new System.Drawing.Size(194, 22);
-            this.cmiExpandSelected.Text = "Expand Selected";
+            this.cmiExpandSelected.Text = resources.GetString("this.cmiExpandSelected.Text");
             this.cmiExpandSelected.Click += new System.EventHandler(this.cmiExpandSelected_Click);
             // 
             // cmiCollapseSelected
             // 
             this.cmiCollapseSelected.Name = "cmiCollapseSelected";
             this.cmiCollapseSelected.Size = new System.Drawing.Size(194, 22);
-            this.cmiCollapseSelected.Text = "Collapse Selected";
+            this.cmiCollapseSelected.Text = resources.GetString("this.cmiCollapseSelected.Text");
             this.cmiCollapseSelected.Click += new System.EventHandler(this.cmiCollapseSelected_Click);
             // 
             // expandCollapseSeparator
@@ -241,14 +241,14 @@ namespace EVEMon.SkillPlanner
             // 
             this.cmiExpandAll.Name = "cmiExpandAll";
             this.cmiExpandAll.Size = new System.Drawing.Size(194, 22);
-            this.cmiExpandAll.Text = "Expand All";
+            this.cmiExpandAll.Text = resources.GetString("this.cmiExpandAll.Text");
             this.cmiExpandAll.Click += new System.EventHandler(this.cmiExpandAll_Click);
             // 
             // cmiCollapseAll
             // 
             this.cmiCollapseAll.Name = "cmiCollapseAll";
             this.cmiCollapseAll.Size = new System.Drawing.Size(194, 22);
-            this.cmiCollapseAll.Text = "Collapse All";
+            this.cmiCollapseAll.Text = resources.GetString("this.cmiCollapseAll.Text");
             this.cmiCollapseAll.Click += new System.EventHandler(this.cmiCollapseAll_Click);
             // 
             // lbSearchList
@@ -290,48 +290,48 @@ namespace EVEMon.SkillPlanner
             this.cmiLvPlanTo.Image = ((System.Drawing.Image)(resources.GetObject("cmiLvPlanTo.Image")));
             this.cmiLvPlanTo.Name = "cmiLvPlanTo";
             this.cmiLvPlanTo.Size = new System.Drawing.Size(194, 22);
-            this.cmiLvPlanTo.Text = "&Plan To...";
+            this.cmiLvPlanTo.Text = resources.GetString("this.cmiLvPlanTo.Text");
             // 
             // tsmLevel0
             // 
             this.tsmLevel0.Name = "tsmLevel0";
             this.tsmLevel0.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel0.Text = "&Remove";
+            this.tsmLevel0.Text = resources.GetString("this.tsmLevel0.Text");
             this.tsmLevel0.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel1
             // 
             this.tsmLevel1.Name = "tsmLevel1";
             this.tsmLevel1.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel1.Text = "Level &1";
+            this.tsmLevel1.Text = resources.GetString("this.tsmLevel1.Text");
             this.tsmLevel1.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel2
             // 
             this.tsmLevel2.Name = "tsmLevel2";
             this.tsmLevel2.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel2.Text = "Level &2";
+            this.tsmLevel2.Text = resources.GetString("this.tsmLevel2.Text");
             this.tsmLevel2.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel3
             // 
             this.tsmLevel3.Name = "tsmLevel3";
             this.tsmLevel3.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel3.Text = "Level &3";
+            this.tsmLevel3.Text = resources.GetString("this.tsmLevel3.Text");
             this.tsmLevel3.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel4
             // 
             this.tsmLevel4.Name = "tsmLevel4";
             this.tsmLevel4.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel4.Text = "Level &4";
+            this.tsmLevel4.Text = resources.GetString("this.tsmLevel4.Text");
             this.tsmLevel4.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // tsmLevel5
             // 
             this.tsmLevel5.Name = "tsmLevel5";
             this.tsmLevel5.Size = new System.Drawing.Size(117, 22);
-            this.tsmLevel5.Text = "Level &5";
+            this.tsmLevel5.Text = resources.GetString("this.tsmLevel5.Text");
             this.tsmLevel5.Click += new System.EventHandler(this.planToLevelMenuItem_Click);
             // 
             // planToMenuSkillListSeparator
@@ -343,7 +343,7 @@ namespace EVEMon.SkillPlanner
             // 
             this.showInSkillBrowserListMenu.Name = "showInSkillBrowserListMenu";
             this.showInSkillBrowserListMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillBrowserListMenu.Text = "Show in Skill &Browser";
+            this.showInSkillBrowserListMenu.Text = resources.GetString("this.showInSkillBrowserListMenu.Text");
             this.showInSkillBrowserListMenu.Click += new System.EventHandler(this.showInSkillBrowserMenu_Click);
             // 
             // showInSkillExplorerListMenu
@@ -351,7 +351,7 @@ namespace EVEMon.SkillPlanner
             this.showInSkillExplorerListMenu.Image = ((System.Drawing.Image)(resources.GetObject("showInSkillExplorerListMenu.Image")));
             this.showInSkillExplorerListMenu.Name = "showInSkillExplorerListMenu";
             this.showInSkillExplorerListMenu.Size = new System.Drawing.Size(194, 22);
-            this.showInSkillExplorerListMenu.Text = "Show in Skill &Explorer...";
+            this.showInSkillExplorerListMenu.Text = resources.GetString("this.showInSkillExplorerListMenu.Text");
             this.showInSkillExplorerListMenu.Click += new System.EventHandler(this.showInSkillExplorerMenu_Click);
             // 
             // lbSearchTextHint
@@ -363,7 +363,7 @@ namespace EVEMon.SkillPlanner
             this.lbSearchTextHint.Name = "lbSearchTextHint";
             this.lbSearchTextHint.Size = new System.Drawing.Size(65, 13);
             this.lbSearchTextHint.TabIndex = 22;
-            this.lbSearchTextHint.Text = "Search Text";
+            this.lbSearchTextHint.Text = resources.GetString("this.lbSearchTextHint.Text");
             this.lbSearchTextHint.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.lbSearchTextHint.Click += new System.EventHandler(this.lblSearchTextHint_Click);
             // 
@@ -378,7 +378,7 @@ namespace EVEMon.SkillPlanner
             this.lbNoMatches.Padding = new System.Windows.Forms.Padding(4, 30, 4, 4);
             this.lbNoMatches.Size = new System.Drawing.Size(227, 299);
             this.lbNoMatches.TabIndex = 1;
-            this.lbNoMatches.Text = "No skills match your search.";
+            this.lbNoMatches.Text = resources.GetString("this.lbNoMatches.Text");
             this.lbNoMatches.TextAlign = System.Drawing.ContentAlignment.TopCenter;
             this.lbNoMatches.Visible = false;
             // 
@@ -391,7 +391,7 @@ namespace EVEMon.SkillPlanner
             this.cbShowNonPublic.Padding = new System.Windows.Forms.Padding(2, 0, 0, 0);
             this.cbShowNonPublic.Size = new System.Drawing.Size(227, 22);
             this.cbShowNonPublic.TabIndex = 2;
-            this.cbShowNonPublic.Text = "Show Non-Public Skills";
+            this.cbShowNonPublic.Text = resources.GetString("this.cbShowNonPublic.Text");
             this.cbShowNonPublic.UseVisualStyleBackColor = true;
             this.cbShowNonPublic.CheckedChanged += new System.EventHandler(this.cbShowNonPublic_CheckedChanged);
             // 
@@ -403,7 +403,7 @@ namespace EVEMon.SkillPlanner
             this.lblFilter.Name = "lblFilter";
             this.lblFilter.Size = new System.Drawing.Size(32, 13);
             this.lblFilter.TabIndex = 25;
-            this.lblFilter.Text = "Filter:";
+            this.lblFilter.Text = resources.GetString("this.lblFilter.Text");
             // 
             // cbSorting
             // 
@@ -426,7 +426,7 @@ namespace EVEMon.SkillPlanner
             this.lblSort.Name = "lblSort";
             this.lblSort.Size = new System.Drawing.Size(29, 13);
             this.lblSort.TabIndex = 27;
-            this.lblSort.Text = "Sort:";
+            this.lblSort.Text = resources.GetString("this.lblSort.Text");
             // 
             // lvSortedSkillList
             // 
@@ -453,12 +453,12 @@ namespace EVEMon.SkillPlanner
             // 
             // chName
             // 
-            this.chName.Text = "Name";
+            this.chName.Text = resources.GetString("this.chName.Text");
             this.chName.Width = 120;
             // 
             // chSortKey
             // 
-            this.chSortKey.Text = "Sort";
+            this.chSortKey.Text = resources.GetString("this.chSortKey.Text");
             // 
             // ilSkillIcons
             // 
@@ -529,7 +529,7 @@ namespace EVEMon.SkillPlanner
             this.lblFilterBy.Name = "lblFilterBy";
             this.lblFilterBy.Size = new System.Drawing.Size(22, 13);
             this.lblFilterBy.TabIndex = 37;
-            this.lblFilterBy.Text = "By:";
+            this.lblFilterBy.Text = resources.GetString("this.lblFilterBy.Text");
             // 
             // pnlResults
             // 

--- a/src/EVEMon/SkillPlanner/SkillSelectControl.resx
+++ b/src/EVEMon/SkillPlanner/SkillSelectControl.resx
@@ -324,4 +324,94 @@
         A6uGCYBoZDbcVGRFGJIggFcBsiSIRmaDFRF0JH5vOkYBALc2UwG7hivNAAAAAElFTkSuQmCC
 </value>
   </data>
+  <data name="this.cmiPlanToLevel.Text" xml:space="preserve">
+    <value>&amp;Plan to...</value>
+  </data>
+  <data name="this.level0ToolStripMenuItem.Text" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="this.level1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;1</value>
+  </data>
+  <data name="this.level2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;2</value>
+  </data>
+  <data name="this.level3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;3</value>
+  </data>
+  <data name="this.level4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;4</value>
+  </data>
+  <data name="this.level5ToolStripMenuItem.Text" xml:space="preserve">
+    <value>Level &amp;5</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>Expand Selected</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>Collapse Selected</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>Expand All</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>Collapse All</value>
+  </data>
+  <data name="this.cmiLvPlanTo.Text" xml:space="preserve">
+    <value>&amp;Plan To...</value>
+  </data>
+  <data name="this.tsmLevel0.Text" xml:space="preserve">
+    <value>&amp;Remove</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>Level &amp;1</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>Level &amp;2</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>Level &amp;3</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>Level &amp;4</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>Level &amp;5</value>
+  </data>
+  <data name="this.showInSkillBrowserListMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Browser</value>
+  </data>
+  <data name="this.showInSkillExplorerListMenu.Text" xml:space="preserve">
+    <value>Show in Skill &amp;Explorer...</value>
+  </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>Search Text</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>No skills match your search.</value>
+  </data>
+  <data name="this.cbShowNonPublic.Text" xml:space="preserve">
+    <value>Show Non-Public Skills</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="this.lblSort.Text" xml:space="preserve">
+    <value>Sort:</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="this.chSortKey.Text" xml:space="preserve">
+    <value>Sort</value>
+  </data>
+  <data name="this.lblFilterBy.Text" xml:space="preserve">
+    <value>By:</value>
+  </data>
 </root>

--- a/src/EVEMon/SkillPlanner/SkillSelectControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/SkillSelectControl.zh-CN.resx
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+  <data name="this.cmiPlanToLevel.Text" xml:space="preserve">
+    <value>计划...</value>
+  </data>
+  <data name="this.level0ToolStripMenuItem.Text" xml:space="preserve">
+    <value>删除(&amp;R)</value>
+  </data>
+  <data name="this.level1ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;1</value>
+  </data>
+  <data name="this.level2ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;2</value>
+  </data>
+  <data name="this.level3ToolStripMenuItem.Text" xml:space="preserve">
+    <value>等级&amp;3</value>
+  </data>
+  <data name="this.level4ToolStripMenuItem.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.level5ToolStripMenuItem.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.showInSkillBrowserMenu.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.showInSkillExplorerMenu.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.cmiExpandSelected.Text" xml:space="preserve">
+    <value>展开所选内容</value>
+  </data>
+  <data name="this.cmiCollapseSelected.Text" xml:space="preserve">
+    <value>折叠所选内容</value>
+  </data>
+  <data name="this.cmiExpandAll.Text" xml:space="preserve">
+    <value>全部展开</value>
+  </data>
+  <data name="this.cmiCollapseAll.Text" xml:space="preserve">
+    <value>全部折叠</value>
+  </data>
+  <data name="this.cmiLvPlanTo.Text" xml:space="preserve">
+    <value>计划...(&amp;P)</value>
+  </data>
+  <data name="this.tsmLevel0.Text" xml:space="preserve">
+    <value>删除(&amp;R)</value>
+  </data>
+  <data name="this.tsmLevel1.Text" xml:space="preserve">
+    <value>等级&amp;1</value>
+  </data>
+  <data name="this.tsmLevel2.Text" xml:space="preserve">
+    <value>等级&amp;2</value>
+  </data>
+  <data name="this.tsmLevel3.Text" xml:space="preserve">
+    <value>等级&amp;3</value>
+  </data>
+  <data name="this.tsmLevel4.Text" xml:space="preserve">
+    <value>4级</value>
+  </data>
+  <data name="this.tsmLevel5.Text" xml:space="preserve">
+    <value>5级</value>
+  </data>
+  <data name="this.showInSkillBrowserListMenu.Text" xml:space="preserve">
+    <value>在技能和浏览器中显示</value>
+  </data>
+  <data name="this.showInSkillExplorerListMenu.Text" xml:space="preserve">
+    <value>在技能和资源管理器中显示...</value>
+  </data>
+  <data name="this.lbSearchTextHint.Text" xml:space="preserve">
+    <value>搜索文本</value>
+  </data>
+  <data name="this.lbNoMatches.Text" xml:space="preserve">
+    <value>没有符合您搜索条件的技能。</value>
+  </data>
+  <data name="this.cbShowNonPublic.Text" xml:space="preserve">
+    <value>展示非公共技能</value>
+  </data>
+  <data name="this.lblFilter.Text" xml:space="preserve">
+    <value>过滤器：</value>
+  </data>
+  <data name="this.lblSort.Text" xml:space="preserve">
+    <value>排序：</value>
+  </data>
+  <data name="this.chName.Text" xml:space="preserve">
+    <value>名称</value>
+  </data>
+  <data name="this.chSortKey.Text" xml:space="preserve">
+    <value>排序</value>
+  </data>
+  <data name="this.lblFilterBy.Text" xml:space="preserve">
+    <value>作者：</value>
+  </data>
+</root>

--- a/src/EVEMon/SkillPlanner/SkillTreeDisplayControl.zh-CN.resx
+++ b/src/EVEMon/SkillPlanner/SkillTreeDisplayControl.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Updater/DataUpdateDownloadForm.zh-CN.resx
+++ b/src/EVEMon/Updater/DataUpdateDownloadForm.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Updater/DataUpdateNotifyForm.zh-CN.resx
+++ b/src/EVEMon/Updater/DataUpdateNotifyForm.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Updater/UpdateDownloadForm.zh-CN.resx
+++ b/src/EVEMon/Updater/UpdateDownloadForm.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>

--- a/src/EVEMon/Updater/UpdateNotifyForm.zh-CN.resx
+++ b/src/EVEMon/Updater/UpdateNotifyForm.zh-CN.resx
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Name1" xml:space="preserve">
+    <value>这是我的长绳子</value>
+  </data>
+</root>


### PR DESCRIPTION
Closes #114.

## Summary
Adds Simplified Chinese (`zh-CN`) UI localization for EVEMon.

## Changelog
- Added persisted UI language selection with English and Simplified Chinese options.
- Applied selected culture at startup before runtime forms are created.
- Added `zh-CN` satellite resource files for runtime EVEMon projects.
- Moved common designer literals into `.resx` resources so translated UI strings can load correctly.
- Added restart-required messaging when the selected UI language changes.

## Validation
- `dotnet restore EVEMon.sln --source https://api.nuget.org/v3/index.json`
- `dotnet build EVEMon.sln -c Debug --no-restore`
- Resource validation: no missing `zh-CN` keys and no lost `{0}` placeholders.

## Notes
`dotnet test EVEMon.sln -c Debug --no-build --no-restore` still has one existing failure in `Tests.EVEMon.Common.AsyncVoidMethodsTests.EnsureNoAsyncVoidMethods` for pre-existing `SSOWebServerHttpListener` async-void methods.