### PR TITLE
fix: deliver SDE datafiles from immutable Git tags

### DIFF
--- a/.github/scripts/Test-SdeDatafiles.ps1
+++ b/.github/scripts/Test-SdeDatafiles.ps1
@@ -1,0 +1,167 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9]+(?:\.[0-9]+)*$')]
+    [string]$Build,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
+    [string]$Repository,
+
+    [string]$BaselinePatch,
+
+    [switch]$Remote
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$expectedNames = @(
+    'eve-blueprints-en-US.xml.gzip'
+    'eve-certificates-en-US.xml.gzip'
+    'eve-geography-en-US.xml.gzip'
+    'eve-items-en-US.xml.gzip'
+    'eve-masteries-en-US.xml.gzip'
+    'eve-properties-en-US.xml.gzip'
+    'eve-reprocessing-en-US.xml.gzip'
+    'eve-skills-en-US.xml.gzip'
+)
+
+$workspace = if ($env:GITHUB_WORKSPACE) {
+    $env:GITHUB_WORKSPACE
+}
+else {
+    (Get-Location).Path
+}
+
+$resourcesDirectory = Join-Path $workspace 'src/EVEMon.Common/Resources'
+$patchPath = Join-Path $workspace 'updates/patch.xml'
+$tag = "sde-$Build"
+$expectedBaseUrl = "https://raw.githubusercontent.com/$Repository/$tag/src/EVEMon.Common/Resources"
+
+if (-not (Test-Path -LiteralPath $patchPath -PathType Leaf)) {
+    throw "patch.xml not found: $patchPath"
+}
+
+[xml]$patch = Get-Content -LiteralPath $patchPath -Raw
+
+if ($BaselinePatch) {
+    if (-not (Test-Path -LiteralPath $BaselinePatch -PathType Leaf)) {
+        throw "Baseline patch.xml not found: $BaselinePatch"
+    }
+
+    [xml]$baseline = Get-Content -LiteralPath $BaselinePatch -Raw
+    foreach ($sectionName in @('newest', 'releases')) {
+        $baselineSection = $baseline.SelectSingleNode("/evemon/$sectionName")
+        $currentSection = $patch.SelectSingleNode("/evemon/$sectionName")
+        if ($null -eq $baselineSection -or $null -eq $currentSection) {
+            throw "Required application-release section <$sectionName> is missing."
+        }
+
+        if ($baselineSection.OuterXml -cne $currentSection.OuterXml) {
+            throw "Application-release section <$sectionName> changed during the SDE update."
+        }
+    }
+}
+
+$entries = @($patch.evemon.datafiles.datafile)
+if ($entries.Count -ne $expectedNames.Count) {
+    throw "Expected exactly $($expectedNames.Count) datafile entries, found $($entries.Count)."
+}
+
+$entryNames = @($entries | ForEach-Object { [string]$_.name })
+$unexpectedNames = @($entryNames | Where-Object { $_ -cnotin $expectedNames })
+if ($unexpectedNames.Count -gt 0) {
+    throw "Unexpected datafile entries: $($unexpectedNames -join ', ')"
+}
+
+$downloadDirectory = $null
+try {
+    if ($Remote) {
+        $downloadDirectory = Join-Path ([IO.Path]::GetTempPath()) "evemon-sde-$Build-$PID"
+        [IO.Directory]::CreateDirectory($downloadDirectory) | Out-Null
+    }
+
+    foreach ($name in $expectedNames) {
+        $matchingEntries = @($entries | Where-Object { [string]$_.name -ceq $name })
+        if ($matchingEntries.Count -ne 1) {
+            throw "Expected exactly one patch.xml entry for $name, found $($matchingEntries.Count)."
+        }
+
+        $entry = $matchingEntries[0]
+        $entryUrl = [string]$entry.url
+        if ($entryUrl -cne $expectedBaseUrl) {
+            throw "Unexpected base URL for $name. Expected '$expectedBaseUrl', found '$entryUrl'."
+        }
+
+        $type = $name.Replace('eve-', '').Replace('-en-US.xml.gzip', '')
+        $expectedMessage = "SDE $Build $type data file by the EVEMon Development Team`nNOT COMPATIBLE with EVEMon prior to version 2.2.0"
+        $messageElements = @($entry.SelectNodes('./message'))
+        if ($messageElements.Count -ne 1) {
+            throw "Expected exactly one <message> element for $name, found $($messageElements.Count)."
+        }
+        $messageElement = $messageElements[0]
+        if ($messageElement.ChildNodes.Count -ne 1 -or
+            $messageElement.FirstChild.NodeType -ne [System.Xml.XmlNodeType]::CDATA) {
+            throw "Datafile message for $name must contain exactly one CDATA section."
+        }
+        if ([string]$messageElement.FirstChild.Value -cne $expectedMessage) {
+            throw "Unexpected datafile message for $name."
+        }
+
+        $localPath = Join-Path $resourcesDirectory $name
+        if (-not (Test-Path -LiteralPath $localPath -PathType Leaf)) {
+            throw "Local datafile not found: $localPath"
+        }
+
+        $manifestHash = [string]$entry.md5
+        if ($manifestHash -cnotmatch '^[0-9a-f]{32}$') {
+            throw "Invalid MD5 for $name. Expected exactly 32 lowercase hexadecimal characters, found '$manifestHash'."
+        }
+        $localHash = (Get-FileHash -LiteralPath $localPath -Algorithm MD5).Hash.ToLowerInvariant()
+        if ($localHash -cne $manifestHash) {
+            throw "Local MD5 mismatch for $name. patch.xml=$manifestHash local=$localHash"
+        }
+
+        if (-not $Remote) {
+            continue
+        }
+
+        $remoteUrl = "$entryUrl/$name"
+        $remotePath = Join-Path $downloadDirectory $name
+        $downloaded = $false
+        for ($attempt = 1; $attempt -le 6; $attempt++) {
+            try {
+                Invoke-WebRequest -Uri $remoteUrl -OutFile $remotePath
+                $downloaded = $true
+                break
+            }
+            catch {
+                if ($attempt -eq 6) {
+                    throw "Failed to download $remoteUrl after $attempt attempts: $($_.Exception.Message)"
+                }
+
+                Start-Sleep -Seconds 2
+            }
+        }
+
+        if (-not $downloaded) {
+            throw "Failed to download $remoteUrl."
+        }
+
+        $remoteHash = (Get-FileHash -LiteralPath $remotePath -Algorithm MD5).Hash.ToLowerInvariant()
+        if ($remoteHash -cne $manifestHash) {
+            throw "Remote MD5 mismatch for $name. patch.xml=$manifestHash remote=$remoteHash"
+        }
+
+        Write-Host "Validated $name ($manifestHash) from $remoteUrl"
+    }
+}
+finally {
+    if ($downloadDirectory -and [IO.Directory]::Exists($downloadDirectory)) {
+        [IO.Directory]::Delete($downloadDirectory, $true)
+    }
+}
+
+$scope = if ($Remote) { 'local and remote' } else { 'local' }
+Write-Host "Validated all $($expectedNames.Count) SDE datafiles ($scope) for $tag."

--- a/.github/scripts/Test-SdeDatafiles.ps1
+++ b/.github/scripts/Test-SdeDatafiles.ps1
@@ -8,6 +8,9 @@ param(
     [ValidatePattern('^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$')]
     [string]$Repository,
 
+    [ValidatePattern('^[A-Za-z0-9][A-Za-z0-9._-]*$')]
+    [string]$TagName,
+
     [string]$BaselinePatch,
 
     [switch]$Remote
@@ -36,7 +39,7 @@ else {
 
 $resourcesDirectory = Join-Path $workspace 'src/EVEMon.Common/Resources'
 $patchPath = Join-Path $workspace 'updates/patch.xml'
-$tag = "sde-$Build"
+$tag = if ($TagName) { $TagName } else { "sde-$Build" }
 $expectedBaseUrl = "https://raw.githubusercontent.com/$Repository/$tag/src/EVEMon.Common/Resources"
 
 if (-not (Test-Path -LiteralPath $patchPath -PathType Leaf)) {

--- a/.github/workflows/update-sde.yml
+++ b/.github/workflows/update-sde.yml
@@ -19,15 +19,21 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout workflow revision
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.sha }}
           fetch-depth: 0
 
       - name: Stage validation helper
         shell: pwsh
         run: Copy-Item -LiteralPath .github/scripts/Test-SdeDatafiles.ps1 -Destination "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1"
+
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
 
       - name: Inspect latest SDE and existing refs
         id: sde

--- a/.github/workflows/update-sde.yml
+++ b/.github/workflows/update-sde.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
           if [[ "$SANDBOX_MODE" == "true" ]]; then
-            BRANCH="test/sde-update-$BUILD-$GITHUB_RUN_ID"
+            BRANCH="automated/sde-test-$BUILD-$GITHUB_RUN_ID"
             TAG="test-sde-$BUILD-$GITHUB_RUN_ID"
             echo "Sandbox mode uses isolated branch $BRANCH and tag $TAG."
           else

--- a/.github/workflows/update-sde.yml
+++ b/.github/workflows/update-sde.yml
@@ -5,6 +5,12 @@ on:
     # Check daily at 14:00 UTC (after CCP's typical downtime)
     - cron: '0 14 * * *'
   workflow_dispatch:
+    inputs:
+      sandbox:
+        description: 'Use isolated test refs and create a draft test PR'
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: update-sde-datafiles
@@ -49,8 +55,14 @@ jobs:
             exit 1
           fi
 
-          BRANCH="automated/sde-update-$BUILD"
-          TAG="sde-$BUILD"
+          if [[ "$SANDBOX_MODE" == "true" ]]; then
+            BRANCH="test/sde-update-$BUILD-$GITHUB_RUN_ID"
+            TAG="test-sde-$BUILD-$GITHUB_RUN_ID"
+            echo "Sandbox mode uses isolated branch $BRANCH and tag $TAG."
+          else
+            BRANCH="automated/sde-update-$BUILD"
+            TAG="sde-$BUILD"
+          fi
           BRANCH_REF="refs/heads/$BRANCH"
           TAG_REF="refs/tags/$TAG"
 
@@ -135,6 +147,7 @@ jobs:
           echo "tag_commit=$TAG_COMMIT" >> "$GITHUB_OUTPUT"
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
           echo "pr_head_sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "sandbox=$SANDBOX_MODE" >> "$GITHUB_OUTPUT"
           echo "action=$ACTION" >> "$GITHUB_OUTPUT"
 
           if [[ "$ACTION" == "processed" ]]; then
@@ -148,6 +161,7 @@ jobs:
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          SANDBOX_MODE: ${{ github.event_name == 'workflow_dispatch' && (inputs.sandbox || github.ref_name != github.event.repository.default_branch) }}
 
       - name: Checkout existing SDE commit and stage baseline
         if: steps.sde.outputs.action == 'existing_branch' || steps.sde.outputs.action == 'existing_tag'
@@ -331,11 +345,17 @@ jobs:
           BRANCH="${{ steps.sde.outputs.branch }}"
           DATE="$(date -u +%Y-%m-%d)"
 
+          if [[ "${{ steps.sde.outputs.sandbox }}" == "true" ]]; then
+            COMMIT_MESSAGE="[TEST] Update datafiles for SDE $BUILD ($DATE)"
+          else
+            COMMIT_MESSAGE="Update datafiles for SDE $BUILD ($DATE)"
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add src/EVEMon.Common/Resources/ src/EVEMon.Common/Serialization/Flags.xml updates/patch.xml
-          git commit -m "Update datafiles for SDE $BUILD ($DATE)"
+          git commit -m "$COMMIT_MESSAGE"
 
       - name: Validate local datafile manifest
         if: steps.sde.outputs.action != 'processed' && (steps.sde.outputs.action != 'generate' || steps.changes.outputs.changed == 'true')
@@ -344,6 +364,7 @@ jobs:
           $validationParameters = @{
             Build = "${{ steps.sde.outputs.build }}"
             Repository = "${{ github.repository }}"
+            TagName = "${{ steps.sde.outputs.tag }}"
             BaselinePatch = "$env:RUNNER_TEMP/patch-before-sde.xml"
           }
           & "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1" @validationParameters
@@ -464,6 +485,7 @@ jobs:
           & "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1"
           -Build "${{ steps.sde.outputs.build }}"
           -Repository "${{ github.repository }}"
+          -TagName "${{ steps.sde.outputs.tag }}"
           -Remote
 
       - name: Create missing pull request
@@ -476,6 +498,7 @@ jobs:
           BRANCH="${{ steps.sde.outputs.branch }}"
           TAG="${{ steps.sde.outputs.tag }}"
           LARGE="${{ steps.diffcheck.outputs.large }}"
+          SANDBOX="${{ steps.sde.outputs.sandbox }}"
 
           EXISTING_PR="$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
@@ -492,6 +515,14 @@ jobs:
           BODY_FILE="$(mktemp)"
           trap 'rm -f "$BODY_FILE"' EXIT
 
+          if [[ "$SANDBOX" == "true" ]]; then
+            echo "> [!WARNING]" >> "$BODY_FILE"
+            echo "> Sandbox test only. Do not merge this pull request." >> "$BODY_FILE"
+            echo "" >> "$BODY_FILE"
+            echo "Workflow run: [${GITHUB_RUN_ID}](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})" >> "$BODY_FILE"
+            echo "" >> "$BODY_FILE"
+          fi
+
           echo "Generated from [eve-sde-converter ${{ steps.sde.outputs.upstream_tag }}](https://github.com/noirsoldats/eve-sde-converter/releases/tag/${{ steps.sde.outputs.upstream_tag }})." >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
           echo "Datafiles: [$TAG](https://github.com/${GITHUB_REPOSITORY}/tree/${TAG}/src/EVEMon.Common/Resources)" >> "$BODY_FILE"
@@ -503,10 +534,21 @@ jobs:
             echo "> Warning: This update is unusually large. Please inspect the generated data before merging." >> "$BODY_FILE"
           fi
 
-          gh pr create \
-            --title "Update datafiles for SDE $BUILD" \
-            --body-file "$BODY_FILE" \
-            --base main \
+          TITLE="Update datafiles for SDE $BUILD"
+          if [[ "$SANDBOX" == "true" ]]; then
+            TITLE="[TEST] $TITLE"
+          fi
+
+          PR_ARGS=(
+            --title "$TITLE"
+            --body-file "$BODY_FILE"
+            --base main
             --head "$BRANCH"
+          )
+          if [[ "$SANDBOX" == "true" ]]; then
+            PR_ARGS+=(--draft)
+          fi
+
+          gh pr create "${PR_ARGS[@]}"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/update-sde.yml
+++ b/.github/workflows/update-sde.yml
@@ -285,35 +285,6 @@ jobs:
             echo "Recorded unchanged SDE build with lightweight tag $TAG at $EXPECTED_SHA."
           fi
 
-      - name: Diff size sanity check
-        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
-        id: diffcheck
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          DIFF_BYTES=$(git diff --numstat src/EVEMon.Common/Resources/ | \
-            awk '{ total += $1 + $2 } END { print total+0 }')
-          echo "diff_bytes=$DIFF_BYTES" >> "$GITHUB_OUTPUT"
-
-          CHANGED_SIZE=0
-          for file in src/EVEMon.Common/Resources/*.xml.gzip; do
-            if ! git diff --quiet -- "$file" 2>/dev/null; then
-              SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null || echo 0)
-              CHANGED_SIZE=$((CHANGED_SIZE + SIZE))
-            fi
-          done
-          echo "changed_size=$CHANGED_SIZE" >> "$GITHUB_OUTPUT"
-
-          THRESHOLD=2097152
-          if [[ "$CHANGED_SIZE" -gt "$THRESHOLD" ]]; then
-            echo "large=true" >> "$GITHUB_OUTPUT"
-            echo "WARNING: Large diff detected (${CHANGED_SIZE} bytes changed). Flagging for review."
-          else
-            echo "large=false" >> "$GITHUB_OUTPUT"
-            echo "Diff size OK (${CHANGED_SIZE} bytes changed)."
-          fi
-
       - name: Build PatchXmlCreator
         if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
         run: dotnet build tools/PatchXmlCreator/PatchXmlCreator.csproj -c Release
@@ -497,7 +468,6 @@ jobs:
           BUILD="${{ steps.sde.outputs.build }}"
           BRANCH="${{ steps.sde.outputs.branch }}"
           TAG="${{ steps.sde.outputs.tag }}"
-          LARGE="${{ steps.diffcheck.outputs.large }}"
           SANDBOX="${{ steps.sde.outputs.sandbox }}"
 
           EXISTING_PR="$(gh pr list \
@@ -525,14 +495,40 @@ jobs:
 
           echo "Generated from [eve-sde-converter ${{ steps.sde.outputs.upstream_tag }}](https://github.com/noirsoldats/eve-sde-converter/releases/tag/${{ steps.sde.outputs.upstream_tag }})." >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
+
+          CHANGE_LINES=()
+          while IFS= read -r FILE; do
+            if [[ "$FILE" == "src/EVEMon.Common/Resources/MD5Sums.txt" ]]; then
+              continue
+            fi
+
+            OLD_SIZE=0
+            NEW_SIZE=0
+            if git cat-file -e "HEAD^:$FILE" 2>/dev/null; then
+              OLD_SIZE="$(git cat-file -s "HEAD^:$FILE")"
+            fi
+            if git cat-file -e "HEAD:$FILE" 2>/dev/null; then
+              NEW_SIZE="$(git cat-file -s "HEAD:$FILE")"
+            fi
+
+            DELTA=$((NEW_SIZE - OLD_SIZE))
+            if [[ "$DELTA" -gt 0 ]]; then
+              DELTA_TEXT="+$DELTA"
+            else
+              DELTA_TEXT="$DELTA"
+            fi
+            CHANGE_LINES+=("- \`${FILE##*/}\`: $OLD_SIZE -> $NEW_SIZE bytes ($DELTA_TEXT bytes)")
+          done < <(git diff --name-only HEAD^ HEAD -- \
+            src/EVEMon.Common/Resources/ \
+            src/EVEMon.Common/Serialization/Flags.xml)
+
+          echo "Changed generated files: ${#CHANGE_LINES[@]}" >> "$BODY_FILE"
+          printf '%s\n' "${CHANGE_LINES[@]}" >> "$BODY_FILE"
+          echo "" >> "$BODY_FILE"
+
           echo "Datafiles: [$TAG](https://github.com/${GITHUB_REPOSITORY}/tree/${TAG}/src/EVEMon.Common/Resources)" >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
           echo "Validation: all 8 tagged downloads succeeded and matched the MD5 hashes in \`patch.xml\`." >> "$BODY_FILE"
-
-          if [[ "$LARGE" == "true" ]]; then
-            echo "" >> "$BODY_FILE"
-            echo "> Warning: This update is unusually large. Please inspect the generated data before merging." >> "$BODY_FILE"
-          fi
 
           TITLE="Update datafiles for SDE $BUILD"
           if [[ "$SANDBOX" == "true" ]]; then

--- a/.github/workflows/update-sde.yml
+++ b/.github/workflows/update-sde.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 14 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: update-sde-datafiles
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write
@@ -17,55 +21,200 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Setup .NET 8
-        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          ref: main
+          fetch-depth: 0
 
-      - name: Get latest SDE release from eve-sde-converter
-        id: sde-release
+      - name: Stage validation helper
+        shell: pwsh
+        run: Copy-Item -LiteralPath .github/scripts/Test-SdeDatafiles.ps1 -Destination "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1"
+
+      - name: Inspect latest SDE and existing refs
+        id: sde
         shell: bash
         run: |
-          RELEASE=$(gh release view --repo noirsoldats/eve-sde-converter --json tagName,publishedAt -q '.tagName')
-          echo "tag=$RELEASE" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
 
-          # Extract build number from tag (e.g., sde-3279491 -> 3279491)
-          BUILD=$(echo "$RELEASE" | sed 's/sde-//')
-          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
-
-          # Check if a PR branch for this version already exists
-          if git ls-remote --heads origin "automated/sde-update-$BUILD" | grep -q .; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "SDE $BUILD already applied, skipping."
+          UPSTREAM_TAG="$(gh release view --repo noirsoldats/eve-sde-converter --json tagName -q '.tagName')"
+          if [[ "$UPSTREAM_TAG" =~ ^sde-([0-9]+([.][0-9]+)*)$ ]]; then
+            BUILD="${BASH_REMATCH[1]}"
           else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "New SDE version: $BUILD"
+            echo "Unexpected eve-sde-converter tag: $UPSTREAM_TAG" >&2
+            exit 1
+          fi
+
+          BRANCH="automated/sde-update-$BUILD"
+          TAG="sde-$BUILD"
+          BRANCH_REF="refs/heads/$BRANCH"
+          TAG_REF="refs/tags/$TAG"
+
+          remote_ref_sha() {
+            git ls-remote --refs origin "$1" | awk 'NR == 1 { print $1 }'
+          }
+
+          BRANCH_SHA="$(remote_ref_sha "$BRANCH_REF")"
+          TAG_REF_SHA="$(remote_ref_sha "$TAG_REF")"
+          TAG_COMMIT=""
+          if [[ -n "$TAG_REF_SHA" ]]; then
+            git fetch --quiet --no-tags origin "$TAG_REF"
+            TAG_COMMIT="$(git rev-parse 'FETCH_HEAD^{commit}')"
+          fi
+
+          if [[ -n "$BRANCH_SHA" && -n "$TAG_COMMIT" && "$BRANCH_SHA" != "$TAG_COMMIT" ]]; then
+            echo "Ref conflict for SDE $BUILD: $BRANCH_REF=$BRANCH_SHA but $TAG_REF resolves to $TAG_COMMIT." >&2
+            echo "Refusing to move the existing tag." >&2
+            exit 1
+          fi
+
+          PR_INFO="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --head "$BRANCH" \
+            --limit 100 \
+            --json number,state,url,headRefOid \
+            --jq 'if length == 0 then "" else .[0] | [.number, .state, .url, .headRefOid] | @tsv end')"
+          PR_NUMBER=""
+          PR_STATE=""
+          PR_URL=""
+          PR_HEAD_SHA=""
+          if [[ -n "$PR_INFO" ]]; then
+            IFS=$'\t' read -r PR_NUMBER PR_STATE PR_URL PR_HEAD_SHA <<< "$PR_INFO"
+            if [[ -z "$PR_HEAD_SHA" ]]; then
+              echo "PR #$PR_NUMBER has no resolvable head commit; refusing to repair refs." >&2
+              exit 1
+            fi
+            if [[ -n "$BRANCH_SHA" && "$BRANCH_SHA" != "$PR_HEAD_SHA" ]]; then
+              echo "Ref conflict for SDE $BUILD: $BRANCH_REF=$BRANCH_SHA but PR #$PR_NUMBER points to $PR_HEAD_SHA." >&2
+              exit 1
+            fi
+            if [[ -n "$TAG_COMMIT" && "$TAG_COMMIT" != "$PR_HEAD_SHA" ]]; then
+              echo "Ref conflict for SDE $BUILD: $TAG_REF resolves to $TAG_COMMIT but PR #$PR_NUMBER points to $PR_HEAD_SHA." >&2
+              echo "Refusing to move the existing tag." >&2
+              exit 1
+            fi
+          fi
+
+          ACTION="generate"
+          if [[ -n "$TAG_COMMIT" && -n "$BRANCH_SHA" && -n "$PR_NUMBER" ]]; then
+            # The complete publication state already agrees at one commit.
+            ACTION="processed"
+          elif [[ -n "$TAG_COMMIT" && -n "$PR_NUMBER" && "$PR_STATE" != "OPEN" ]]; then
+            # Deleted branches are normal after a pull request is closed or merged.
+            ACTION="processed"
+          elif [[ -n "$BRANCH_SHA" ]]; then
+            # Reconcile a missing tag and/or pull request from the branch commit.
+            ACTION="existing_branch"
+          elif [[ -n "$TAG_COMMIT" ]]; then
+            if [[ -n "$PR_NUMBER" ]]; then
+              # Recreate the branch for an open pull request at its agreeing tag commit.
+              ACTION="existing_tag"
+            elif git merge-base --is-ancestor "$TAG_COMMIT" HEAD; then
+              # A tag on main with no branch/PR records a build with no data changes.
+              ACTION="processed"
+            else
+              # Recreate a missing branch at the immutable tag commit.
+              ACTION="existing_tag"
+            fi
+          elif [[ -n "$PR_NUMBER" ]]; then
+            echo "PR #$PR_NUMBER exists for $BRANCH, but both its branch and $TAG are missing." >&2
+            echo "Refusing to guess a replacement commit." >&2
+            exit 1
+          fi
+
+          echo "upstream_tag=$UPSTREAM_TAG" >> "$GITHUB_OUTPUT"
+          echo "build=$BUILD" >> "$GITHUB_OUTPUT"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "branch_sha=$BRANCH_SHA" >> "$GITHUB_OUTPUT"
+          echo "tag_commit=$TAG_COMMIT" >> "$GITHUB_OUTPUT"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_head_sha=$PR_HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "action=$ACTION" >> "$GITHUB_OUTPUT"
+
+          if [[ "$ACTION" == "processed" ]]; then
+            if [[ -n "$PR_NUMBER" ]]; then
+              echo "SDE $BUILD is already tracked by $TAG and PR #$PR_NUMBER ($PR_STATE): $PR_URL"
+            else
+              echo "SDE $BUILD is already recorded by $TAG on main (no data changes)."
+            fi
+          else
+            echo "SDE $BUILD requires workflow action: $ACTION"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
 
-      - name: Download SDE database
-        if: steps.sde-release.outputs.skip == 'false'
+      - name: Checkout existing SDE commit and stage baseline
+        if: steps.sde.outputs.action == 'existing_branch' || steps.sde.outputs.action == 'existing_tag'
         shell: bash
         run: |
-          gh release download ${{ steps.sde-release.outputs.tag }} \
+          set -euo pipefail
+
+          BRANCH="${{ steps.sde.outputs.branch }}"
+          if [[ "${{ steps.sde.outputs.action }}" == "existing_branch" ]]; then
+            BRANCH_REF="refs/heads/$BRANCH"
+            git fetch --force --no-tags origin "$BRANCH_REF:refs/remotes/origin/$BRANCH"
+            FETCHED_BRANCH_SHA="$(git rev-parse "refs/remotes/origin/$BRANCH^{commit}")"
+            if [[ "$FETCHED_BRANCH_SHA" != "${{ steps.sde.outputs.branch_sha }}" ]]; then
+              echo "$BRANCH_REF changed during inspection; refusing to repair from a different commit." >&2
+              exit 1
+            fi
+            git checkout -B "$BRANCH" "refs/remotes/origin/$BRANCH"
+          else
+            TAG_REF="refs/tags/${{ steps.sde.outputs.tag }}"
+            git fetch --quiet --no-tags origin "$TAG_REF"
+            TAG_COMMIT="$(git rev-parse 'FETCH_HEAD^{commit}')"
+            if [[ "$TAG_COMMIT" != "${{ steps.sde.outputs.tag_commit }}" ]]; then
+              echo "$TAG_REF changed during inspection; refusing to repair from a moved tag." >&2
+              exit 1
+            fi
+            git checkout -B "$BRANCH" "$TAG_COMMIT"
+          fi
+
+          RECOVERED_SHA="$(git rev-parse 'HEAD^{commit}')"
+          PARENT_TEXT="$(git show -s --format=%P "$RECOVERED_SHA")"
+          read -r -a PARENTS <<< "$PARENT_TEXT"
+          if [[ "${#PARENTS[@]}" -ne 1 ]]; then
+            echo "Recovered SDE commit $RECOVERED_SHA must have exactly one parent; found ${#PARENTS[@]}." >&2
+            exit 1
+          fi
+          PARENT_SHA="${PARENTS[0]}"
+          if ! git cat-file -e "${PARENT_SHA}^{commit}" 2>/dev/null; then
+            echo "Recovered SDE parent $PARENT_SHA is unavailable; refusing to validate without it." >&2
+            exit 1
+          fi
+          if ! git show "${PARENT_SHA}:updates/patch.xml" > "$RUNNER_TEMP/patch-before-sde.xml"; then
+            echo "Could not read updates/patch.xml from recovered SDE parent $PARENT_SHA." >&2
+            exit 1
+          fi
+
+      - name: Setup .NET 8
+        if: steps.sde.outputs.action == 'generate'
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Download SDE database
+        if: steps.sde.outputs.action == 'generate'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh release download "${{ steps.sde.outputs.upstream_tag }}" \
             --repo noirsoldats/eve-sde-converter \
             --pattern "eve.db" \
             --dir tools/XmlGenerator
-          # XmlGenerator expects sqlite-latest.sqlite
           mv tools/XmlGenerator/eve.db tools/XmlGenerator/sqlite-latest.sqlite
-          echo "Downloaded SDE database (${{ steps.sde-release.outputs.tag }})"
+          echo "Downloaded SDE database (${{ steps.sde.outputs.upstream_tag }})"
           ls -lh tools/XmlGenerator/sqlite-latest.sqlite
         env:
           GH_TOKEN: ${{ github.token }}
 
       - name: Build XmlGenerator
-        if: steps.sde-release.outputs.skip == 'false'
+        if: steps.sde.outputs.action == 'generate'
         run: dotnet build tools/XmlGenerator/XmlGenerator.csproj -c Release
 
       - name: Run XmlGenerator
-        if: steps.sde-release.outputs.skip == 'false'
+        if: steps.sde.outputs.action == 'generate'
         shell: cmd
         run: |
           REM App.config has Data Source=..\..\sqlite-latest.sqlite
@@ -73,13 +222,15 @@ jobs:
           copy tools\XmlGenerator\sqlite-latest.sqlite tools\XmlGenerator\bin\sqlite-latest.sqlite
           cd tools\XmlGenerator\bin\Release\net8.0-windows
           EVEMonXmlGenerator.exe
-          if %ERRORLEVEL% NEQ 0 echo XmlGenerator exited with code %ERRORLEVEL%
+          if %ERRORLEVEL% NEQ 0 exit /b %ERRORLEVEL%
 
       - name: Check for changes
-        if: steps.sde-release.outputs.skip == 'false'
+        if: steps.sde.outputs.action == 'generate'
         id: changes
         shell: bash
         run: |
+          set -euo pipefail
+
           if git diff --quiet src/EVEMon.Common/Resources/ src/EVEMon.Common/Serialization/Flags.xml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No datafile changes detected."
@@ -89,29 +240,53 @@ jobs:
             git diff --stat src/EVEMon.Common/Resources/ src/EVEMon.Common/Serialization/Flags.xml
           fi
 
+      - name: Record unchanged SDE build
+        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          TAG="${{ steps.sde.outputs.tag }}"
+          TAG_REF="refs/tags/$TAG"
+          EXPECTED_SHA="$(git rev-parse HEAD)"
+          REMOTE_TAG_REF_SHA="$(git ls-remote --refs origin "$TAG_REF" | awk 'NR == 1 { print $1 }')"
+
+          if [[ -n "$REMOTE_TAG_REF_SHA" ]]; then
+            git fetch --quiet --no-tags origin "$TAG_REF"
+            REMOTE_TAG_COMMIT="$(git rev-parse 'FETCH_HEAD^{commit}')"
+            if [[ "$REMOTE_TAG_COMMIT" != "$EXPECTED_SHA" ]]; then
+              echo "$TAG already exists at $REMOTE_TAG_COMMIT, expected $EXPECTED_SHA. Refusing to move it." >&2
+              exit 1
+            fi
+            echo "$TAG already records this unchanged SDE build."
+          else
+            git tag "$TAG" "$EXPECTED_SHA"
+            git push origin "$TAG_REF:$TAG_REF"
+            echo "Recorded unchanged SDE build with lightweight tag $TAG at $EXPECTED_SHA."
+          fi
+
       - name: Diff size sanity check
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
         id: diffcheck
         shell: bash
         run: |
-          # Calculate total size of changed datafiles in bytes
+          set -euo pipefail
+
           DIFF_BYTES=$(git diff --numstat src/EVEMon.Common/Resources/ | \
             awk '{ total += $1 + $2 } END { print total+0 }')
           echo "diff_bytes=$DIFF_BYTES" >> "$GITHUB_OUTPUT"
 
-          # Binary files report as - / - in numstat, so also check raw byte diff
           CHANGED_SIZE=0
-          for f in src/EVEMon.Common/Resources/*.xml.gzip; do
-            if ! git diff --quiet -- "$f" 2>/dev/null; then
-              SIZE=$(stat -c%s "$f" 2>/dev/null || stat -f%z "$f" 2>/dev/null || echo 0)
+          for file in src/EVEMon.Common/Resources/*.xml.gzip; do
+            if ! git diff --quiet -- "$file" 2>/dev/null; then
+              SIZE=$(stat -c%s "$file" 2>/dev/null || stat -f%z "$file" 2>/dev/null || echo 0)
               CHANGED_SIZE=$((CHANGED_SIZE + SIZE))
             fi
           done
           echo "changed_size=$CHANGED_SIZE" >> "$GITHUB_OUTPUT"
 
-          # Threshold: 2MB of changed file size is unusual for a routine SDE update
           THRESHOLD=2097152
-          if [ "$CHANGED_SIZE" -gt "$THRESHOLD" ]; then
+          if [[ "$CHANGED_SIZE" -gt "$THRESHOLD" ]]; then
             echo "large=true" >> "$GITHUB_OUTPUT"
             echo "WARNING: Large diff detected (${CHANGED_SIZE} bytes changed). Flagging for review."
           else
@@ -120,105 +295,212 @@ jobs:
           fi
 
       - name: Build PatchXmlCreator
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
         run: dotnet build tools/PatchXmlCreator/PatchXmlCreator.csproj -c Release
 
       - name: Update patch.xml
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
         shell: bash
         run: |
-          BUILD=${{ steps.sde-release.outputs.build }}
-          REPO="${{ github.repository }}"
+          set -euo pipefail
+
+          BUILD="${{ steps.sde.outputs.build }}"
+          TAG="${{ steps.sde.outputs.tag }}"
+          RAW_BASE="https://raw.githubusercontent.com/${GITHUB_REPOSITORY}/${TAG}/src/EVEMon.Common/Resources"
+          cp updates/patch.xml "$RUNNER_TEMP/patch-before-sde.xml"
           dotnet run --project tools/PatchXmlCreator/PatchXmlCreator.csproj -c Release --no-build -- \
             datafiles-only \
             updates/patch.xml \
             src/EVEMon.Common/Resources \
-            "https://github.com/${REPO}/releases/download/sde-${BUILD}" \
+            "$RAW_BASE" \
             "$BUILD"
 
-      - name: Create branch and commit
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+      - name: Create local SDE commit
+        if: steps.sde.outputs.action == 'generate' && steps.changes.outputs.changed == 'true'
         shell: bash
         run: |
-          BUILD=${{ steps.sde-release.outputs.build }}
-          BRANCH="automated/sde-update-$BUILD"
-          DATE=$(date -u +%Y-%m-%d)
+          set -euo pipefail
+
+          BUILD="${{ steps.sde.outputs.build }}"
+          BRANCH="${{ steps.sde.outputs.branch }}"
+          DATE="$(date -u +%Y-%m-%d)"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add src/EVEMon.Common/Resources/ src/EVEMon.Common/Serialization/Flags.xml updates/patch.xml
           git commit -m "Update datafiles for SDE $BUILD ($DATE)"
-          git push origin "$BRANCH"
 
-      - name: Create release with datafile assets
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+      - name: Validate local datafile manifest
+        if: steps.sde.outputs.action != 'processed' && (steps.sde.outputs.action != 'generate' || steps.changes.outputs.changed == 'true')
+        shell: pwsh
+        run: |
+          $validationParameters = @{
+            Build = "${{ steps.sde.outputs.build }}"
+            Repository = "${{ github.repository }}"
+            BaselinePatch = "$env:RUNNER_TEMP/patch-before-sde.xml"
+          }
+          & "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1" @validationParameters
+
+      - name: Publish or reconcile branch and tag
+        if: steps.sde.outputs.action != 'processed' && (steps.sde.outputs.action != 'generate' || steps.changes.outputs.changed == 'true')
         shell: bash
         run: |
-          BUILD=${{ steps.sde-release.outputs.build }}
+          set -euo pipefail
 
-          # Create release with datafile assets (skip if it already exists)
-          if gh release view "sde-${BUILD}" > /dev/null 2>&1; then
-            echo "Release sde-${BUILD} already exists, skipping."
-          else
-            gh release create "sde-${BUILD}" \
-              --title "SDE ${BUILD} Datafiles" \
-              --notes "Automated datafile release from CCP SDE build ${BUILD}." \
-              --target "automated/sde-update-${BUILD}" \
-              src/EVEMon.Common/Resources/eve-*-en-US.xml.gzip
+          ACTION="${{ steps.sde.outputs.action }}"
+          BRANCH="${{ steps.sde.outputs.branch }}"
+          TAG="${{ steps.sde.outputs.tag }}"
+          BRANCH_REF="refs/heads/$BRANCH"
+          TAG_REF="refs/tags/$TAG"
+          EXPECTED_SHA="$(git rev-parse HEAD)"
+          INSPECTED_BRANCH_SHA="${{ steps.sde.outputs.branch_sha }}"
+          INSPECTED_TAG_COMMIT="${{ steps.sde.outputs.tag_commit }}"
+
+          remote_ref_sha() {
+            git ls-remote --refs origin "$1" | awk 'NR == 1 { print $1 }'
+          }
+
+          remote_tag_commit() {
+            local tag_ref_sha
+            tag_ref_sha="$(remote_ref_sha "$TAG_REF")"
+            if [[ -z "$tag_ref_sha" ]]; then
+              echo ""
+              return 0
+            fi
+            git fetch --quiet --no-tags origin "$TAG_REF"
+            git rev-parse 'FETCH_HEAD^{commit}'
+          }
+
+          CURRENT_BRANCH_SHA="$(remote_ref_sha "$BRANCH_REF")"
+          CURRENT_TAG_COMMIT="$(remote_tag_commit)"
+
+          if [[ -n "$INSPECTED_BRANCH_SHA" && "$CURRENT_BRANCH_SHA" != "$INSPECTED_BRANCH_SHA" ]]; then
+            echo "$BRANCH_REF changed during the run: inspected=$INSPECTED_BRANCH_SHA current=$CURRENT_BRANCH_SHA." >&2
+            exit 1
           fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+          if [[ -n "$INSPECTED_TAG_COMMIT" && "$CURRENT_TAG_COMMIT" != "$INSPECTED_TAG_COMMIT" ]]; then
+            echo "$TAG_REF changed during the run: inspected=$INSPECTED_TAG_COMMIT current=$CURRENT_TAG_COMMIT." >&2
+            echo "Refusing to move or repair from a moved tag." >&2
+            exit 1
+          fi
 
-      - name: Create Pull Request
-        if: steps.sde-release.outputs.skip == 'false' && steps.changes.outputs.changed == 'true'
+          if [[ -n "$CURRENT_BRANCH_SHA" && -n "$CURRENT_TAG_COMMIT" && "$CURRENT_BRANCH_SHA" != "$CURRENT_TAG_COMMIT" ]]; then
+            echo "Ref conflict: $BRANCH_REF=$CURRENT_BRANCH_SHA but $TAG_REF resolves to $CURRENT_TAG_COMMIT." >&2
+            echo "Refusing to move the existing tag." >&2
+            exit 1
+          fi
+
+          case "$ACTION" in
+            generate)
+              if [[ -n "$CURRENT_BRANCH_SHA" || -n "$CURRENT_TAG_COMMIT" ]]; then
+                echo "A remote SDE ref appeared after inspection; refusing to overwrite it." >&2
+                exit 1
+              fi
+              git tag "$TAG" "$EXPECTED_SHA"
+              git push --atomic origin \
+                "$BRANCH_REF:$BRANCH_REF" \
+                "$TAG_REF:$TAG_REF"
+              ;;
+
+            existing_branch)
+              if [[ "$CURRENT_BRANCH_SHA" != "$EXPECTED_SHA" ]]; then
+                echo "$BRANCH_REF moved from $EXPECTED_SHA to $CURRENT_BRANCH_SHA; refusing to continue." >&2
+                exit 1
+              fi
+              if [[ -z "$CURRENT_TAG_COMMIT" ]]; then
+                git tag "$TAG" "$EXPECTED_SHA"
+                git push --atomic \
+                  --force-with-lease="$BRANCH_REF:$EXPECTED_SHA" \
+                  origin \
+                  "$BRANCH_REF:$BRANCH_REF" \
+                  "$TAG_REF:$TAG_REF"
+              elif [[ "$CURRENT_TAG_COMMIT" != "$EXPECTED_SHA" ]]; then
+                echo "$TAG_REF resolves to $CURRENT_TAG_COMMIT, expected $EXPECTED_SHA. Refusing to move it." >&2
+                exit 1
+              fi
+              ;;
+
+            existing_tag)
+              if [[ "$CURRENT_TAG_COMMIT" != "$EXPECTED_SHA" ]]; then
+                echo "$TAG_REF moved from $EXPECTED_SHA to $CURRENT_TAG_COMMIT; refusing to continue." >&2
+                exit 1
+              fi
+              if [[ -z "$CURRENT_BRANCH_SHA" ]]; then
+                git push \
+                  --force-with-lease="$BRANCH_REF:" \
+                  origin \
+                  "$BRANCH_REF:$BRANCH_REF"
+              elif [[ "$CURRENT_BRANCH_SHA" != "$EXPECTED_SHA" ]]; then
+                echo "$BRANCH_REF is at $CURRENT_BRANCH_SHA, expected $EXPECTED_SHA." >&2
+                exit 1
+              fi
+              ;;
+
+            *)
+              echo "Unsupported SDE action: $ACTION" >&2
+              exit 1
+              ;;
+          esac
+
+          FINAL_BRANCH_SHA="$(remote_ref_sha "$BRANCH_REF")"
+          FINAL_TAG_COMMIT="$(remote_tag_commit)"
+          if [[ "$FINAL_BRANCH_SHA" != "$EXPECTED_SHA" || "$FINAL_TAG_COMMIT" != "$EXPECTED_SHA" ]]; then
+            echo "Remote ref verification failed: branch=$FINAL_BRANCH_SHA tag=$FINAL_TAG_COMMIT expected=$EXPECTED_SHA" >&2
+            exit 1
+          fi
+          echo "Verified $BRANCH_REF and lightweight $TAG_REF at $EXPECTED_SHA."
+
+      - name: Validate tagged datafile downloads
+        if: steps.sde.outputs.action != 'processed' && (steps.sde.outputs.action != 'generate' || steps.changes.outputs.changed == 'true')
+        shell: pwsh
+        run: >-
+          & "$env:RUNNER_TEMP/Test-SdeDatafiles.ps1"
+          -Build "${{ steps.sde.outputs.build }}"
+          -Repository "${{ github.repository }}"
+          -Remote
+
+      - name: Create missing pull request
+        if: steps.sde.outputs.action != 'processed' && (steps.sde.outputs.action != 'generate' || steps.changes.outputs.changed == 'true')
         shell: bash
         run: |
-          BUILD=${{ steps.sde-release.outputs.build }}
-          DATE=$(date -u +%Y-%m-%d)
+          set -euo pipefail
+
+          BUILD="${{ steps.sde.outputs.build }}"
+          BRANCH="${{ steps.sde.outputs.branch }}"
+          TAG="${{ steps.sde.outputs.tag }}"
           LARGE="${{ steps.diffcheck.outputs.large }}"
-          CHANGED_SIZE="${{ steps.diffcheck.outputs.changed_size }}"
-          DIFF_STAT=$(git diff --stat HEAD~1)
 
-          # Build PR body in a temp file to avoid YAML/heredoc issues
-          BODY_FILE=$(mktemp)
-          echo "## Summary" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "Automated update of EVEMon datafiles from CCP's Static Data Export." >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "- **SDE Build:** $BUILD" >> "$BODY_FILE"
-          echo "- **Source:** [eve-sde-converter ${{ steps.sde-release.outputs.tag }}](https://github.com/noirsoldats/eve-sde-converter/releases/tag/${{ steps.sde-release.outputs.tag }})" >> "$BODY_FILE"
-          echo "- **Date:** $DATE" >> "$BODY_FILE"
-          echo "- **Release:** [sde-${BUILD}](https://github.com/${{ github.repository }}/releases/tag/sde-${BUILD})" >> "$BODY_FILE"
-
-          if [ "$LARGE" = "true" ]; then
-            echo "" >> "$BODY_FILE"
-            echo "> **Warning:** This update is unusually large (${CHANGED_SIZE} bytes of changed datafiles). This may indicate a major game patch or warrants closer inspection before merging." >> "$BODY_FILE"
+          EXISTING_PR="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all \
+            --head "$BRANCH" \
+            --limit 100 \
+            --json number,state,url \
+            --jq 'if length == 0 then "" else .[0] | "#\(.number) (\(.state)): \(.url)" end')"
+          if [[ -n "$EXISTING_PR" ]]; then
+            echo "SDE $BUILD already has a pull request: $EXISTING_PR"
+            exit 0
           fi
 
+          BODY_FILE="$(mktemp)"
+          trap 'rm -f "$BODY_FILE"' EXIT
+
+          echo "Generated from [eve-sde-converter ${{ steps.sde.outputs.upstream_tag }}](https://github.com/noirsoldats/eve-sde-converter/releases/tag/${{ steps.sde.outputs.upstream_tag }})." >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
-          echo "### Changes" >> "$BODY_FILE"
+          echo "Datafiles: [$TAG](https://github.com/${GITHUB_REPOSITORY}/tree/${TAG}/src/EVEMon.Common/Resources)" >> "$BODY_FILE"
           echo "" >> "$BODY_FILE"
-          echo "- Updated datafiles in \`src/EVEMon.Common/Resources/\`" >> "$BODY_FILE"
-          echo "- Updated \`updates/patch.xml\` with new MD5 checksums and release asset URLs" >> "$BODY_FILE"
-          echo "- Created release \`sde-${BUILD}\` with datafile assets for live patching" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "### Changed files" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "$DIFF_STAT" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "## Test plan" >> "$BODY_FILE"
-          echo "" >> "$BODY_FILE"
-          echo "- [ ] Verify EVEMon loads without errors" >> "$BODY_FILE"
-          echo "- [ ] Spot-check new items/skills appear in the skill browser" >> "$BODY_FILE"
-          echo "- [ ] Verify live patching works (patch.xml points to correct release assets)" >> "$BODY_FILE"
+          echo "Validation: all 8 tagged downloads succeeded and matched the MD5 hashes in \`patch.xml\`." >> "$BODY_FILE"
+
+          if [[ "$LARGE" == "true" ]]; then
+            echo "" >> "$BODY_FILE"
+            echo "> Warning: This update is unusually large. Please inspect the generated data before merging." >> "$BODY_FILE"
+          fi
 
           gh pr create \
             --title "Update datafiles for SDE $BUILD" \
             --body-file "$BODY_FILE" \
             --base main \
-            --head "automated/sde-update-$BUILD"
-
-          rm -f "$BODY_FILE"
+            --head "$BRANCH"
         env:
           GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![GPL licensed](https://img.shields.io/badge/license-GPL%20v2-blue.svg)]()
-[![GitHub tag](https://img.shields.io/github/tag/mgoeppner/evemon.svg)]()
+[![GitHub tag](https://img.shields.io/github/v/tag/mgoeppner/evemon?filter=v%2A&sort=semver)]()
 [![CI](https://github.com/mgoeppner/evemon/actions/workflows/ci.yml/badge.svg)](https://github.com/mgoeppner/evemon/actions/workflows/ci.yml)
 [![Installer](https://github.com/mgoeppner/evemon/actions/workflows/installer.yml/badge.svg)](https://github.com/mgoeppner/evemon/actions/workflows/installer.yml)
 

--- a/updates/patch.xml
+++ b/updates/patch.xml
@@ -31,7 +31,7 @@
       <name>eve-blueprints-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>a1afd8f0137db993f0696bcb69f92aac</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 blueprints data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -39,7 +39,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-certificates-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>a3ba391840d18fa94295f409979369f3</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 certificates data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -47,7 +47,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-geography-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>1daa4b67cb8b8ddd88d8031d91c3d0d1</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 geography data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -55,7 +55,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-items-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>8d8b485b6fe87c010d67caa669f69acc</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 items data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -63,7 +63,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-masteries-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>d90a87970f30775b8b6d58f8b6002688</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 masteries data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -71,7 +71,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-properties-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>0b0b626102c661622e79265599bb4fa9</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 properties data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -79,7 +79,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-reprocessing-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>dcccef0bc1f94bf6cf4d24a1f2809fda</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 reprocessing data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>
@@ -87,7 +87,7 @@ NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
       <name>eve-skills-en-US.xml.gzip</name>
       <date>20 August 2026</date>
       <md5>f9bdc0906d1ecaa28ff7d2ffb51bffd2</md5>
-      <url>https://github.com/mgoeppner/evemon/releases/download/sde-3475087</url>
+      <url>https://raw.githubusercontent.com/mgoeppner/evemon/sde-3475087/src/EVEMon.Common/Resources</url>
       <message><![CDATA[SDE 3475087 skills data file by the EVEMon Development Team
 NOT COMPATIBLE with EVEMon prior to version 2.2.0]]></message>
     </datafile>


### PR DESCRIPTION
## Why

Each SDE update currently creates a GitHub Release. This mixes data updates with real EVEMon app releases and can make an SDE build appear as the Latest release.

This PR keeps the same eight datafiles and the same `patch.xml` format. EVEMon will download them from permanent `sde-BUILD` Git tags instead. No client change is needed.

## What changes

- Continue reading new SDE builds from [noirsoldats/eve-sde-converter](https://github.com/noirsoldats/eve-sde-converter/releases)
- Stop creating SDE Releases in the EVEMon repository
- Publish changed builds with an immutable `sde-BUILD` tag and an update PR
- Record unchanged builds with only an `sde-BUILD` tag
- Download datafiles from their raw Git tag URL
- Validate all eight files locally before publishing
- Download all eight public files after publishing and check their MD5 hashes again
- Stop safely when existing branches, tags, or PRs point to different commits
- Move the current `sde-3475087` URLs to its existing raw tag
- Make the README badge show only `v*` application tags

Application Releases, installer links, and the `patch.xml` schema are unchanged.

### Optional sandbox mode

Manual runs can use isolated test refs and create a `[TEST]` draft PR. Runs started from a non-main branch use sandbox mode automatically.

Sandbox runs never touch production `automated/sde-update-*` branches or `sde-*` tags. A sandbox draft PR is only for testing and must not be merged.

## Testing

A full sandbox run completed successfully:

- [Workflow run 33273494930](https://github.com/emyth-juk/evemon/actions/runs/33273494930)
- [Draft test PR #60](https://github.com/emyth-juk/evemon/pull/60)
- Build `sde-3484357`
- Test branch and lightweight tag both point to [commit `9e043e2c`](https://github.com/emyth-juk/evemon/commit/9e043e2c990f00a62ee07310364becbb407cbaf2)
- All eight local files passed validation
- All eight public downloads succeeded
- Every downloaded file matched its MD5 hash in `patch.xml`
- [v5.0.1](https://github.com/emyth-juk/evemon/releases/tag/v5.0.1) stayed the Latest release


## Before merging
@mgoeppner 
- Confirm that GitHub Actions can create `automated/sde-update-*` branches, `sde-*` tags, and pull requests. The workflow requests `contents: write` and `pull-requests: write`
- Keep every existing production `sde-*` tag unchanged
- Do not update or move [`sde-3484357`](https://github.com/mgoeppner/evemon/tree/sde-3484357)
- Do not amend or reopen [PR #183](https://github.com/mgoeppner/evemon/pull/183). Its immutable tag points to the old, closed candidate commit
- Use a separate migration PR for SDE 3484357 after this workflow PR is merged

## Rollout after merging

- Create the separate SDE 3484357 migration PR without moving its tag
- Mark [v5.0.1](https://github.com/mgoeppner/evemon/releases/tag/v5.0.1) as Latest
- After the live feed uses raw URLs, delete the old SDE Release records but keep every Git tag
- Keep the `sde-3475087` Release record for seven days
- After seven days, delete only that Release record and keep its tag

These cleanup steps are manual. The workflow does not delete old Releases.

<details> <summary>Production SDE update flow</summary>

```mermaid
flowchart TD
    subgraph P1["1. Inspect"]
        INSPECT["GitHub Actions runs daily or manually<br/>GitHub CLI reads the newest Noirsoldats SDE and PRs<br/>Git checks branch and tag state"]:::auto
        DECIDE{"State of<br/>sde-BUILD?"}:::auto
        INSPECT --> DECIDE
    end

    subgraph P2["2. Generate"]
        GEN["GitHub CLI downloads eve.db<br/>XmlGenerator builds 8 compressed XML datafiles<br/>plus Flags.xml and MD5Sums.txt"]:::tool
        CHANGED{"EVEMon data<br/>changed?"}:::auto
        TAGONLY["Git tags main as sde-BUILD<br/>No PR needed"]:::auto
        PATCH["PatchXmlCreator updates patch.xml<br/>Raw URL, date, message, and MD5<br/>Git creates the SDE commit"]:::tool

        GEN --> CHANGED
        CHANGED -->|"no"| TAGONLY
        CHANGED -->|"yes"| PATCH
    end

    subgraph P3["3. Validate and publish"]
        LOCAL["Test-SdeDatafiles.ps1 checks local data<br/>8 names, URLs, messages, and MD5 hashes<br/>App release sections must stay unchanged"]:::check
        PUBLISH["Git publishes or repairs production refs<br/>A new branch and tag are pushed atomically<br/>No GitHub Release is created"]:::auto
        REMOTE["Test-SdeDatafiles.ps1 downloads all 8 files<br/>from the raw tag and checks every MD5"]:::check
        PR["GitHub CLI creates the update PR<br/>if it is missing"]:::auto

        LOCAL -->|"valid"| PUBLISH
        PUBLISH --> REMOTE
        REMOTE -->|"valid"| PR
    end

    subgraph P4["4. Consume"]
        MERGE["Maintainer reviews<br/>and merges the PR"]:::user
        CLIENT["EVEMon UpdateManager and data updater<br/>read patch.xml, download from the raw tag<br/>and check MD5 before replacing files"]:::user

        MERGE --> CLIENT
    end

    REPAIR["Git checks out the existing SDE commit<br/>and its parent patch.xml as the baseline"]:::auto
    DONE(["Done"]):::good
    STOP(["Stop safely<br/>Existing SDE tags never move"]):::halt

    DECIDE -->|"new build"| GEN
    DECIDE -->|"partial state, SHAs agree"| REPAIR
    DECIDE -->|"already processed"| DONE
    DECIDE -->|"unsafe or conflicting state"| STOP

    REPAIR --> LOCAL
    PATCH --> LOCAL
    TAGONLY --> DONE
    PR --> MERGE
    LOCAL -->|"invalid"| STOP
    REMOTE -->|"mismatch"| STOP

    classDef auto fill:#1D4ED8,stroke:#60A5FA,color:#FFFFFF,stroke-width:1.5px
    classDef tool fill:#6D28D9,stroke:#A78BFA,color:#FFFFFF,stroke-width:1.5px
    classDef check fill:#B45309,stroke:#FBBF24,color:#FFFFFF,stroke-width:1.5px
    classDef user fill:#0F766E,stroke:#2DD4BF,color:#FFFFFF,stroke-width:1.5px
    classDef good fill:#15803D,stroke:#4ADE80,color:#FFFFFF,stroke-width:2px
    classDef halt fill:#B91C1C,stroke:#F87171,color:#FFFFFF,stroke-width:2px

    style P1 fill:transparent,stroke:#64748B,stroke-width:1.5px
    style P2 fill:transparent,stroke:#8B5CF6,stroke-width:1.5px
    style P3 fill:transparent,stroke:#F59E0B,stroke-width:1.5px
    style P4 fill:transparent,stroke:#14B8A6,stroke-width:1.5px
```
</details>