### PR TITLE
fix: correct certificate filter typo

### DIFF
--- a/src/EVEMon.Common/Enumerations/CertificateFilter.cs
+++ b/src/EVEMon.Common/Enumerations/CertificateFilter.cs
@@ -13,7 +13,7 @@ namespace EVEMon.Common.Enumerations
         [Description("Hide Completed")]
         HideMaxLevel = 2,
 
-        [Description("Trrainable Next Level")]
+        [Description("Trainable Next Level")]
         NextLevelTrainable = 3,
 
         [Description("Untrainable Next Level")]


### PR DESCRIPTION
Fixes #141

## Summary
- Corrects the certificate filter label typo from "Trrainable" to "Trainable".

## Validation
- `dotnet test tests/Tests.EVEMon.Common/Tests.EVEMon.Common.csproj --no-restore --property:EnableWindowsTargeting=true`
- `git diff --check`